### PR TITLE
Remove reset

### DIFF
--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -85,6 +85,7 @@ class MiddleFirrtlToLowFirrtl extends CoreTransform {
     passes.ResolveGenders,
     passes.InferWidths,
     passes.Legalize,
+    new firrtl.transforms.RemoveReset,
     new firrtl.transforms.CheckCombLoops)
 }
 

--- a/src/main/scala/firrtl/transforms/RemoveReset.scala
+++ b/src/main/scala/firrtl/transforms/RemoveReset.scala
@@ -1,0 +1,43 @@
+// See LICENSE for license details.
+
+package firrtl
+package transforms
+
+import firrtl.ir._
+import firrtl.Mappers._
+
+import scala.collection.mutable
+
+/** Remove Synchronous Reset
+  *
+  * @note This pass must run after LowerTypes
+  */
+class RemoveReset extends Transform {
+  def inputForm = MidForm
+  def outputForm = MidForm
+
+  private case class Reset(cond: Expression, value: Expression)
+
+  private def onModule(m: DefModule): DefModule = {
+    val resets = mutable.HashMap.empty[String, Reset]
+    def onStmt(stmt: Statement): Statement = {
+      stmt match {
+        case reg @ DefRegister(_, rname, _, _, reset, init) if reset != Utils.zero =>
+          // Add register reset to map
+          resets(rname) = Reset(reset, init)
+          reg.copy(reset = Utils.zero, init = WRef(reg))
+        case Connect(info, ref @ WRef(rname, _, RegKind, _), expr) if resets.contains(rname) =>
+          val reset = resets(rname)
+          val muxType = Utils.mux_type_and_widths(reset.value, expr)
+          Connect(info, ref, Mux(reset.cond, reset.value, expr, muxType))
+        case other => other map onStmt
+      }
+    }
+    m.map(onStmt)
+  }
+
+  def execute(state: CircuitState): CircuitState = {
+    val c = state.circuit.map(onModule)
+    state.copy(circuit = c)
+  }
+}

--- a/src/test/scala/firrtlTests/IntegrationSpec.scala
+++ b/src/test/scala/firrtlTests/IntegrationSpec.scala
@@ -11,6 +11,7 @@ import java.io.File
 class GCDExecutionTest extends ExecutionTest("GCDTester", "/integration")
 class RightShiftExecutionTest extends ExecutionTest("RightShiftTester", "/integration")
 class MemExecutionTest extends ExecutionTest("MemTester", "/integration")
+class PipeExecutionTest extends ExecutionTest("PipeTester", "/integration")
 
 // This is a bit custom some kind of one off
 class GCDSplitEmissionExecutionTest extends FirrtlFlatSpec {

--- a/test/integration/PipeTester.fir
+++ b/test/integration/PipeTester.fir
@@ -1,0 +1,51 @@
+
+circuit PipeTester :
+  ; This module should simply delay a signal by 2 cycles
+  ; Internal registers reset to 0
+  module Pipe :
+    input clock : Clock
+    input reset : UInt<1>
+    input in : UInt<4>
+    output out : UInt<4>
+
+    ;reg r : UInt<4>, clock with : (reset => (reset, UInt(0)))
+    ;r <= in
+    ; This is equivalent to the above
+
+    reg r : UInt<4>, clock
+    r <= mux(reset, UInt(0), in)
+
+    reg s : UInt<4>, clock with : (reset => (reset, UInt(0)))
+    s <= r
+    out <= s
+
+  module PipeTester :
+    input clock : Clock
+    input reset : UInt<1>
+
+    inst pipe of Pipe
+    pipe.clock <= clock
+    pipe.reset <= reset
+    pipe.in <= UInt(3)
+
+    reg cycle : UInt<4>, clock with : (reset => (reset, UInt<4>(0)))
+    cycle <= tail(add(cycle, UInt(1)), 1)
+
+    wire fail : UInt<1>
+    fail <= UInt(0)
+
+    when fail :
+      printf(clock, not(reset), "Assertion failed!\n")
+      stop(clock, not(reset), 1)
+
+    when not(reset) :
+      when lt(cycle, UInt(2)) :
+        when neq(pipe.out, UInt(0)) :
+          fail <= UInt(1)
+      when eq(cycle, UInt(2)) :
+        when neq(pipe.out, UInt(3)) :
+          fail <= UInt(1)
+      when eq(cycle, UInt(3)) :
+        printf(clock, UInt(1), "Success!\n")
+        stop(clock, UInt(1), 0)
+


### PR DESCRIPTION
1. Fixed a kind of scary bug where a register that drives another register could be deleted from the latter register's update in emitted Verilog. See PipeTester for an example. Note that as far as I can tell, this bug has yet to manifest since Chisel cannot generate Firrtl that exhibits the bug. Improved constant propagation could have made it show up though, and my second commit here also made it show up.
1. Replace register reset with an explicit mux that is connected to the register. Removing reset enables more powerful constant propagation and other optimizations (like replacing all wires with nodes)
