### PR TITLE
Add Yosys formal equivalence checking to Travis regressions

### DIFF
--- a/.install_yosys.sh
+++ b/.install_yosys.sh
@@ -1,0 +1,11 @@
+set -e
+# Install Yosys (https://github.com/cliffordwolf/yosys)
+if [ ! -f $INSTALL_DIR/bin/yosys ]; then
+  mkdir -p $INSTALL_DIR
+  git clone https://github.com/cliffordwolf/yosys.git
+  cd yosys
+  git pull
+  git checkout yosys-0.7
+  make
+  make PREFIX=$INSTALL_DIR install
+fi

--- a/.run_formal_checks.sh
+++ b/.run_formal_checks.sh
@@ -1,0 +1,17 @@
+set -e
+# Run formal check only for PRs
+if [ $TRAVIS_PULL_REQUEST = "false" ]; then
+    echo "Not a pull request, no formal check"
+    exit 0
+elif [[ $TRAVIS_COMMIT_MESSAGE == *"[skip formal checks]"* ]]; then
+    echo "Commit message says to skip formal checks"
+    exit 0
+else
+    # $TRAVIS_BRANCH is branch targeted by PR
+    # Travis does a shallow clone, checkout PR target so that we have it
+    # THen return to previous branch so HEAD points to the commit we're testing
+    git remote set-branches origin $TRAVIS_BRANCH && git fetch
+    git checkout $TRAVIS_BRANCH
+    git checkout -
+    bash ./scripts/formal_equiv.sh HEAD $TRAVIS_BRANCH
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,6 @@ jobs:
       script:
         - sbt clean assembly publish-local
         - bash .run_chisel_tests.sh
+    - stage: test
+      script:
+        - bash .run_formal_checks.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ env:
 before_script:
   - bash .install_verilator.sh
   - verilator --version
+  - bash .install_yosys.sh
+  - yosys -V
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
 git:
   depth: 10
 
-sbt_args: -Dsbt.log.noformat=true ++$TRAVIS_SCALA_VERSION
+sbt_args: -Dsbt.log.noformat=true
 
 env:
   global:
@@ -26,14 +26,7 @@ before_script:
 
 jobs:
   include:
-    - stage: Test
-    - &test
+    - stage: test
       script:
-        # FIRRTL Tests
-        - cd $TRAVIS_BUILD_DIR
-        - sbt clean test
-    - <<: *test
-      script:
-        - cd $TRAVIS_BUILD_DIR
         - sbt clean assembly publish-local
         - bash .run_chisel_tests.sh

--- a/scripts/formal_equiv.sh
+++ b/scripts/formal_equiv.sh
@@ -1,0 +1,57 @@
+# This script is for formally comparing the Verilog emitted by different git revisions
+# There must be two valid git revision arguments
+set -e
+
+if [ $# -ne 2 ]; then
+    echo "There must be exactly two arguments!"
+    exit -1
+fi
+
+HASH1=`git rev-parse $1`
+HASH2=`git rev-parse $2`
+
+echo "Comparing git revisions $HASH1 and $HASH2"
+
+if [ $HASH1 = $HASH2 ]; then
+    echo "Both git revisions are the same! Nothing to do!"
+    exit 0
+fi
+
+RET=""
+make_verilog () {
+    git checkout $1
+    local filename="rob.$1.v"
+
+    sbt clean
+    sbt "run-main firrtl.Driver -i regress/Rob.fir -o $filename -X verilog"
+    RET=$filename
+}
+
+# Generate Verilog to compare
+make_verilog $HASH1
+FILE1=$RET
+
+make_verilog $HASH2
+FILE2=$RET
+
+echo "Comparing $FILE1 and $FILE2"
+
+if cmp -s $FILE1 $FILE2; then
+    echo "File contents are identical!"
+    exit 0
+else
+    echo "Running equivalence check using Yosys"
+    yosys -q -p "
+      read_verilog $FILE1
+      rename Rob top1
+      read_verilog $FILE2
+      rename Rob top2
+      proc
+      memory
+      equiv_make top1 top2 equiv
+      hierarchy -top equiv
+      clean -purge
+      equiv_simple
+      equiv_status -assert
+    "
+fi


### PR DESCRIPTION
This adds a helper script for running equivalence checks using Yosys. For now it only checks BOOM's Rob because there are namespace issues with circuits with multiple modules. The check only runs on PRs and only if the emitted Verilog is actually different.

I have run the script locally and it seems to work well, but I can't test it on actual Travis without a PR. I'm going to see if creating a PR against this branch that trivially changes Verilog emission will trigger it.