### PR TITLE
Improvements to Constant Propagation and Testing

### DIFF
--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -98,12 +98,12 @@ class LowFirrtlOptimization extends CoreTransform {
   def outputForm = LowForm
   def transforms = Seq(
     passes.RemoveValidIf,
-    passes.ConstProp,
+    new firrtl.transforms.ConstantPropagation,
     passes.PadWidths,
-    passes.ConstProp,
+    new firrtl.transforms.ConstantPropagation,
     passes.Legalize,
     passes.memlib.VerilogMemDelays, // TODO move to Verilog emitter
-    passes.ConstProp,
+    new firrtl.transforms.ConstantPropagation,
     passes.SplitExpressions,
     passes.CommonSubexpressionElimination,
     new firrtl.transforms.DeadCodeElimination)

--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -1,6 +1,7 @@
 // See LICENSE for license details.
 
-package firrtl.passes
+package firrtl
+package transforms
 
 import firrtl._
 import firrtl.ir._
@@ -10,7 +11,10 @@ import firrtl.PrimOps._
 
 import annotation.tailrec
 
-object ConstProp extends Pass {
+class ConstantPropagation extends Transform {
+  def inputForm = LowForm
+  def outputForm = LowForm
+
   private def pad(e: Expression, t: Type) = (bitWidth(e.tpe), bitWidth(t)) match {
     case (we, wt) if we < wt => DoPrim(Pad, Seq(e), Seq(wt), t)
     case (we, wt) if we == wt => e
@@ -291,5 +295,9 @@ object ConstProp extends Pass {
       case m: Module => constPropModule(m)
     }
     Circuit(c.info, modulesx, c.main)
+  }
+
+  def execute(state: CircuitState): CircuitState = {
+    state.copy(circuit = run(state.circuit))
   }
 }

--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -4,6 +4,7 @@ package firrtl
 package transforms
 
 import firrtl._
+import firrtl.annotations._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
@@ -243,7 +244,7 @@ class ConstantPropagation extends Transform {
   // 2. Propagate references again for backwards reference (Wires)
   // TODO Replacing all wires with nodes makes the second pass unnecessary
   @tailrec
-  private def constPropModule(m: Module): Module = {
+  private def constPropModule(m: Module, dontTouches: Set[String]): Module = {
     var nPropagated = 0L
     val nodeMap = collection.mutable.HashMap[String, Expression]()
 
@@ -276,8 +277,8 @@ class ConstantPropagation extends Transform {
     def constPropStmt(s: Statement): Statement = {
       val stmtx = s map constPropStmt map constPropExpression
       stmtx match {
-        case x: DefNode => nodeMap(x.name) = x.value
-        case Connect(_, WRef(wname, wtpe, WireKind, _), expr) =>
+        case x: DefNode if !dontTouches.contains(x.name) => nodeMap(x.name) = x.value
+        case Connect(_, WRef(wname, wtpe, WireKind, _), expr) if !dontTouches.contains(wname) =>
           val exprx = constPropExpression(pad(expr, wtpe))
           nodeMap(wname) = exprx
         case _ =>
@@ -286,18 +287,28 @@ class ConstantPropagation extends Transform {
     }
 
     val res = Module(m.info, m.name, m.ports, backPropStmt(constPropStmt(m.body)))
-    if (nPropagated > 0) constPropModule(res) else res
+    if (nPropagated > 0) constPropModule(res, dontTouches) else res
   }
 
-  def run(c: Circuit): Circuit = {
+  private def run(c: Circuit, dontTouchMap: Map[String, Set[String]]): Circuit = {
     val modulesx = c.modules.map {
       case m: ExtModule => m
-      case m: Module => constPropModule(m)
+      case m: Module => constPropModule(m, dontTouchMap.getOrElse(m.name, Set.empty))
     }
     Circuit(c.info, modulesx, c.main)
   }
 
   def execute(state: CircuitState): CircuitState = {
-    state.copy(circuit = run(state.circuit))
+    val dontTouches: Seq[(String, String)] = state.annotations match {
+      case Some(aMap) => aMap.annotations.collect {
+        case DontTouchAnnotation(ComponentName(c, ModuleName(m, _))) => m -> c
+      }
+      case None => Seq.empty
+    }
+    // Map from module name to component names
+    val dontTouchMap: Map[String, Set[String]] =
+      dontTouches.groupBy(_._1).mapValues(_.map(_._2).toSet)
+
+    state.copy(circuit = run(state.circuit, dontTouchMap))
   }
 }

--- a/src/test/scala/firrtlTests/AnnotationTests.scala
+++ b/src/test/scala/firrtlTests/AnnotationTests.scala
@@ -49,13 +49,6 @@ class AnnotationTests extends AnnotationSpec with Matchers {
     Annotation(ComponentName(s, ModuleName(mod, CircuitName("Top"))), classOf[Transform], value)
   def manno(mod: String): Annotation =
     Annotation(ModuleName(mod, CircuitName("Top")), classOf[Transform], "some value")
-	// TODO unify with FirrtlMatchers, problems with multiple definitions of parse
-  def dontTouch(path: String): Annotation = {
-    val parts = path.split('.')
-    require(parts.size >= 2, "Must specify both module and component!")
-    val name = ComponentName(parts.tail.mkString("."), ModuleName(parts.head, CircuitName("Top")))
-    DontTouchAnnotation(name)
-  }
 
   "Loose and Sticky annotation on a node" should "pass through" in {
     val input: String =

--- a/src/test/scala/firrtlTests/AnnotationTests.scala
+++ b/src/test/scala/firrtlTests/AnnotationTests.scala
@@ -23,13 +23,13 @@ trait AnnotationSpec extends LowTransformSpec {
   def transform = new ResolveAndCheck
 
   // Check if Annotation Exception is thrown
-  override def failingexecute(annotations: AnnotationMap, input: String): Exception = {
+  override def failingexecute(input: String, annotations: Seq[Annotation]): Exception = {
     intercept[AnnotationException] {
-      compile(CircuitState(parse(input), ChirrtlForm, Some(annotations)), Seq.empty)
+      compile(CircuitState(parse(input), ChirrtlForm, Some(AnnotationMap(annotations))), Seq.empty)
     }
   }
-  def execute(aMap: Option[AnnotationMap], input: String, check: Annotation): Unit = {
-    val cr = compile(CircuitState(parse(input), ChirrtlForm, aMap), Seq.empty)
+  def execute(input: String, check: Annotation, annotations: Seq[Annotation]): Unit = {
+    val cr = compile(CircuitState(parse(input), ChirrtlForm, Some(AnnotationMap(annotations))), Seq.empty)
     cr.annotations.get.annotations should contain (check)
   }
 }
@@ -58,7 +58,7 @@ class AnnotationTests extends AnnotationSpec with Matchers {
          |    input b : UInt<1>
          |    node c = b""".stripMargin
     val ta = anno("c", "")
-    execute(getAMap(ta), input, ta)
+    execute(input, ta, Seq(ta))
   }
 
   "Annotations" should "be readable from file" in {

--- a/src/test/scala/firrtlTests/CInferMDirSpec.scala
+++ b/src/test/scala/firrtlTests/CInferMDirSpec.scala
@@ -5,6 +5,7 @@ package firrtlTests
 import firrtl._
 import firrtl.ir._
 import firrtl.passes._
+import firrtl.transforms._
 import firrtl.Mappers._
 import annotations._
 
@@ -39,7 +40,7 @@ class CInferMDir extends LowTransformSpec {
   def transform = new SeqTransform {
     def inputForm = LowForm
     def outputForm = LowForm
-    def transforms = Seq(ConstProp, CInferMDirCheckPass)
+    def transforms = Seq(new ConstantPropagation, CInferMDirCheckPass)
   }
 
   "Memory" should "have correct mem port directions" in {

--- a/src/test/scala/firrtlTests/ChirrtlMemSpec.scala
+++ b/src/test/scala/firrtlTests/ChirrtlMemSpec.scala
@@ -5,6 +5,7 @@ package firrtlTests
 import firrtl._
 import firrtl.ir._
 import firrtl.passes._
+import firrtl.transforms._
 import firrtl.Mappers._
 import annotations._
 
@@ -53,7 +54,7 @@ class ChirrtlMemSpec extends LowTransformSpec {
   def transform = new SeqTransform {
     def inputForm = LowForm
     def outputForm = LowForm
-    def transforms = Seq(ConstProp, MemEnableCheckPass)
+    def transforms = Seq(new ConstantPropagation, MemEnableCheckPass)
   }
 
   "Sequential Memory" should "have correct enable signals" in {

--- a/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+++ b/src/test/scala/firrtlTests/ConstantPropagationTests.scala
@@ -373,3 +373,46 @@ class ConstantPropagationSpec extends FirrtlFlatSpec {
       (parse(exec(input))) should be (parse(check))
    }
 }
+
+// More sophisticated tests of the full compiler
+class ConstantPropagationIntegrationSpec extends LowTransformSpec {
+  def transform = new LowFirrtlOptimization
+
+  "ConstProp" should "should not optimize across dontTouch on nodes" in {
+      val input =
+        """circuit Top :
+          |  module Top :
+          |    input x : UInt<1>
+          |    output y : UInt<1>
+          |    node z = x
+          |    y <= z""".stripMargin
+      val check =
+        """circuit Top :
+          |  module Top :
+          |    input x : UInt<1>
+          |    output y : UInt<1>
+          |    node z = x
+          |    y <= z""".stripMargin
+    execute(input, check, Seq(dontTouch("Top.z")))
+  }
+
+  it should "should not optimize across dontTouch on wires" in {
+      val input =
+        """circuit Top :
+          |  module Top :
+          |    input x : UInt<1>
+          |    output y : UInt<1>
+          |    wire z : UInt<1>
+          |    y <= z
+          |    z <= x""".stripMargin
+      val check =
+        """circuit Top :
+          |  module Top :
+          |    input x : UInt<1>
+          |    output y : UInt<1>
+          |    wire z : UInt<1>
+          |    y <= z
+          |    z <= x""".stripMargin
+    execute(input, check, Seq(dontTouch("Top.z")))
+  }
+}

--- a/src/test/scala/firrtlTests/FirrtlSpec.scala
+++ b/src/test/scala/firrtlTests/FirrtlSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.prop._
 import scala.io.Source
 
 import firrtl._
-import firrtl.Parser.IgnoreInfo
+import firrtl.Parser.UseInfo
 import firrtl.annotations._
 import firrtl.transforms.{DontTouchAnnotation, NoDedupAnnotation}
 import firrtl.util.BackendCompilationUtilities
@@ -100,7 +100,7 @@ trait FirrtlMatchers extends Matchers {
     require(!s.contains("\n"))
     s.replaceAll("\\s+", " ").trim
   }
-  def parse(str: String) = Parser.parse(str.split("\n").toIterator, IgnoreInfo)
+  def parse(str: String) = Parser.parse(str.split("\n").toIterator, UseInfo)
   /** Helper for executing tests
     * compiler will be run on input then emitted result will each be split into
     * lines and normalized.

--- a/src/test/scala/firrtlTests/LowerTypesSpec.scala
+++ b/src/test/scala/firrtlTests/LowerTypesSpec.scala
@@ -8,6 +8,7 @@ import org.scalatest.prop._
 import firrtl.Parser
 import firrtl.ir.Circuit
 import firrtl.passes._
+import firrtl.transforms._
 import firrtl._
 
 class LowerTypesSpec extends FirrtlFlatSpec {
@@ -27,7 +28,7 @@ class LowerTypesSpec extends FirrtlFlatSpec {
     ExpandWhens,
     CheckInitialization,
     Legalize,
-    ConstProp,
+    new ConstantPropagation,
     ResolveKinds,
     InferTypes,
     ResolveGenders,

--- a/src/test/scala/firrtlTests/PassTests.scala
+++ b/src/test/scala/firrtlTests/PassTests.scala
@@ -13,9 +13,8 @@ import logger._
 
 // An example methodology for testing Firrtl Passes
 // Spec class should extend this class
-abstract class SimpleTransformSpec extends FlatSpec with Matchers with Compiler with LazyLogging {
+abstract class SimpleTransformSpec extends FlatSpec with FirrtlMatchers with Compiler with LazyLogging {
    // Utility function
-   def parse(s: String): Circuit = Parser.parse(s.split("\n").toIterator, infoMode = UseInfo)
    def squash(c: Circuit): Circuit = RemoveEmpty.run(c)
 
    // Executes the test. Call in tests.

--- a/src/test/scala/firrtlTests/PassTests.scala
+++ b/src/test/scala/firrtlTests/PassTests.scala
@@ -9,6 +9,7 @@ import firrtl.ir.Circuit
 import firrtl.Parser.UseInfo
 import firrtl.passes.{Pass, PassExceptions, RemoveEmpty}
 import firrtl._
+import firrtl.annotations._
 import logger._
 
 // An example methodology for testing Firrtl Passes
@@ -18,8 +19,9 @@ abstract class SimpleTransformSpec extends FlatSpec with FirrtlMatchers with Com
    def squash(c: Circuit): Circuit = RemoveEmpty.run(c)
 
    // Executes the test. Call in tests.
-   def execute(annotations: AnnotationMap, input: String, check: String): Unit = {
-      val finalState = compileAndEmit(CircuitState(parse(input), ChirrtlForm, Some(annotations)))
+   // annotations cannot have default value because scalatest trait Suite has a default value
+   def execute(input: String, check: String, annotations: Seq[Annotation]): Unit = {
+      val finalState = compileAndEmit(CircuitState(parse(input), ChirrtlForm, Some(AnnotationMap(annotations))))
       val actual = RemoveEmpty.run(parse(finalState.getEmittedCircuit.value)).serialize
       val expected = parse(check).serialize
       logger.debug(actual)
@@ -27,9 +29,10 @@ abstract class SimpleTransformSpec extends FlatSpec with FirrtlMatchers with Com
       (actual) should be (expected)
    }
    // Executes the test, should throw an error
-   def failingexecute(annotations: AnnotationMap, input: String): Exception = {
+   // No default to be consistent with execute
+   def failingexecute(input: String, annotations: Seq[Annotation]): Exception = {
       intercept[PassExceptions] {
-         compile(CircuitState(parse(input), ChirrtlForm, Some(annotations)), Seq.empty)
+         compile(CircuitState(parse(input), ChirrtlForm, Some(AnnotationMap(annotations))), Seq.empty)
       }
    }
 }

--- a/src/test/scala/firrtlTests/ReplSeqMemTests.scala
+++ b/src/test/scala/firrtlTests/ReplSeqMemTests.scala
@@ -22,7 +22,7 @@ class ReplSeqMemSpec extends SimpleTransformSpec {
     new SeqTransform {
       def inputForm = LowForm
       def outputForm = LowForm
-      def transforms = Seq(ConstProp, CommonSubexpressionElimination, new DeadCodeElimination, RemoveEmpty)
+      def transforms = Seq(new ConstantPropagation, CommonSubexpressionElimination, new DeadCodeElimination, RemoveEmpty)
     }
   )
 

--- a/src/test/scala/firrtlTests/transforms/BlacklBoxSourceHelperSpec.scala
+++ b/src/test/scala/firrtlTests/transforms/BlacklBoxSourceHelperSpec.scala
@@ -78,12 +78,12 @@ class BlacklBoxSourceHelperTransformSpec extends LowTransformSpec {
 
   "annotated external modules" should "appear in output directory" in {
 
-    val aMap = AnnotationMap(Seq(
+    val annos = Seq(
       Annotation(moduleName, classOf[BlackBoxSourceHelper], BlackBoxTargetDir("test_run_dir").serialize),
       Annotation(moduleName, classOf[BlackBoxSourceHelper], BlackBoxResource("/blackboxes/AdderExtModule.v").serialize)
-    ))
+    )
 
-    execute(aMap, input, output)
+    execute(input, output, annos)
 
     new java.io.File("test_run_dir/AdderExtModule.v").exists should be (true)
     new java.io.File(s"test_run_dir/${BlackBoxSourceHelper.FileListName}").exists should be (true)

--- a/src/test/scala/firrtlTests/transforms/DedupTests.scala
+++ b/src/test/scala/firrtlTests/transforms/DedupTests.scala
@@ -46,8 +46,7 @@ class DedupModuleTests extends HighTransformSpec {
            |    output x: UInt<1>
            |    x <= UInt(1)
            """.stripMargin
-      val aMap = new AnnotationMap(Nil)
-      execute(aMap, input, check)
+      execute(input, check, Seq.empty)
    }
    "The module A and B" should "be deduped" in {
       val input =
@@ -83,8 +82,7 @@ class DedupModuleTests extends HighTransformSpec {
            |    output x: UInt<1>
            |    x <= UInt(1)
            """.stripMargin
-      val aMap = new AnnotationMap(Nil)
-      execute(aMap, input, check)
+      execute(input, check, Seq.empty)
    }
    "The module A and B with comments" should "be deduped" in {
       val input =
@@ -120,8 +118,7 @@ class DedupModuleTests extends HighTransformSpec {
            |    output x: UInt<1>
            |    x <= UInt(1)
            """.stripMargin
-      val aMap = new AnnotationMap(Nil)
-      execute(aMap, input, check)
+      execute(input, check, Seq.empty)
    }
    "The module B, but not A, with comments" should "be deduped if not annotated" in {
       val input =
@@ -148,8 +145,7 @@ class DedupModuleTests extends HighTransformSpec {
            |    output x: UInt<1> @[xx 1:1]
            |    x <= UInt(1)
            """.stripMargin
-      val aMap = new AnnotationMap(Seq(NoDedupAnnotation(ModuleName("A", CircuitName("Top")))))
-      execute(aMap, input, check)
+      execute(input, check, Seq(dontDedup("A")))
    }
 }
 


### PR DESCRIPTION
The name of this branch is a lie, here's what this PR actually does:

1. Clean up some testing stuff (deletes duplicated code and makes some testing functions a little more concise)
2. passes.ConstProp -> transforms.ConstantPropagation
3. Make Constant Propagation respect dontTouch. This means not propagating across components marked dontTouch. Less important now but still relevant and will be *very* important once we can const prop across module boundaries