### PR TITLE
Fix bug emitting and reparsing ExtModule String parameters

### DIFF
--- a/src/main/scala/firrtl/ir/IR.scala
+++ b/src/main/scala/firrtl/ir/IR.scala
@@ -481,7 +481,7 @@ case class DoubleParam(name: String, value: Double) extends Param {
 }
 /** String Parameter */
 case class StringParam(name: String, value: StringLit) extends Param {
-  override def serialize: String = super.serialize + value.serialize
+  override def serialize: String = super.serialize + value.escape
 }
 /** Raw String Parameter
   * Useful for Verilog type parameters

--- a/src/test/scala/firrtlTests/ParserSpec.scala
+++ b/src/test/scala/firrtlTests/ParserSpec.scala
@@ -114,7 +114,8 @@ class ParserSpec extends FirrtlFlatSpec {
       |    in.0.1 <= in.0.0
       |    in2.4.23.bar.123 <= in2.4.23.foo
       """.stripMargin
-    firrtl.Parser.parse(input split "\n")
+    val c = firrtl.Parser.parse(input)
+    firrtl.Parser.parse(c.serialize)
   }
 
   // ********** Doubles as parameters **********
@@ -123,7 +124,6 @@ class ParserSpec extends FirrtlFlatSpec {
     val signs = Seq("", "+", "-")
     val tests = "0.0" +: (signs flatMap (s => nums map (n => s + n)))
     for (test <- tests) {
-      println(s"Trying $test")
       val input = s"""
         |circuit Test :
         |  extmodule Ext :
@@ -136,8 +136,26 @@ class ParserSpec extends FirrtlFlatSpec {
         |    input foo : UInt<32>
         |    output bar : UInt<32>
         """.stripMargin
-      firrtl.Parser.parse(input split "\n")
+      val c = firrtl.Parser.parse(input)
+      firrtl.Parser.parse(c.serialize)
     }
+  }
+
+  "Strings" should "be legal parameters for extmodules" in {
+    val input = s"""
+      |circuit Test :
+      |  extmodule Ext :
+      |    input foo : UInt<32>
+      |
+      |    defname = MyExtModule
+      |    parameter STR = "hello=%d"
+      |
+      |  module Test :
+      |    input foo : UInt<32>
+      |    output bar : UInt<32>
+      """.stripMargin
+    val c = firrtl.Parser.parse(input)
+    firrtl.Parser.parse(c.serialize)
   }
 }
 


### PR DESCRIPTION
Pretty straightforward, I previously changed StringLit serialize to not include the double quotes but that's problematic for String parameter reparsing since they emit without the necessary double quotes