### PR TITLE
Emit source locators as comments in emitted Verilog

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -233,6 +233,10 @@ class VerilogEmitter extends SeqTransform with Emitter {
       case (i: Int) => w write i.toString
       case (i: Long) => w write i.toString
       case (i: BigInt) => w write i.toString
+      case (i: Info) => i match {
+        case NoInfo => // Do nothing
+        case ix => w.write(s" //$ix")
+      }
       case (s: Seq[Any]) =>
         s foreach (emit(_, top + 1))
         if (top == 0) w write "\n"
@@ -378,22 +382,23 @@ class VerilogEmitter extends SeqTransform with Emitter {
       val at_clock = mutable.LinkedHashMap[Expression,ArrayBuffer[Seq[Any]]]()
       val initials = ArrayBuffer[Seq[Any]]()
       val simulates = ArrayBuffer[Seq[Any]]()
-      def declare(b: String, n: String, t: Type) = t match {
+      def declare(b: String, n: String, t: Type, info: Info) = t match {
         case tx: VectorType =>
-          declares += Seq(b, " ", tx.tpe, " ", n, " [0:", tx.size - 1, "];")
+          declares += Seq(b, " ", tx.tpe, " ", n, " [0:", tx.size - 1, "];",info)
         case tx =>
-          declares += Seq(b, " ", tx, " ", n,";")
+          declares += Seq(b, " ", tx, " ", n,";",info)
       }
-      def assign(e: Expression, value: Expression) {
-        assigns += Seq("assign ", e, " = ", value, ";")
+      def assign(e: Expression, value: Expression, info: Info) {
+        assigns += Seq("assign ", e, " = ", value, ";", info)
       }
 
       // In simulation, assign garbage under a predicate
-      def garbageAssign(e: Expression, syn: Expression, garbageCond: Expression) = {
+      def garbageAssign(e: Expression, syn: Expression, garbageCond: Expression, info: Info) = {
         assigns += Seq("`ifndef RANDOMIZE_GARBAGE_ASSIGN")
-        assigns += Seq("assign ", e, " = ", syn, ";")
+        assigns += Seq("assign ", e, " = ", syn, ";", info)
         assigns += Seq("`else")
-        assigns += Seq("assign ", e, " = ", garbageCond, " ? ", rand_string(syn.tpe), " : ", syn, ";")
+        assigns += Seq("assign ", e, " = ", garbageCond, " ? ", rand_string(syn.tpe), " : ", syn,
+                       ";", info)
         assigns += Seq("`endif // RANDOMIZE_GARBAGE_ASSIGN")
       }
       def invalidAssign(e: Expression) = {
@@ -455,12 +460,12 @@ class VerilogEmitter extends SeqTransform with Emitter {
         }
       }
 
-      def update(e: Expression, value: Expression, clk: Expression, en: Expression) {
+      def update(e: Expression, value: Expression, clk: Expression, en: Expression, info: Info) = {
          if (!at_clock.contains(clk)) at_clock(clk) = ArrayBuffer[Seq[Any]]()
          if (weq(en,one)) at_clock(clk) += Seq(e," <= ",value,";")
          else {
             at_clock(clk) += Seq("if(",en,") begin")
-            at_clock(clk) += Seq(tab,e," <= ",value,";")
+            at_clock(clk) += Seq(tab,e," <= ",value,";",info)
             at_clock(clk) += Seq("end")
          }
       }
@@ -471,7 +476,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
          val nx = namespace.newName("_RAND")
          val rand = VRandom(bitWidth(t))
          val tx = SIntType(IntWidth(rand.realWidth))
-         declare("reg",nx, tx)
+         declare("reg",nx, tx, NoInfo)
          initials += Seq(wref(nx, tx), " = ", VRandom(bitWidth(t)), ";")
          Seq(nx, "[", bitWidth(t) - 1, ":0]")
       }
@@ -492,7 +497,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
         initials += Seq("`endif // RANDOMIZE_MEM_INIT")
       }
 
-      def simulate(clk: Expression, en: Expression, s: Seq[Any], cond: Option[String]) {
+      def simulate(clk: Expression, en: Expression, s: Seq[Any], cond: Option[String], info: Info) = {
         if (!at_clock.contains(clk)) at_clock(clk) = ArrayBuffer[Seq[Any]]()
         at_clock(clk) += Seq("`ifndef SYNTHESIS")
         if (cond.nonEmpty) {
@@ -501,7 +506,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
           at_clock(clk) += Seq("`endif")
         }
         at_clock(clk) += Seq(tab,tab,"if (",en,") begin")
-        at_clock(clk) += Seq(tab,tab,tab,s)
+        at_clock(clk) += Seq(tab,tab,tab,s,info)
         at_clock(clk) += Seq(tab,tab,"end")
         if (cond.nonEmpty) {
           at_clock(clk) += Seq(s"`ifdef ${cond.get}")
@@ -539,42 +544,44 @@ class VerilogEmitter extends SeqTransform with Emitter {
         }
 
         // dirs are already padded
-        portdefs ++= (dirs, padToMax(tpes), m.ports).zipped.map {
-          case (dir, tpe, Port(_, name, _,_)) => Seq(dir, " " , tpe, " ", name)
+        portdefs ++= (dirs, padToMax(tpes), m.ports).zipped.toSeq.zipWithIndex.map {
+          case ((dir, tpe, Port(info, name, _,_)), i) =>
+            if (i != m.ports.size - 1) Seq(dir, " " , tpe, " ", name, ",", info)
+            else Seq(dir, " " , tpe, " ", name, info)
         }
       }
 
       def build_streams(s: Statement): Statement = s map build_streams match {
         case sx @ Connect(info, loc @ WRef(_, _, PortKind | WireKind | InstanceKind, _), expr) =>
-          assign(loc, expr)
+          assign(loc, expr, info)
           sx
         case sx: DefWire =>
-          declare("wire",sx.name,sx.tpe)
+          declare("wire", sx.name, sx.tpe, sx.info)
           sx
         case sx: DefRegister =>
-          declare("reg", sx.name, sx.tpe)
+          declare("reg", sx.name, sx.tpe, sx.info)
           val e = wref(sx.name, sx.tpe)
           update_and_reset(e, sx.clock, sx.reset, sx.init)
           initialize(e)
           sx
         case sx @ IsInvalid(info, expr) =>
           val wref = netlist(expr) match { case e: WRef => e }
-          declare("reg", wref.name, sx.expr.tpe)
+          declare("reg", wref.name, sx.expr.tpe, info)
           initialize(wref)
           kind(expr) match {
-            case PortKind | WireKind | InstanceKind => assign(expr, netlist(expr))
+            case PortKind | WireKind | InstanceKind => assign(expr, netlist(expr), info)
             case _ =>
           }
           sx
         case sx: DefNode =>
-          declare("wire", sx.name, sx.value.tpe)
-          assign(WRef(sx.name, sx.value.tpe, NodeKind, MALE), sx.value)
+          declare("wire", sx.name, sx.value.tpe, sx.info)
+          assign(WRef(sx.name, sx.value.tpe, NodeKind, MALE), sx.value, sx.info)
           sx
         case sx: Stop =>
-          simulate(sx.clk, sx.en, stop(sx.ret), Some("STOP_COND"))
+          simulate(sx.clk, sx.en, stop(sx.ret), Some("STOP_COND"), sx.info)
           sx
         case sx: Print =>
-          simulate(sx.clk, sx.en, printf(sx.string, sx.args), Some("PRINTF_COND"))
+          simulate(sx.clk, sx.en, printf(sx.string, sx.args), Some("PRINTF_COND"), sx.info)
           sx
         // If we are emitting an Attach, it must not have been removable in VerilogPrep
         case sx: Attach =>
@@ -583,11 +590,11 @@ class VerilogEmitter extends SeqTransform with Emitter {
           for (set <- sx.exprs.toSet.subsets(2)) {
             val (a, b) = set.toSeq match { case Seq(x, y) => (x, y) }
             // Synthesizable ones as well
-            attachSynAssigns += Seq("assign ", a, " = ", b, ";")
-            attachSynAssigns += Seq("assign ", b, " = ", a, ";")
+            attachSynAssigns += Seq("assign ", a, " = ", b, ";", sx.info)
+            attachSynAssigns += Seq("assign ", b, " = ", a, ";", sx.info)
           }
           // alias implementation for everything else
-          attachAliases += Seq("alias ", sx.exprs.flatMap(e => Seq(e, " = ")).init, ";")
+          attachAliases += Seq("alias ", sx.exprs.flatMap(e => Seq(e, " = ")).init, ";", sx.info)
           sx
         case sx: WDefInstanceConnector =>
           val (module, params) = moduleMap(sx.module) match {
@@ -595,7 +602,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
             case Module(_, name, _, _) => (name, Seq.empty)
           }
           val ps = if (params.nonEmpty) params map stringify mkString ("#(", ", ", ") ") else ""
-          instdeclares += Seq(module, " ", ps, sx.name ," (")
+          instdeclares += Seq(module, " ", ps, sx.name ," (", sx.info)
           for (((port, ref), i) <- sx.portCons.zipWithIndex) {
             val line = Seq(tab, ".", remove_root(port), "(", ref, ")")
             if (i != sx.portCons.size - 1) instdeclares += Seq(line, ",")
@@ -606,7 +613,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
         case sx: DefMemory =>
           val fullSize = sx.depth * (sx.dataType match { case GroundType(IntWidth(width)) => width })
           val decl = if (fullSize > (1 << 29)) "reg /* sparse */" else "reg"
-          declare(decl, sx.name, VectorType(sx.dataType, sx.depth))
+          declare(decl, sx.name, VectorType(sx.dataType, sx.depth), sx.info)
           initialize_mem(sx)
           if (sx.readLatency != 0 || sx.writeLatency != 1)
             throw EmitterException("All memories should be transformed into " +
@@ -618,12 +625,12 @@ class VerilogEmitter extends SeqTransform with Emitter {
             // Ports should share an always@posedge, so can't have intermediary wire
             val clk = netlist(memPortField(sx, r, "clk"))
 
-            declare("wire", LowerTypes.loweredName(data), data.tpe)
-            declare("wire", LowerTypes.loweredName(addr), addr.tpe)
+            declare("wire", LowerTypes.loweredName(data), data.tpe, sx.info)
+            declare("wire", LowerTypes.loweredName(addr), addr.tpe, sx.info)
             // declare("wire", LowerTypes.loweredName(en), en.tpe)
 
             //; Read port
-            assign(addr, netlist(addr)) //;Connects value to m.r.addr
+            assign(addr, netlist(addr), NoInfo) // Info should come from addr connection
             // assign(en, netlist(en))     //;Connects value to m.r.en
             val mem = WRef(sx.name, memType(sx), MemKind, UNKNOWNGENDER)
             val memPort = WSubAccess(mem, addr, sx.dataType, UNKNOWNGENDER)
@@ -631,9 +638,9 @@ class VerilogEmitter extends SeqTransform with Emitter {
             val garbageGuard = DoPrim(Geq, Seq(addr, depthValue), Seq(), UnknownType)
 
             if ((sx.depth & (sx.depth - 1)) == 0)
-              assign(data, memPort)
+              assign(data, memPort, sx.info)
             else
-              garbageAssign(data, memPort, garbageGuard)
+              garbageAssign(data, memPort, garbageGuard, sx.info)
           }
 
           for (w <- sx.writers) {
@@ -644,20 +651,21 @@ class VerilogEmitter extends SeqTransform with Emitter {
             //Ports should share an always@posedge, so can't have intermediary wire
             val clk = netlist(memPortField(sx, w, "clk"))
 
-            declare("wire", LowerTypes.loweredName(data), data.tpe)
-            declare("wire", LowerTypes.loweredName(addr), addr.tpe)
-            declare("wire", LowerTypes.loweredName(mask), mask.tpe)
-            declare("wire", LowerTypes.loweredName(en), en.tpe)
+            declare("wire", LowerTypes.loweredName(data), data.tpe, sx.info)
+            declare("wire", LowerTypes.loweredName(addr), addr.tpe, sx.info)
+            declare("wire", LowerTypes.loweredName(mask), mask.tpe, sx.info)
+            declare("wire", LowerTypes.loweredName(en), en.tpe, sx.info)
 
-            //; Write port
-            assign(data, netlist(data))
-            assign(addr, netlist(addr))
-            assign(mask, netlist(mask))
-            assign(en, netlist(en))
+            // Write port
+            // Info should come from netlist
+            assign(data, netlist(data), NoInfo)
+            assign(addr, netlist(addr), NoInfo)
+            assign(mask, netlist(mask), NoInfo)
+            assign(en, netlist(en), NoInfo)
 
             val mem = WRef(sx.name, memType(sx), MemKind, UNKNOWNGENDER)
             val memPort = WSubAccess(mem, addr, sx.dataType, UNKNOWNGENDER)
-            update(memPort, data, clk, AND(en, mask))
+            update(memPort, data, clk, AND(en, mask), sx.info)
           }
 
           if (sx.readwriters.nonEmpty)
@@ -668,13 +676,8 @@ class VerilogEmitter extends SeqTransform with Emitter {
       }
 
       def emit_streams() {
-        emit(Seq("module ", m.name, "("))
-        for ((x, i) <- portdefs.zipWithIndex) {
-          if (i != portdefs.size - 1)
-            emit(Seq(tab, x, ","))
-          else
-            emit(Seq(tab, x))
-        }
+        emit(Seq("module ", m.name, "(", m.info))
+        for (x <- portdefs) emit(Seq(tab, x))
         emit(Seq(");"))
 
         if (declares.isEmpty && assigns.isEmpty) emit(Seq(tab, "initial begin end"))

--- a/src/test/scala/firrtlTests/FirrtlSpec.scala
+++ b/src/test/scala/firrtlTests/FirrtlSpec.scala
@@ -11,6 +11,7 @@ import org.scalatest.prop._
 import scala.io.Source
 
 import firrtl._
+import firrtl.ir._
 import firrtl.Parser.UseInfo
 import firrtl.annotations._
 import firrtl.transforms.{DontTouchAnnotation, NoDedupAnnotation}
@@ -119,9 +120,116 @@ trait FirrtlMatchers extends Matchers {
   }
 }
 
+object FirrtlCheckers extends FirrtlMatchers {
+  import matchers._
+  implicit class TestingFunctionsOnCircuitState(val state: CircuitState) extends AnyVal {
+    def search(pf: PartialFunction[Any, Boolean]): Boolean = state.circuit.search(pf)
+  }
+  implicit class TestingFunctionsOnCircuit(val circuit: Circuit) extends AnyVal {
+    def search(pf: PartialFunction[Any, Boolean]): Boolean = {
+      val f = pf.lift
+      def rec(node: Any): Boolean = {
+        f(node) match {
+          // If the partial function is defined on this node, return its result
+          case Some(res) => res
+          // Otherwise keep digging
+          case None =>
+            require(node.isInstanceOf[Product] || !node.isInstanceOf[FirrtlNode],
+                    "Error! Unexpected FirrtlNode that does not implement Product!")
+            val iter = node match {
+              case p: Product => p.productIterator
+              case i: Iterable[Any] => i.iterator
+              case _ => Iterator.empty
+            }
+            iter.foldLeft(false) {
+              case (res, elt) => if (res) res else rec(elt)
+            }
+        }
+      }
+      rec(circuit)
+    }
+  }
+
+  /** Checks that the emitted circuit has the expected line, both will be normalized */
+  def containLine(expectedLine: String) = new CircuitStateStringMatcher(expectedLine)
+
+  class CircuitStateStringMatcher(expectedLine: String) extends Matcher[CircuitState] {
+    override def apply(state: CircuitState): MatchResult = {
+      val emitted = state.getEmittedCircuit.value
+      MatchResult(
+        emitted.split("\n").map(normalized).contains(normalized(expectedLine)),
+        emitted + "\n did not contain \"" + expectedLine + "\"",
+        s"${state.circuit.main} contained $expectedLine"
+      )
+    }
+  }
+
+  def containTree(pf: PartialFunction[Any, Boolean]) = new CircuitStatePFMatcher(pf)
+
+  class CircuitStatePFMatcher(pf: PartialFunction[Any, Boolean]) extends Matcher[CircuitState] {
+    override def apply(state: CircuitState): MatchResult = {
+      MatchResult(
+        state.search(pf),
+        state.circuit.serialize + s"\n did not contain $pf",
+        s"${state.circuit.main} contained $pf"
+      )
+    }
+  }
+}
+
 abstract class FirrtlPropSpec extends PropSpec with PropertyChecks with FirrtlRunners with LazyLogging
 
 abstract class FirrtlFlatSpec extends FlatSpec with FirrtlRunners with FirrtlMatchers with LazyLogging
+
+// Who tests the testers?
+class TestFirrtlFlatSpec extends FirrtlFlatSpec {
+  import FirrtlCheckers._
+
+  val c = parse("""
+    |circuit Test:
+    |  module Test :
+    |    input in : UInt<8>
+    |    output out : UInt<8>
+    |    out <= in
+    |""".stripMargin)
+  val state = CircuitState(c, ChirrtlForm)
+  val compiled = (new LowFirrtlCompiler).compileAndEmit(state, List.empty)
+
+  // While useful, ScalaTest helpers should be used over search
+  behavior of "Search"
+
+  it should "be supported on Circuit" in {
+    assert(c search {
+      case Connect(_, Reference("out",_), Reference("in",_)) => true
+    })
+  }
+  it should "be supported on CircuitStates" in {
+    assert(state search {
+      case Connect(_, Reference("out",_), Reference("in",_)) => true
+    })
+  }
+  it should "be supported on the results of compilers" in {
+    assert(compiled search {
+      case Connect(_, WRef("out",_,_,_), WRef("in",_,_,_)) => true
+    })
+  }
+
+  // Use these!!!
+  behavior of "ScalaTest helpers"
+
+  they should "work for lines of emitted text" in {
+    compiled should containLine (s"input in : UInt<8>")
+    compiled should containLine (s"output out : UInt<8>")
+    compiled should containLine (s"out <= in")
+  }
+
+  they should "work for partial functions matching on subtrees" in {
+    val UInt8 = UIntType(IntWidth(8)) // BigInt unapply is weird
+    compiled should containTree { case Port(_, "in", Input, UInt8) => true }
+    compiled should containTree { case Port(_, "out", Output, UInt8) => true }
+    compiled should containTree { case Connect(_, WRef("out",_,_,_), WRef("in",_,_,_)) => true }
+  }
+}
 
 /** Super class for execution driven Firrtl tests */
 abstract class ExecutionTest(name: String, dir: String, vFiles: Seq[String] = Seq.empty) extends FirrtlPropSpec {

--- a/src/test/scala/firrtlTests/InfoSpec.scala
+++ b/src/test/scala/firrtlTests/InfoSpec.scala
@@ -1,0 +1,120 @@
+// See LICENSE for license details.
+
+package firrtlTests
+
+import firrtl._
+import firrtl.ir._
+import FirrtlCheckers._
+
+class InfoSpec extends FirrtlFlatSpec {
+  def compile(input: String): CircuitState =
+    (new VerilogCompiler).compileAndEmit(CircuitState(parse(input), ChirrtlForm), List.empty)
+  def compileBody(body: String) = {
+    val str = """
+      |circuit Test :
+      |  module Test :
+      |""".stripMargin + body.split("\n").mkString("    ", "\n    ", "")
+    compile(str)
+  }
+
+  // Some useful constants to use and look for
+  val Info1 = FileInfo(StringLit("Source.scala 1:4"))
+  val Info2 = FileInfo(StringLit("Source.scala 2:4"))
+  val Info3 = FileInfo(StringLit("Source.scala 3:4"))
+
+  "Source locators on module ports" should "be propagated to Verilog" in {
+    val result = compileBody(s"""
+      |input x : UInt<8> $Info1
+      |output y : UInt<8> $Info2
+      |y <= x""".stripMargin
+    )
+    result should containTree { case Port(Info1, "x", Input, _) => true }
+    result should containLine (s"input [7:0] x, //$Info1")
+    result should containTree { case Port(Info2, "y", Output, _) => true }
+    result should containLine (s"output [7:0] y //$Info2")
+  }
+
+  "Source locators on aggregates" should "be propagated to Verilog" in {
+    val result = compileBody(s"""
+      |input io : { x : UInt<8>, flip y : UInt<8> } $Info1
+      |io.y <= io.x""".stripMargin
+    )
+    result should containTree { case Port(Info1, "io_x", Input, _) => true }
+    result should containLine (s"input [7:0] io_x, //$Info1")
+    result should containTree { case Port(Info1, "io_y", Output, _) => true }
+    result should containLine (s"output [7:0] io_y //$Info1")
+  }
+
+  "Source locators" should "be propagated on declarations" in {
+    val result = compileBody(s"""
+      |input clock : Clock
+      |input x : UInt<8>
+      |output y : UInt<8>
+      |reg r : UInt<8>, clock $Info1
+      |wire w : UInt<8> $Info2
+      |node n = or(w, x) $Info3
+      |w <= and(x, r)
+      |r <= or(n, r)
+      |y <= r""".stripMargin
+    )
+    result should containTree { case DefRegister(Info1, "r", _,_,_,_) => true }
+    result should containLine (s"reg [7:0] r; //$Info1")
+    result should containTree { case DefWire(Info2, "w", _) => true }
+    result should containLine (s"wire [7:0] w; //$Info2")
+    result should containTree { case DefNode(Info3, "n", _) => true }
+    result should containLine (s"wire [7:0] n; //$Info3")
+    result should containLine (s"assign n = w | x; //$Info3")
+  }
+
+  they should "be propagated on memories" in {
+    val result = compileBody(s"""
+      |input clock : Clock
+      |input addr : UInt<5>
+      |output z : UInt<8>
+      |mem m: $Info1
+      |  data-type => UInt<8>
+      |  depth => 32
+      |  read-latency => 0
+      |  write-latency => 1
+      |  reader => r
+      |  writer => w
+      |m.r.clk <= clock
+      |m.r.addr <= addr
+      |m.r.en <= UInt(1)
+      |m.w.clk <= clock
+      |m.w.addr <= addr
+      |m.w.en <= UInt(0)
+      |m.w.data <= UInt(0)
+      |m.w.mask <= UInt(0)
+      |z <= m.r.data
+      |""".stripMargin
+    )
+
+    result should containTree { case DefMemory(Info1, "m", _,_,_,_,_,_,_,_) => true }
+    result should containLine (s"reg [7:0] m [0:31]; //$Info1")
+    result should containLine (s"wire [7:0] m_r_data; //$Info1")
+    result should containLine (s"wire [4:0] m_r_addr; //$Info1")
+    result should containLine (s"wire [7:0] m_w_data; //$Info1")
+    result should containLine (s"wire [4:0] m_w_addr; //$Info1")
+    result should containLine (s"wire  m_w_mask; //$Info1")
+    result should containLine (s"wire  m_w_en; //$Info1")
+    result should containLine (s"assign m_r_data = m[m_r_addr]; //$Info1")
+    result should containLine (s"m[m_w_addr] <= m_w_data; //$Info1")
+  }
+
+  they should "be propagated on instances" in {
+    val result = compile(s"""
+      |circuit Test :
+      |  module Child :
+      |    output io : { flip in : UInt<8>, out : UInt<8> }
+      |    io.out <= io.in
+      |  module Test :
+      |    output io : { flip in : UInt<8>, out : UInt<8> }
+      |    inst c of Child $Info1
+      |    io <= c.io
+      |""".stripMargin
+    )
+    result should containTree { case WDefInstance(Info1, "c", "Child", _) => true }
+    result should containLine (s"Child c ( //$Info1")
+  }
+}


### PR DESCRIPTION
This simply emits source locators as a comment at the end of the associated line in the Verilog. I might've missed a couple of things, but I think it hits most cases.

Future work (that I'm working on):
- Preserve source locators through ExpandWhens
- Improve instance connections (currently we have lots of extra assigns from instance ports, WDefInstanceConector provides a mechanism to remove these extra assigns and should also support Info)