### PR TITLE
Make ReplaceAccesses optimize multi-dimensional accesses

### DIFF
--- a/src/main/scala/firrtl/passes/ReplaceAccesses.scala
+++ b/src/main/scala/firrtl/passes/ReplaceAccesses.scala
@@ -18,7 +18,7 @@ object ReplaceAccesses extends Pass {
   def run(c: Circuit): Circuit = {
     def onStmt(s: Statement): Statement = s map onStmt map onExp
     def onExp(e: Expression): Expression = e match {
-      case WSubAccess(ex, UIntLiteral(value, width), t, g) => WSubIndex(ex, value.toInt, t, g)
+      case WSubAccess(ex, UIntLiteral(value, width), t, g) => WSubIndex(onExp(ex), value.toInt, t, g)
       case _ => e map onExp
     }
   

--- a/src/test/scala/firrtlTests/ReplaceAccessesSpec.scala
+++ b/src/test/scala/firrtlTests/ReplaceAccessesSpec.scala
@@ -1,0 +1,47 @@
+// See LICENSE for license details.
+
+package firrtlTests
+
+import firrtl._
+import firrtl.ir.Circuit
+import firrtl.Parser.IgnoreInfo
+import firrtl.passes._
+import firrtl.transforms._
+
+class ReplaceAccessesSpec extends FirrtlFlatSpec {
+  val transforms = Seq(
+    ToWorkingIR,
+    ResolveKinds,
+    InferTypes,
+    ResolveGenders,
+    InferWidths,
+    ReplaceAccesses)
+  protected def exec(input: String) = {
+    transforms.foldLeft(CircuitState(parse(input), UnknownForm)) {
+      (c: CircuitState, t: Transform) => t.runTransform(c)
+    }.circuit.serialize
+  }
+}
+
+class ReplaceAccessesMultiDim extends ReplaceAccessesSpec {
+  "ReplacesAccesses" should "replace constant accesses with fixed indices" in {
+    val input =
+      """circuit Top :
+  module Top :
+    input clock : Clock
+    output out : UInt<1>
+    reg r_vec : UInt<1>[4][2], clock
+    out <= r_vec[UInt<2>(2)][UInt<1>(1)]
+"""
+    val check =
+      """circuit Top :
+  module Top :
+    input clock : Clock
+    output out : UInt<1>
+    reg r_vec : UInt<1>[4][2], clock with :
+      reset => (UInt<1>(0), r_vec)
+    out <= r_vec[2][1]
+"""
+    (parse(exec(input))) should be (parse(check))
+  }
+}


### PR DESCRIPTION
Currently, the `ReplaceAccesses` pass does not recurse on the `ex` sub-expression of a `WSubAccess` expression. Therefore, multi-dimensional accesses are not properly optimized.

This changes the pass to optimize this correctly and adds a new test case that fails under the old version and succeeds with the update.