### PR TITLE
Make pathsInDAG walk all possible paths

### DIFF
--- a/src/main/scala/firrtl/graph/DiGraph.scala
+++ b/src/main/scala/firrtl/graph/DiGraph.scala
@@ -273,16 +273,16 @@ class DiGraph[T] (val edges: Map[T, Set[T]]) extends DiGraphLike[T] {
     // paths(v) holds the set of paths from start to v
     val paths = new mutable.HashMap[T,mutable.Set[Seq[T]]] with mutable.MultiMap[T,Seq[T]]
     val queue = new mutable.Queue[T]
-    val visited = new mutable.HashSet[Seq[T]]
+    val reachable = reachableFrom(start)
     paths.addBinding(start,Seq(start))
-    queue.enqueue(start)
-    visited += Seq(start)
+    queue += start
+    queue ++= linearize.filter(reachable.contains(_))
     while (!queue.isEmpty) {
       val current = queue.dequeue
-      for (v <- getEdges(current); p <- paths(current); if !visited.contains(p :+ v)) {
-        queue.enqueue(v)
-        visited += p :+ v
-        paths.addBinding(v, p :+ v)
+      for (v <- getEdges(current)) {
+        for (p <- paths(current)) {
+          paths.addBinding(v, p :+ v)
+        }
       }
     }
       (paths map { case (k,v) => (k,v.toSeq) }).toMap

--- a/src/main/scala/firrtl/graph/DiGraph.scala
+++ b/src/main/scala/firrtl/graph/DiGraph.scala
@@ -273,20 +273,16 @@ class DiGraph[T] (val edges: Map[T, Set[T]]) extends DiGraphLike[T] {
     // paths(v) holds the set of paths from start to v
     val paths = new mutable.HashMap[T,mutable.Set[Seq[T]]] with mutable.MultiMap[T,Seq[T]]
     val queue = new mutable.Queue[T]
-    val visited = new mutable.HashSet[T]
+    val visited = new mutable.HashSet[Seq[T]]
     paths.addBinding(start,Seq(start))
     queue.enqueue(start)
-    visited += start
+    visited += Seq(start)
     while (!queue.isEmpty) {
       val current = queue.dequeue
-      for (v <- getEdges(current)) {
-        if (!visited.contains(v)) {
-          queue.enqueue(v)
-          visited += v
-        }
-        for (p <- paths(current)) {
-          paths.addBinding(v, p :+ v)
-        }
+      for (v <- getEdges(current); p <- paths(current); if !visited.contains(p :+ v)) {
+        queue.enqueue(v)
+        visited += p :+ v
+        paths.addBinding(v, p :+ v)
       }
     }
       (paths map { case (k,v) => (k,v.toSeq) }).toMap


### PR DESCRIPTION
This is gated on clarification of the intent of `pathsInDAG`.

This changes `pathsInDAG` to walk every possible path from a root to all reachable nodes. The old version, defining visited-ness by instance definition, would only return paths for all nodes that have unique instance definitions. 

I _think_ this is what it's supposed to be doing (based on the comment), but I need the above-mentioned clarification of intent.

See: https://github.com/freechipsproject/firrtl/issues/654#issuecomment-328889277.