### PR TITLE
Modify ExpandWhens to process elses as if they were modified whens

### DIFF
--- a/src/test/scala/firrtlTests/CompilerTests.scala
+++ b/src/test/scala/firrtlTests/CompilerTests.scala
@@ -86,8 +86,9 @@ circuit Top :
       "    input reset : UInt<1>",
       "    input a : UInt<1>[2]",
       "    wire b : UInt<1>",
-      "    node _GEN_0 = mux(reset, UInt<1>(\"h0\"), a[0])",
-      "    b <= _GEN_0\n\n"
+      "    node _GEN_0 = eq(reset, UInt<1>(\"h0\"))",
+      "    node _GEN_1 = mux(reset, UInt<1>(\"h0\"), a[0])",
+      "    b <= _GEN_1\n\n"
    ).reduce(_ + "\n" + _)
    "A circuit" should "match exactly to its MidForm state" in {
       (parse(getOutput)) should be (parse(check))


### PR DESCRIPTION
ucb-bar/chisel3#510 introduces FIRRTL `else` statements to Chisel's code generation. However, this produced a small (and consistent) area regression in rocket-chip, possibly due to buffering/fanout or other select signal logic.

This PR introduces a minimal change to ExpandWhens to keep Verilog code generation consistent with prior versions of Chisel3.

This pull request causes the following FIRRTL:
```
  when (a) :
    x <= y
  else :
    when (b) :
      x <= z
```
to produce the same mux tree structure as the original style emitted by chisel3:
```
  when (a) :
    x <= y
  when (and(not(a), b)) :
    x <= z
```
This is desirable as a baseline to make code generation essentially identical while allowing other changes depending on initialization checks to go forward.
