### PR TITLE
Create way of collecting program arguments in Driver

### DIFF
--- a/src/main/scala/firrtl/ExecutionOptionsManager.scala
+++ b/src/main/scala/firrtl/ExecutionOptionsManager.scala
@@ -34,7 +34,9 @@ case class CommonOptions(
     globalLogLevel:    LogLevel.Value = LogLevel.None,
     logToFile:         Boolean        = false,
     logClassNames:     Boolean        = false,
-    classLogLevels: Map[String, LogLevel.Value] = Map.empty) extends ComposableOptions {
+    classLogLevels: Map[String, LogLevel.Value] = Map.empty,
+    programArgs:    Seq[String]                 = Seq.empty
+) extends ComposableOptions {
 
   def getLogFileName(optionsManager: ExecutionOptionsManager): String = {
     if(topName.isEmpty) {
@@ -126,6 +128,10 @@ trait HasCommonOptions {
     .text(s"shows class names and log level in logging output, useful for target --class-log-level")
 
   parser.help("help").text("prints this usage text")
+
+  parser.arg[String]("<arg>...").unbounded().optional().action( (x, c) =>
+    commonOptions = commonOptions.copy(programArgs = commonOptions.programArgs :+ x) ).text("optional unbounded args")
+
 }
 
 /** Firrtl output configuration specified by [[FirrtlExecutionOptions]]

--- a/src/test/scala/firrtlTests/DriverSpec.scala
+++ b/src/test/scala/firrtlTests/DriverSpec.scala
@@ -11,6 +11,7 @@ import firrtl.transforms.BlackBoxSourceHelper
 import firrtl._
 import firrtl.util.BackendCompilationUtilities
 
+//noinspection ScalaStyle
 class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities {
   "CommonOptions are some simple options available across the chisel3 ecosystem" - {
     "CommonOption provide an scopt implementation of an OptionParser" - {
@@ -52,6 +53,29 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
         dir.exists() should be (true)
         FileUtils.deleteDirectoryHierarchy("a") should be (true)
       }
+    }
+    "options include by default a list of strings that are returned in commonOptions.programArgs" in {
+      val optionsManager = new ExecutionOptionsManager("test")
+
+      optionsManager.parse(Array("--top-name", "dog", "fox", "tardigrade", "stomatopod")) should be (true)
+      println(s"programArgs ${optionsManager.commonOptions.programArgs}")
+      optionsManager.commonOptions.programArgs.length should be (3)
+      optionsManager.commonOptions.programArgs should be ("fox" :: "tardigrade" :: "stomatopod" :: Nil)
+
+      optionsManager.commonOptions = CommonOptions()
+      optionsManager.parse(
+        Array("dog", "stomatopod")) should be (true)
+      println(s"programArgs ${optionsManager.commonOptions.programArgs}")
+      optionsManager.commonOptions.programArgs.length should be (2)
+      optionsManager.commonOptions.programArgs should be ("dog" :: "stomatopod" :: Nil)
+
+      optionsManager.commonOptions = CommonOptions()
+      optionsManager.parse(
+        Array("fox", "--top-name", "dog", "tardigrade", "stomatopod")) should be (true)
+      println(s"programArgs ${optionsManager.commonOptions.programArgs}")
+      optionsManager.commonOptions.programArgs.length should be (3)
+      optionsManager.commonOptions.programArgs should be ("fox" :: "tardigrade" :: "stomatopod" :: Nil)
+
     }
   }
   "FirrtlOptions holds option information for the firrtl compiler" - {


### PR DESCRIPTION
Adds programArgs to commonOptions
programArgs is all arguments on command line with out leading -/+
or are not bound to a flag.
Create simple test