### PR TITLE
Namespace - only save suffix for temp names

### DIFF
--- a/src/main/scala/firrtl/Namespace.scala
+++ b/src/main/scala/firrtl/Namespace.scala
@@ -11,7 +11,7 @@ class Namespace private {
   private val tempNamePrefix: String = "_GEN"
   // Begin with a tempNamePrefix in namespace so we always have a number suffix
   private val namespace = mutable.HashSet[String](tempNamePrefix)
-  private var n = 0L
+  private var tempN = 0
 
   def tryName(value: String): Boolean = {
     val unused = !contains(value)
@@ -21,15 +21,23 @@ class Namespace private {
 
   def contains(value: String): Boolean = namespace.contains(value)
 
-  def newName(value: String): String = {
+  private def newNameIndex(value: String, idx: Int): (String, Int) = {
+    var n = idx
     var str = value
     while (!tryName(str)) {
       str = s"${value}_$n"
       n += 1
     }
-    str
+    (str, n)
   }
-  def newTemp: String = newName(tempNamePrefix)
+
+  def newName(value: String): String = newNameIndex(value, 0)._1
+
+  def newTemp: String = {
+    val (name, n) = newNameIndex(tempNamePrefix, tempN)
+    tempN = n
+    name
+  }
 }
 
 object Namespace {

--- a/src/test/scala/firrtlTests/NamespaceSpec.scala
+++ b/src/test/scala/firrtlTests/NamespaceSpec.scala
@@ -1,0 +1,26 @@
+// See LICENSE for license details.
+
+package firrtlTests
+
+import firrtl.Namespace
+
+class NamespaceSpec extends FirrtlFlatSpec {
+
+  "A Namespace" should "not allow collisions" in {
+    val namespace = Namespace()
+    namespace.newName("foo") should be ("foo")
+    namespace.newName("foo") should be ("foo_0")
+  }
+
+  it should "start temps with a suffix of 0" in {
+    Namespace().newTemp.last should be ('0')
+  }
+
+  it should "handle multiple prefixes with independent suffixes" in {
+    val namespace = Namespace()
+    namespace.newName("foo") should be ("foo")
+    namespace.newName("foo") should be ("foo_0")
+    namespace.newName("bar") should be ("bar")
+    namespace.newName("bar") should be ("bar_0")
+  }
+}


### PR DESCRIPTION
This prevents collisions for one prefix (including temp) from
incrementing the suffix for other prefixes. Makes names more stable.