### PR TITLE
Change default source locator to "use" instead of "append"

### DIFF
--- a/src/main/scala/firrtl/ExecutionOptionsManager.scala
+++ b/src/main/scala/firrtl/ExecutionOptionsManager.scala
@@ -172,7 +172,7 @@ case class FirrtlExecutionOptions(
     inputFileNameOverride:  String = "",
     outputFileNameOverride: String = "",
     compilerName:           String = "verilog",
-    infoModeName:           String = "append",
+    infoModeName:           String = "use",
     inferRW:                Seq[String] = Seq.empty,
     firrtlSource:           Option[String] = None,
     customTransforms:       Seq[Transform] = List.empty,


### PR DESCRIPTION
I think for most users, the Firrtl source locators are not useful. I have told people about source locators in the emitted Verilog and gotten the response "Yeah, but it's just the Firrtl source locators, I need the Scala". The option to use append is still there on the command-line, but in general I think just using the Chisel ones is more useful.