### PR TITLE
Reorder port and wire assignments in Verilog

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -533,11 +533,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
           (dir, tpe) match {
             case (_, AnalogType(_)) => "inout " // padded to length of output
             case (Input, _) => "input "
-            case (Output, _) =>
-              // Assign to the Port
-              val ex = WRef(name, tpe, PortKind, FEMALE)
-              assign(ex, netlist(ex))
-              "output"
+            case (Output, _) => "output"
           }
         }
         // Turn types into strings, all ports must be GroundTypes
@@ -553,13 +549,11 @@ class VerilogEmitter extends SeqTransform with Emitter {
       }
 
       def build_streams(s: Statement): Statement = s map build_streams match {
+        case sx@Connect(info, loc@WRef(_, _, PortKind|WireKind|InstanceKind, _), expr) =>
+          assign(loc, expr)
+          sx
         case sx: DefWire =>
           declare("wire",sx.name,sx.tpe)
-          val e = wref(sx.name,sx.tpe)
-          netlist get e match {
-            case Some(n) => assign(e,n)
-            case None =>
-          }
           sx
         case sx: DefRegister =>
           declare("reg", sx.name, sx.tpe)
@@ -567,10 +561,14 @@ class VerilogEmitter extends SeqTransform with Emitter {
           update_and_reset(e, sx.clock, sx.reset, sx.init)
           initialize(e)
           sx
-        case sx: IsInvalid =>
-          val wref = netlist(sx.expr) match { case e: WRef => e }
+        case sx@IsInvalid(info, expr) =>
+          val wref = netlist(expr) match { case e: WRef => e }
           declare("reg", wref.name, sx.expr.tpe)
           initialize(wref)
+          kind(expr) match {
+            case PortKind | WireKind => assign(expr, netlist(expr))
+            case _ =>
+          }
           sx
         case sx: DefNode =>
           declare("wire", sx.name, sx.value.tpe)

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -549,7 +549,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
       }
 
       def build_streams(s: Statement): Statement = s map build_streams match {
-        case sx@Connect(info, loc@WRef(_, _, PortKind|WireKind|InstanceKind, _), expr) =>
+        case sx @ Connect(info, loc @ WRef(_, _, PortKind | WireKind | InstanceKind, _), expr) =>
           assign(loc, expr)
           sx
         case sx: DefWire =>
@@ -561,12 +561,12 @@ class VerilogEmitter extends SeqTransform with Emitter {
           update_and_reset(e, sx.clock, sx.reset, sx.init)
           initialize(e)
           sx
-        case sx@IsInvalid(info, expr) =>
+        case sx @ IsInvalid(info, expr) =>
           val wref = netlist(expr) match { case e: WRef => e }
           declare("reg", wref.name, sx.expr.tpe)
           initialize(wref)
           kind(expr) match {
-            case PortKind | WireKind => assign(expr, netlist(expr))
+            case PortKind | WireKind | InstanceKind => assign(expr, netlist(expr))
             case _ =>
           }
           sx

--- a/src/test/scala/firrtlTests/UnitTests.scala
+++ b/src/test/scala/firrtlTests/UnitTests.scala
@@ -127,7 +127,8 @@ class UnitTests extends FirrtlFlatSpec {
   "Emitting a nested expression" should "throw an exception" in {
     val passes = Seq(
       ToWorkingIR,
-      InferTypes)
+      InferTypes,
+      ResolveKinds)
     intercept[PassException] {
       val c = Parser.parse(splitExpTestCode.split("\n").toIterator)
       val c2 = passes.foldLeft(c)((c, p) => p run c)


### PR DESCRIPTION
Made a simple change to make wire and port assignments print out in the correct order.