### PR TITLE
Constant propagation across module boundaries

### DIFF
--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -286,7 +286,8 @@ class ConstantPropagation extends Transform {
     // (can have more than 1 of the same submodule)
     val constSubInputs = mutable.HashMap.empty[String, mutable.HashMap[String, Seq[Literal]]]
 
-    nodeMap ++= constInputs
+    // Copy constant mapping for constant inputs (except ones marked dontTouch!)
+    nodeMap ++= constInputs.filterNot { case (pname, _) => dontTouches.contains(pname) }
 
     // Note that on back propagation we *only* worry about swapping names and propagating references
     // to constant wires, we don't need to worry about propagating primops or muxes since we'll do

--- a/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+++ b/src/test/scala/firrtlTests/ConstantPropagationTests.scala
@@ -739,6 +739,45 @@ class ConstantPropagationIntegrationSpec extends LowTransformSpec {
     execute(input, check, Seq.empty)
   }
 
+  it should "pad constant connections to outputs when propagating" in {
+      val input =
+        """circuit Top :
+          |  module Child :
+          |    output x : UInt<8>
+          |    x <= UInt<2>("h3")
+          |  module Top :
+          |    output z : UInt<16>
+          |    inst c of Child
+          |    z <= cat(UInt<2>("h3"), c.x)""".stripMargin
+      val check =
+        """circuit Top :
+          |  module Top :
+          |    output z : UInt<16>
+          |    z <= UInt<16>("h303")""".stripMargin
+    execute(input, check, Seq.empty)
+  }
+
+  it should "pad constant connections to submodule inputs when propagating" in {
+      val input =
+        """circuit Top :
+          |  module Child :
+          |    input x : UInt<8>
+          |    output y : UInt<16>
+          |    y <= cat(UInt<2>("h3"), x)
+          |  module Top :
+          |    output z : UInt<16>
+          |    inst c of Child
+          |    c.x <= UInt<2>("h3")
+          |    z <= c.y""".stripMargin
+      val check =
+        """circuit Top :
+          |  module Top :
+          |    output z : UInt<16>
+          |    z <= UInt<16>("h303")""".stripMargin
+    execute(input, check, Seq.empty)
+  }
+
+
   "Registers with no reset or connections" should "be replaced with constant zero" in {
       val input =
         """circuit Top :


### PR DESCRIPTION
The long awaited. This could perhaps be improved and suggestions are welcome.

The process of constant propagating within a module is expanded to include possible constants on inputs and outputs of the module itself as well as instances. The biggest change involves the new "outer loop" of constant propagating modules in a topologically sorted order and repeating when necessary. Explanation pasted from a comment below. Important thing to note **This preserves deduplication**.

This outer loop works by applying constant propagation to the modules in a topologically
sorted order from leaf to root
Modules will register any outputs they drive with a constant in constOutputs which is then
checked by later modules in the same iteration (since we iterate from leaf to root)
Since Modules can be instantiated multiple times, for inputs we must check that all instances
are driven with the same constant value. Then, if we find a Module input where each instance
is driven with the same constant (and not seen in a previous iteration), we iterate again