### PR TITLE
Fix 498

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -747,6 +747,7 @@ class VerilogEmitter extends Transform with PassBased with Emitter {
   def passSeq = Seq(
     passes.VerilogModulusCleanup,
     passes.VerilogWrap,
+    passes.SplitExpressions,
     passes.VerilogRename,
     passes.VerilogPrep)
 

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -748,6 +748,8 @@ class VerilogEmitter extends Transform with PassBased with Emitter {
     passes.VerilogModulusCleanup,
     passes.VerilogWrap,
     passes.SplitExpressions,
+    passes.CommonSubexpressionElimination,
+    passes.DeadCodeElimination,
     passes.VerilogRename,
     passes.VerilogPrep)
 

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -104,7 +104,6 @@ class LowFirrtlOptimization extends CoreTransform {
     passes.Legalize,
     passes.memlib.VerilogMemDelays, // TODO move to Verilog emitter
     passes.ConstProp,
-    passes.SplitExpressions,
     passes.CommonSubexpressionElimination,
     passes.DeadCodeElimination)
 }

--- a/src/main/scala/firrtl/passes/PadWidths.scala
+++ b/src/main/scala/firrtl/passes/PadWidths.scala
@@ -44,10 +44,14 @@ object PadWidths extends Pass {
         ex map fixup((ex.args map width foldLeft 0)(math.max))
       case Dshl =>
         // special case as args aren't all same width
-        ex copy (op = Dshlw, args = Seq(fixup(width(ex.tpe))(ex.args.head), ex.args(1)))
+        val w = width(ex.tpe)
+        val arg = set_primop_type(ex.copy(args = Seq(fixup(w)(ex.args.head), ex.args(1))))
+        DoPrim(Bits, Seq(arg), Seq(w - 1, 0), UIntType(IntWidth(w)))
       case Shl =>
         // special case as arg should be same width as result
-        ex copy (op = Shlw, args = Seq(fixup(width(ex.tpe))(ex.args.head)))
+        val w = width(ex.tpe)
+        val arg = set_primop_type(ex.copy(op = Shl, args = Seq(fixup(width(ex.tpe))(ex.args.head))))
+        DoPrim(Bits, Seq(arg), Seq(w - 1, 0), UIntType(IntWidth(w)))
       case _ => ex
     }
     case ex => ex

--- a/src/main/scala/firrtl/passes/Passes.scala
+++ b/src/main/scala/firrtl/passes/Passes.scala
@@ -255,6 +255,14 @@ object VerilogWrap extends Pass {
         }
         case _ => e
       }
+      case Bits => e.args.head match {
+        case e0: DoPrim => e0.op match {
+          case Dshl => DoPrim(Dshlw, e0.args, Nil, e.tpe)
+          case Shl => DoPrim(Shlw, e0.args, e0.consts, e.tpe)
+          case _ => e
+        }
+        case _ => e
+      }
       case _ => e
     }
     case _ => e

