### PR TITLE
StringLit.verilogEscape should support all printable ASCII chars

### DIFF
--- a/src/main/scala/firrtl/ir/IR.scala
+++ b/src/main/scala/firrtl/ir/IR.scala
@@ -69,12 +69,12 @@ object StringLit {
   /** Maps characters to ASCII for Verilog emission */
   private def toASCII(char: Char): List[Char] = char match {
     case nonASCII if !nonASCII.isValidByte => List('?')
-    case letter if letter.isLetter => List(letter)
-    case '\n' => List('\\', 'n')
-    case '\\' => List('\\', '\\')
-    case '\t' => List('\\', 't')
     case '"' => List('\\', '"')
-    case other => List('?')
+    case '\\' => List('\\', '\\')
+    case c if c >= ' ' && c <= '~' => List(c)
+    case '\n' => List('\\', 'n')
+    case '\t' => List('\\', 't')
+    case _ => List('?')
   }
 
   /** Create a StringLit from a raw parsed String */

--- a/src/test/scala/firrtlTests/StringSpec.scala
+++ b/src/test/scala/firrtlTests/StringSpec.scala
@@ -66,6 +66,9 @@ class StringSpec extends FirrtlPropSpec {
     val lit = StringLit.unescape(whitelist)
     // Check result
     assert(lit.serialize == whitelist)
+    // Scala likes to escape ' as \', Verilog doesn't
+    val verilogWhitelist = whitelist.replaceAll("""\\'""", "'")
+    assert(lit.verilogEscape.tail.init == verilogWhitelist)
   }
 
   // Valid escapes = \n, \t, \\, \", \'


### PR DESCRIPTION
Defined as the range from ' ' to '~' [0x20, 0x7e]