### PR TITLE
Allow options managers to not exit when flags include --help

### DIFF
--- a/src/main/scala/firrtl/ExecutionOptionsManager.scala
+++ b/src/main/scala/firrtl/ExecutionOptionsManager.scala
@@ -18,8 +18,25 @@ import scala.collection.Seq
 trait ComposableOptions
 
 abstract class HasParser(applicationName: String) {
-  final val parser: OptionParser[Unit] = new OptionParser[Unit](applicationName) {}
-}
+  final val parser = new OptionParser[Unit](applicationName) {
+    var terminateOnExit = true
+    override def terminate(exitState: Either[String, Unit]): Unit = {
+      if(terminateOnExit) sys.exit(0)
+    }
+  }
+
+  /**
+    * By default scopt calls sys.exit when --help is in options, this defeats that
+    */
+  def doNotExitOnHelp(): Unit = {
+    parser.terminateOnExit = false
+  }
+  /**
+    * By default scopt calls sys.exit when --help is in options, this un-defeats doNotExitOnHelp
+    */
+  def exitOnHelp(): Unit = {
+    parser.terminateOnExit = true
+  }}
 
 /**
   * Most of the chisel toolchain components require a topName which defines a circuit or a device under test.


### PR DESCRIPTION
Provide mechanism so that programs can optionally not exit when --help is included in program flags