--- a/src/test/scala/firrtlTests/FirrtlSpec.scala
+++ b/src/test/scala/firrtlTests/FirrtlSpec.scala
@@ -95,7 +95,6 @@ trait FirrtlMatchers extends Matchers {
   def executeTest(input: String, expected: Seq[String], compiler: Compiler) = {
     val finalState = compiler.compileAndEmit(CircuitState(parse(input), ChirrtlForm))
     val lines = finalState.getEmittedCircuit.value split "\n" map normalized
-    println(finalState.getEmittedCircuit.value)
     for (e <- expected) {
       lines should contain (e)
     }

--- a/src/test/scala/firrtlTests/FirrtlSpec.scala
+++ b/src/test/scala/firrtlTests/FirrtlSpec.scala
@@ -95,6 +95,7 @@ trait FirrtlMatchers extends Matchers {
   def executeTest(input: String, expected: Seq[String], compiler: Compiler) = {
     val finalState = compiler.compileAndEmit(CircuitState(parse(input), ChirrtlForm))
     val lines = finalState.getEmittedCircuit.value split "\n" map normalized
+    println(finalState.getEmittedCircuit.value)
     for (e <- expected) {
       lines should contain (e)
     }

--- a/src/test/scala/firrtlTests/UnitTests.scala
+++ b/src/test/scala/firrtlTests/UnitTests.scala
@@ -122,16 +122,14 @@ class UnitTests extends FirrtlFlatSpec {
        |    out <= bits(mux(a, b, c), 0, 0)
        |""".stripMargin
 
-  "Emitting a nested expression" should "throw an exception" in {
+  "Emitting a nested expression" should "not throw an exception" in {
     val passes = Seq(
       ToWorkingIR,
       InferTypes)
-    intercept[PassException] {
-      val c = Parser.parse(splitExpTestCode.split("\n").toIterator)
-      val c2 = passes.foldLeft(c)((c, p) => p run c)
-      val writer = new StringWriter()
-      (new VerilogEmitter).emit(CircuitState(c2, LowForm), writer)
-    }
+    val c = Parser.parse(splitExpTestCode.split("\n").toIterator)
+    val c2 = passes.foldLeft(c)((c, p) => p run c)
+    val writer = new StringWriter()
+    (new VerilogEmitter).emit(CircuitState(c2, LowForm), writer)
   }
 
   "After splitting, emitting a nested expression" should "compile" in {

--- a/src/test/scala/firrtlTests/VerilogEmitterTests.scala
+++ b/src/test/scala/firrtlTests/VerilogEmitterTests.scala
@@ -93,18 +93,18 @@ class DoPrimVerilog extends FirrtlFlatSpec {
       """circuit Dshl :
         |  module Dshl :
         |    input a: UInt<4>
-        |    input b: UInt<1>
+        |    input b: UInt<2>
         |    output c: UInt
         |    c <= dshl(a, b)""".stripMargin
     val check =
       """module Dshl(
         |  input  [3:0] a,
-        |  input        b,
-        |  output [4:0] c
+        |  input  [1:0] b,
+        |  output [6:0] c
         |);
-        |  wire [4:0] _GEN_0;
+        |  wire [6:0] _GEN_0;
         |  assign c = _GEN_0 << b;
-        |  assign _GEN_0 = {{1'd0}, a};
+        |  assign _GEN_0 = {{3'd0}, a};
         |endmodule
         |""".stripMargin.split("\n") map normalized
     executeTest(input, check, compiler)

--- a/src/test/scala/firrtlTests/VerilogEmitterTests.scala
+++ b/src/test/scala/firrtlTests/VerilogEmitterTests.scala
@@ -87,6 +87,48 @@ class DoPrimVerilog extends FirrtlFlatSpec {
         |""".stripMargin.split("\n") map normalized
     executeTest(input, check, compiler)
   }
+  "Dshl" should "emit correctly" in {
+    val compiler = new VerilogCompiler
+    val input =
+      """circuit Dshl :
+        |  module Dshl :
+        |    input a: UInt<4>
+        |    input b: UInt<1>
+        |    output c: UInt
+        |    c <= dshl(a, b)""".stripMargin
+    val check =
+      """module Dshl(
+        |  input  [3:0] a,
+        |  input        b,
+        |  output [4:0] c
+        |);
+        |  wire [4:0] _GEN_0;
+        |  assign c = _GEN_0 << b;
+        |  assign _GEN_0 = {{1'd0}, a};
+        |endmodule
+        |""".stripMargin.split("\n") map normalized
+    executeTest(input, check, compiler)
+  }
+  "Shl" should "emit correctly" in {
+    val compiler = new VerilogCompiler
+    val input =
+      """circuit Shl :
+        |  module Shl :
+        |    input a: UInt<4>
+        |    output c: UInt
+        |    c <= shl(a, 1)""".stripMargin
+    val check =
+      """module Shl(
+        |  input  [3:0] a,
+        |  output [4:0] c
+        |);
+        |  wire [4:0] _GEN_0;
+        |  assign c = _GEN_0 << 1;
+        |  assign _GEN_0 = {{1'd0}, a};
+        |endmodule
+        |""".stripMargin.split("\n") map normalized
+    executeTest(input, check, compiler)
+  }
 }
 
 class VerilogEmitterSpec extends FirrtlFlatSpec {


### PR DESCRIPTION
Reworked Dshlw and Shlw to stay in Verilog emitter.

Moved SplitExpression to Veirlog Emitter. This may have a negative effect on CSE.