### PR TITLE
Add tests for multi-rooted circuits in ConstProp

### DIFF
--- a/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+++ b/src/test/scala/firrtlTests/ConstantPropagationTests.scala
@@ -8,13 +8,6 @@ import firrtl.Parser.IgnoreInfo
 import firrtl.passes._
 import firrtl.transforms._
 
-// Tests the following cases for constant propagation:
-//   1) Unsigned integers are always greater than or
-//        equal to zero
-//   2) Values are always smaller than a number greater
-//        than their maximum value
-//   3) Values are always greater than a number smaller
-//        than their minimum value
 class ConstantPropagationSpec extends FirrtlFlatSpec {
   val transforms = Seq(
       ToWorkingIR,
@@ -23,11 +16,178 @@ class ConstantPropagationSpec extends FirrtlFlatSpec {
       ResolveGenders,
       InferWidths,
       new ConstantPropagation)
-  private def exec(input: String) = {
+  protected def exec(input: String) = {
     transforms.foldLeft(CircuitState(parse(input), UnknownForm)) {
       (c: CircuitState, t: Transform) => t.runTransform(c)
     }.circuit.serialize
   }
+}
+
+class ConstantPropagationMultiModule extends ConstantPropagationSpec {
+   "ConstProp" should "propagate constant inputs" in {
+      val input =
+"""circuit Top :
+  module Child :
+    input in0 : UInt<1>
+    input in1 : UInt<1>
+    output out : UInt<1>
+    out <= and(in0, in1)
+  module Top :
+    input x : UInt<1>
+    output z : UInt<1>
+    inst c of Child
+    c.in0 <= x
+    c.in1 <= UInt<1>(1)
+    z <= c.out
+"""
+      val check =
+"""circuit Top :
+  module Child :
+    input in0 : UInt<1>
+    input in1 : UInt<1>
+    output out : UInt<1>
+    out <= in0
+  module Top :
+    input x : UInt<1>
+    output z : UInt<1>
+    inst c of Child
+    c.in0 <= x
+    c.in1 <= UInt<1>(1)
+    z <= c.out
+"""
+      (parse(exec(input))) should be (parse(check))
+    }
+
+   "ConstProp" should "propagate constant inputs ONLY if ALL instance inputs get the same value" in {
+      def circuit(allSame: Boolean) =
+s"""circuit Top :
+  module Bottom :
+    input in : UInt<1>
+    output out : UInt<1>
+    out <= in
+  module Child :
+    output out : UInt<1>
+    inst b of Bottom
+    b.in <= UInt(1)
+    out <= b.out
+  module Top :
+    input x : UInt<1>
+    output z : UInt<1>
+
+    inst c of Child
+
+    inst b0 of Bottom
+    b0.in <= ${if (allSame) "UInt(1)" else "x"}
+    inst b1 of Bottom
+    b1.in <= UInt(1)
+
+    z <= and(and(b0.out, b1.out), c.out)
+"""
+      val resultFromAllSame =
+"""circuit Top :
+  module Bottom :
+    input in : UInt<1>
+    output out : UInt<1>
+    out <= UInt(1)
+  module Child :
+    output out : UInt<1>
+    inst b of Bottom
+    b.in <= UInt(1)
+    out <= UInt(1)
+  module Top :
+    input x : UInt<1>
+    output z : UInt<1>
+    inst c of Child
+    inst b0 of Bottom
+    b0.in <= UInt(1)
+    inst b1 of Bottom
+    b1.in <= UInt(1)
+    z <= UInt(1)
+"""
+      (parse(exec(circuit(false)))) should be (parse(circuit(false)))
+      (parse(exec(circuit(true)))) should be (parse(resultFromAllSame))
+    }
+
+   // =============================
+   "ConstProp" should "do nothing on unrelated modules" in {
+      val input =
+"""circuit foo :
+  module foo :
+    input dummy : UInt<1>
+    skip
+
+  module bar :
+    input dummy : UInt<1>
+    skip
+"""
+      val check = input
+      (parse(exec(input))) should be (parse(check))
+   }
+
+   // =============================
+   "ConstProp" should "propagate module chains not connected to the top" in {
+      val input =
+"""circuit foo :
+  module foo :
+    input dummy : UInt<1>
+    skip
+
+  module bar1 :
+    output out : UInt<1>
+    inst one of baz1
+    inst zero of baz0
+    out <= or(one.test, zero.test)
+
+  module bar0 :
+    output out : UInt<1>
+    inst one of baz1
+    inst zero of baz0
+    out <= and(one.test, zero.test)
+
+  module baz1 :
+    output test : UInt<1>
+    test <= UInt<1>(1)
+  module baz0 :
+    output test : UInt<1>
+    test <= UInt<1>(0)
+"""
+      val check =
+"""circuit foo :
+  module foo :
+    input dummy : UInt<1>
+    skip
+
+  module bar1 :
+    output out : UInt<1>
+    inst one of baz1
+    inst zero of baz0
+    out <= UInt<1>(1)
+
+  module bar0 :
+    output out : UInt<1>
+    inst one of baz1
+    inst zero of baz0
+    out <= UInt<1>(0)
+
+  module baz1 :
+    output test : UInt<1>
+    test <= UInt<1>(1)
+  module baz0 :
+    output test : UInt<1>
+    test <= UInt<1>(0)
+"""
+      (parse(exec(input))) should be (parse(check))
+   }
+}
+
+// Tests the following cases for constant propagation:
+//   1) Unsigned integers are always greater than or
+//        equal to zero
+//   2) Values are always smaller than a number greater
+//        than their maximum value
+//   3) Values are always greater than a number smaller
+//        than their minimum value
+class ConstantPropagationSingleModule extends ConstantPropagationSpec {
    // =============================
    "The rule x >= 0 " should " always be true if x is a UInt" in {
       val input =
@@ -533,90 +693,6 @@ class ConstantPropagationSpec extends FirrtlFlatSpec {
     z <= UInt<1>(0)
 """
       (parse(exec(input))) should be (parse(check))
-    }
-
-   "ConstProp" should "propagate constant inputs" in {
-      val input =
-"""circuit Top :
-  module Child :
-    input in0 : UInt<1>
-    input in1 : UInt<1>
-    output out : UInt<1>
-    out <= and(in0, in1)
-  module Top :
-    input x : UInt<1>
-    output z : UInt<1>
-    inst c of Child
-    c.in0 <= x
-    c.in1 <= UInt<1>(1)
-    z <= c.out
-"""
-      val check =
-"""circuit Top :
-  module Child :
-    input in0 : UInt<1>
-    input in1 : UInt<1>
-    output out : UInt<1>
-    out <= in0
-  module Top :
-    input x : UInt<1>
-    output z : UInt<1>
-    inst c of Child
-    c.in0 <= x
-    c.in1 <= UInt<1>(1)
-    z <= c.out
-"""
-      (parse(exec(input))) should be (parse(check))
-    }
-
-   "ConstProp" should "propagate constant inputs ONLY if ALL instance inputs get the same value" in {
-      def circuit(allSame: Boolean) =
-s"""circuit Top :
-  module Bottom :
-    input in : UInt<1>
-    output out : UInt<1>
-    out <= in
-  module Child :
-    output out : UInt<1>
-    inst b of Bottom
-    b.in <= UInt(1)
-    out <= b.out
-  module Top :
-    input x : UInt<1>
-    output z : UInt<1>
-
-    inst c of Child
-
-    inst b0 of Bottom
-    b0.in <= ${if (allSame) "UInt(1)" else "x"}
-    inst b1 of Bottom
-    b1.in <= UInt(1)
-
-    z <= and(and(b0.out, b1.out), c.out)
-"""
-      val resultFromAllSame =
-"""circuit Top :
-  module Bottom :
-    input in : UInt<1>
-    output out : UInt<1>
-    out <= UInt(1)
-  module Child :
-    output out : UInt<1>
-    inst b of Bottom
-    b.in <= UInt(1)
-    out <= UInt(1)
-  module Top :
-    input x : UInt<1>
-    output z : UInt<1>
-    inst c of Child
-    inst b0 of Bottom
-    b0.in <= UInt(1)
-    inst b1 of Bottom
-    b1.in <= UInt(1)
-    z <= UInt(1)
-"""
-      (parse(exec(circuit(false)))) should be (parse(circuit(false)))
-      (parse(exec(circuit(true)))) should be (parse(resultFromAllSame))
     }
 }
 


### PR DESCRIPTION
Apply ConstProp for all modules as a default behaviour instead of crashing. (The other way could be fine as well; the ideal case would be to make this transform targetable)

- Added tests
- Need to think about how to target ConstProp only for a specific module?

Close #644