### PR TITLE
Fix problem where wrong verilog file is used.

### DIFF
--- a/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
+++ b/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
@@ -102,7 +102,7 @@ trait BackendCompilationUtilities {
 
     val command = Seq(
       "verilator",
-      "--cc", s"$dutFile.v"
+      "--cc", s"${dir.getAbsolutePath}/$dutFile.v"
     ) ++
       blackBoxVerilogList ++
       vSources.flatMap(file => Seq("-v", file.getAbsolutePath)) ++


### PR DESCRIPTION
When calling verilator in a subdirectory like ./test_run_dir/...
verilator will read the verilog file from the current working directory
if there is a file there with the right name.  This fix specifies
the full absolute path of the verilog file intended.