### PR TITLE
Fix bug in ConstProp where module dependency edges were dropped

### DIFF
--- a/src/main/scala/firrtl/graph/DiGraph.scala
+++ b/src/main/scala/firrtl/graph/DiGraph.scala
@@ -302,7 +302,8 @@ class DiGraph[T] private[graph] (private[graph] val edges: LinkedHashMap[T, Link
     * @return a transformed DiGraph[Q]
     */
   def transformNodes[Q](f: (T) => Q): DiGraph[Q] = {
-    val eprime = edges.map({ case (k, v) => (f(k), v.map(f(_))) })
+    val eprime = edges.map({ case (k, _) => (f(k), new LinkedHashSet[Q]) })
+    edges.foreach({ case (k, v) => eprime(f(k)) ++= v.map(f(_)) })
     new DiGraph(eprime)
   }
 

--- a/src/test/scala/firrtlTests/graph/DiGraphTests.scala
+++ b/src/test/scala/firrtlTests/graph/DiGraphTests.scala
@@ -29,6 +29,13 @@ class DiGraphTests extends FirrtlFlatSpec {
     "c" -> Set("d"),
     "d" -> Set("a")))
 
+  val tupleGraph = DiGraph(Map(
+    ("a", 0) -> Set(("b", 2)),
+    ("a", 1) -> Set(("c", 3)),
+    ("b", 2) -> Set.empty[(String, Int)],
+    ("c", 3) -> Set.empty[(String, Int)]
+  ))
+
   val degenerateGraph = DiGraph(Map("a" -> Set.empty[String]))
 
   acyclicGraph.findSCCs.filter(_.length > 1) shouldBe empty
@@ -46,5 +53,9 @@ class DiGraphTests extends FirrtlFlatSpec {
   acyclicGraph.reverse.getEdgeMap should equal (reversedAcyclicGraph.getEdgeMap)
 
   degenerateGraph.getEdgeMap should equal (degenerateGraph.reverse.getEdgeMap)
+
+  "transformNodes" should "combine vertices that collide, not drop them" in {
+    tupleGraph.transformNodes(_._1).getEdgeMap should contain ("a" -> Set("b", "c"))
+  }
 
 }


### PR DESCRIPTION
This resulted in parent modules sometimes being constant proppagated
before a child module. If the child module has a constant driving one of
its outputs, the parent module would thus not see the constant. This
resulted in strange unstable constant propagation behavior where
sometimes constant outputs would not propagate.

Also add test illustrating why this occurs with uses of InstanceGraph

We could consider making transformNodes in DiGraph combine the edge sets as I clearly expected it to do. see the example in InstanceGraphTests as an illustration of what went wrong in ConstProp.