### PR TITLE
Use Travis Build Stages

### DIFF
--- a/.run_chisel_tests.sh
+++ b/.run_chisel_tests.sh
@@ -7,5 +7,5 @@ else
   mkdir -p chisel3/lib
   cp utils/bin/firrtl.jar chisel3/lib
   cd chisel3
-  sbt clean test
+  sbt "set concurrentRestrictions in Global += Tags.limit(Tags.Test, 2)" clean test
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,20 @@ env:
     VERILATOR_ROOT=$INSTALL_DIR
     PATH=$PATH:$VERILATOR_ROOT/bin:$TRAVIS_BUILD_DIR/utils/bin
 
-install:
-  # Install Verilator (if not found in cache)
-  - bash .install_verilator.sh
-
-script:
-  # FIRRTL Tests
-  - verilator --version
-  - cd $TRAVIS_BUILD_DIR
-  - sbt clean test assembly publish-local
-  # Chisel 3 Tests
-  - bash .run_chisel_tests.sh
+jobs:
+  include:
+    - stage: prepare cache-verilator
+      script:
+      - bash .install_verilator.sh
+      - verilator --version
+    - &test
+      stage: Test
+      script:
+        # FIRRTL Tests
+        - cd $TRAVIS_BUILD_DIR
+        - sbt clean test
+    - <<: *test
+      script:
+        - cd $TRAVIS_BUILD_DIR
+        - sbt clean assembly publish-local
+        - bash .run_chisel_tests.sh


### PR DESCRIPTION
Splits up the chisel and firrtl parts of the test. This means they can run in parallel (and thus be faster). I'm also hopefully it'll prevent the jobs from getting spuriously killed.