### PR TITLE
Reorder vector size nesting to fix multi-dimensional vecs

### DIFF
--- a/src/main/antlr4/FIRRTL.g4
+++ b/src/main/antlr4/FIRRTL.g4
@@ -51,6 +51,10 @@ dir
   | 'output'
   ;
 
+idx
+  : '[' intLit ']'
+  ;
+
 type 
   : 'UInt' ('<' intLit '>')?
   | 'SInt' ('<' intLit '>')?
@@ -58,7 +62,7 @@ type
   | 'Clock'
   | 'Analog' ('<' intLit '>')?
   | '{' field* '}'        // Bundle
-  | type '[' intLit ']'   // Vector
+  | type idx+   // Vector
   ;
 
 field

--- a/src/main/scala/firrtl/Visitor.scala
+++ b/src/main/scala/firrtl/Visitor.scala
@@ -133,7 +133,8 @@ class Visitor(infoMode: InfoMode) extends FIRRTLBaseVisitor[FirrtlNode] {
           else AnalogType(UnknownWidth)
           case "{" => BundleType(ctx.field.asScala.map(visitField))
         }
-      case typeContext: TypeContext => new VectorType(visitType(ctx.`type`), string2Int(ctx.intLit(0).getText))
+      case typeContext: TypeContext =>
+        ctx.idx.asScala.map(i => string2Int(i.intLit.getText)).foldRight(visitType(ctx.`type`))((a, b) => new VectorType(b, a))
     }
   }
 


### PR DESCRIPTION
**Note: there is probably a chisel "bug" counteracting this "bug," so this is definitely not ready for primetime**

The following is currently illegal, causing the compiler to complain that the index `2` is too big for the range of a 2-element vector.
```
circuit Top :
  module Top :
    input clock : Clock
    output out : UInt<1>
    reg r_vec : UInt<1>[4][2], clock
    out <= r_vec[UInt<2>(2)][UInt<1>(1)]
```
This arises because the order in which index notation is considered is not compatible between vec declarations and access expressions. There are two ways to fix it (fixing the declarations or fixing the expressions), and this fix assumes that the access expression from the above block should be resolved to the following AST, as it currently does in master:

```
    SubAccess
    |       |
SubAccess   1
|       |
Ref     2
```

The counterintuitive, but correct implication is that the vec should have type `Vec(Vec(_, 1), 2)`. This PR modifies the grammar to cause that to happen, by using a single production to iterate through the declared sizes of multi-dimensional vecs, followed by a `foldRight` to produce the right IR structure.