### PR TITLE
Fixed inability to disable combo loop check

### DIFF
--- a/src/test/scala/firrtlTests/DriverSpec.scala
+++ b/src/test/scala/firrtlTests/DriverSpec.scala
@@ -137,7 +137,8 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
     copyResourceToFile("/annotations/SampleAnnotations.anno", annotationsTestFile)
     optionsManager.firrtlOptions.annotations.length should be (0)
     Driver.loadAnnotations(optionsManager)
-    optionsManager.firrtlOptions.annotations.length should be (10) // 9 from circuit plus 1 for targetDir
+    println(s"annotations ${optionsManager.firrtlOptions.annotations.mkString("\n")}")
+    optionsManager.firrtlOptions.annotations.length should be (12) // 9 from circuit plus 3 general purpose
 
     optionsManager.firrtlOptions.annotations.head.transformClass should be ("firrtl.passes.InlineInstances")
     annotationsTestFile.delete()

--- a/src/test/scala/firrtlTests/DriverSpec.scala
+++ b/src/test/scala/firrtlTests/DriverSpec.scala
@@ -137,7 +137,6 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
     copyResourceToFile("/annotations/SampleAnnotations.anno", annotationsTestFile)
     optionsManager.firrtlOptions.annotations.length should be (0)
     Driver.loadAnnotations(optionsManager)
-    println(s"annotations ${optionsManager.firrtlOptions.annotations.mkString("\n")}")
     optionsManager.firrtlOptions.annotations.length should be (12) // 9 from circuit plus 3 general purpose
 
     optionsManager.firrtlOptions.annotations.head.transformClass should be ("firrtl.passes.InlineInstances")


### PR DESCRIPTION
Moved checking of dontCheckComboLoops into loadAnnotations so
that it works in cases where Driver.execute is not used.
This is part of a fix for [--no-check-comb-loops doesn't work](https://github.com/freechipsproject/chisel-testers/issues/155)