### PR TITLE
Zero floating

### DIFF
--- a/src/main/scala/firrtl/passes/RemoveValidIf.scala
+++ b/src/main/scala/firrtl/passes/RemoveValidIf.scala
@@ -7,22 +7,22 @@ import firrtl.ir._
 
 // Removes ValidIf as an optimization
 object RemoveValidIf extends Pass {
-   // Recursive. Removes ValidIf's
-   private def onExp(e: Expression): Expression = {
-      e map onExp match {
-         case ValidIf(cond, value, tpe) => value
-         case x => x
-      }
-   }
-   // Recursive.
-   private def onStmt(s: Statement): Statement = s map onStmt map onExp
+  // Recursive. Removes ValidIf's
+  private def onExp(e: Expression): Expression = {
+    e map onExp match {
+      case ValidIf(cond, value, tpe) => value
+      case x => x
+    }
+  }
+  // Recursive.
+  private def onStmt(s: Statement): Statement = s map onStmt map onExp
 
-   private def onModule(m: DefModule): DefModule = {
-      m match {
-         case m: Module => Module(m.info, m.name, m.ports, onStmt(m.body))
-         case m: ExtModule => m
-      }
-   }
+  private def onModule(m: DefModule): DefModule = {
+    m match {
+      case m: Module => Module(m.info, m.name, m.ports, onStmt(m.body))
+      case m: ExtModule => m
+    }
+  }
 
-   def run(c: Circuit): Circuit = Circuit(c.info, c.modules.map(onModule), c.main)
+  def run(c: Circuit): Circuit = Circuit(c.info, c.modules.map(onModule), c.main)
 }


### PR DESCRIPTION
Partial resolution to #597 

This PR replaces IsInvalids with a connection to zero. Unfortunately, our constant propagation does not remove registers or wires, so a full resolution requires more substantial changes. This PR is still useful, however, because connecting these invalid wires and registers to zero simplifies the formal semantics and allows other tools to do that constant propagation.