### PR TITLE
Refactor Annotations Driver API

### DIFF
--- a/src/main/scala/firrtl/Driver.scala
+++ b/src/main/scala/firrtl/Driver.scala
@@ -196,7 +196,7 @@ object Driver {
         case OneFilePerModule(dirName) =>
           val emittedModules = finalState.emittedComponents collect { case x: EmittedModule => x }
           if (emittedModules.isEmpty) throwInternalError // There should be something
-          emittedModules.foreach { case module =>
+          emittedModules.foreach { module =>
             val filename = optionsManager.getBuildFileName(firrtlConfig.outputSuffix, s"$dirName/${module.name}")
             val outputFile = new java.io.PrintWriter(filename)
             outputFile.write(module.value)
@@ -211,8 +211,8 @@ object Driver {
         case file =>
           val filename = optionsManager.getBuildFileName("anno", file)
           val outputFile = new java.io.PrintWriter(filename)
-          finalState.annotations.map {
-            case annos => outputFile.write(annos.annotations.mkString("\n"))
+          finalState.annotations.foreach {
+            finalAnnos => outputFile.write(finalAnnos.annotations.toYaml.prettyPrint)
           }
           outputFile.close()
       }

--- a/src/main/scala/firrtl/Driver.scala
+++ b/src/main/scala/firrtl/Driver.scala
@@ -95,23 +95,15 @@ object Driver {
     *                       update the firrtlOptions with new annotations if it does
     */
   def loadAnnotations(optionsManager: ExecutionOptionsManager with HasFirrtlOptions): Unit = {
-    /*
-     If firrtlAnnotations in the firrtlOptions are nonEmpty then these will be the annotations
-     used by firrtl.
-     To use the file annotations make sure that the annotations in the firrtlOptions are empty
-     The annotation file if needed is found via
-     s"$targetDirName/$topName.anno" or s"$annotationFileNameOverride.anno"
-    */
+
     def firrtlConfig = optionsManager.firrtlOptions
 
-    if (firrtlConfig.annotations.isEmpty || firrtlConfig.forceAppendAnnoFile) {
-      val annotationFileName = firrtlConfig.getAnnotationFileName(optionsManager)
-      val annotationFile = new File(annotationFileName)
-      if (annotationFile.exists) {
-        val annotationsYaml = io.Source.fromFile(annotationFile).getLines().mkString("\n").parseYaml
-        val annotationArray = annotationsYaml.convertTo[Array[Annotation]]
-        optionsManager.firrtlOptions = firrtlConfig.copy(annotations = firrtlConfig.annotations ++ annotationArray)
-      }
+    val annotationFileName = firrtlConfig.getAnnotationFileName(optionsManager)
+    val annotationFile = new File(annotationFileName)
+    if (annotationFile.exists) {
+      val annotationsYaml = io.Source.fromFile(annotationFile).getLines().mkString("\n").parseYaml
+      val annotationArray = annotationsYaml.convertTo[Array[Annotation]]
+      optionsManager.firrtlOptions = firrtlConfig.copy(annotations = firrtlConfig.annotations ++ annotationArray)
     }
 
     if(firrtlConfig.annotations.nonEmpty) {

--- a/src/main/scala/firrtl/Driver.scala
+++ b/src/main/scala/firrtl/Driver.scala
@@ -66,6 +66,17 @@ object Driver {
     outputString
   }
 
+  /** Print a warning message
+    *
+    * @param message error message
+    */
+  //scalastyle:off regex
+  def dramaticWarning(message: String): Unit = {
+    println(Console.YELLOW + "-"*78)
+    println(s"Warning: $message")
+    println("-"*78 + Console.RESET)
+  }
+
   /**
     * print the message in red
     *

--- a/src/main/scala/firrtl/ExecutionOptionsManager.scala
+++ b/src/main/scala/firrtl/ExecutionOptionsManager.scala
@@ -179,7 +179,6 @@ case class FirrtlExecutionOptions(
     annotations:            List[Annotation] = List.empty,
     annotationFileNameOverride: String = "",
     outputAnnotationFileName: String = "",
-    forceAppendAnnoFile:    Boolean = false,
     emitOneFilePerModule:   Boolean = false,
     dontCheckCombLoops:     Boolean = false,
     noDCE:                  Boolean = false)
@@ -319,10 +318,11 @@ trait HasFirrtlOptions {
 
   parser.opt[Unit]("force-append-anno-file")
     .abbr("ffaaf")
+    .hidden()
     .foreach { _ =>
-      firrtlOptions = firrtlOptions.copy(forceAppendAnnoFile = true)
-    }.text {
-      "use this to force appending annotation file to annotations being passed in through optionsManager"
+      val msg = "force-append-anno-file is deprecated and will soon be removed\n" +
+                (" "*9) + "(It does not do anything anymore)"
+      Driver.dramaticWarning(msg)
     }
 
   parser.opt[String]("output-annotation-file")

--- a/src/main/scala/firrtl/ExecutionOptionsManager.scala
+++ b/src/main/scala/firrtl/ExecutionOptionsManager.scala
@@ -177,6 +177,7 @@ case class FirrtlExecutionOptions(
     firrtlSource:           Option[String] = None,
     customTransforms:       Seq[Transform] = List.empty,
     annotations:            List[Annotation] = List.empty,
+    annotationFileNames:    List[String] = List.empty,
     annotationFileNameOverride: String = "",
     outputAnnotationFileName: String = "",
     emitOneFilePerModule:   Boolean = false,
@@ -273,6 +274,7 @@ case class FirrtlExecutionOptions(
     * @param optionsManager this is needed to access build function and its common options
     * @return
     */
+  @deprecated("Use FirrtlOptions.annotationFileNames instead", "1.1")
   def getAnnotationFileName(optionsManager: ExecutionOptionsManager): String = {
     optionsManager.getBuildFileName("anno", annotationFileNameOverride)
   }
@@ -309,12 +311,12 @@ trait HasFirrtlOptions {
 
   parser.opt[String]("annotation-file")
     .abbr("faf")
-    .valueName ("<input-anno-file>")
+    .unbounded()
+    .valueName("<input-anno-file>")
     .foreach { x =>
-      firrtlOptions = firrtlOptions.copy(annotationFileNameOverride = x)
-    }.text {
-    "use this to override the default annotation file name, default is empty"
-  }
+      val annoFiles = x +: firrtlOptions.annotationFileNames
+      firrtlOptions = firrtlOptions.copy(annotationFileNames = annoFiles)
+    }.text("Used to specify annotation files (can appear multiple times)")
 
   parser.opt[Unit]("force-append-anno-file")
     .abbr("ffaaf")

--- a/src/test/scala/firrtlTests/DriverSpec.scala
+++ b/src/test/scala/firrtlTests/DriverSpec.scala
@@ -173,7 +173,7 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
     val annoFile = new File(targetDir, "annotations.anno")
 
     optionsManager.parse(
-      Array("--infer-rw", "circuit", "-faf", annoFile.toString, "-ffaaf")
+      Array("--infer-rw", "circuit", "-faf", annoFile.toString)
     ) should be (true)
 
     copyResourceToFile("/annotations/SampleAnnotations.anno", annoFile)


### PR DESCRIPTION
This is the first part of the annotations refactor

Summary of changes:
- Add Driver.dramaticWarning for warning about features that will be removed
- Remove force-append-anno-file option (making it default behavior to append annotations from anno file)
  - This was basically required when using annotation files because otherwise using any command-line option that created annotations would prevent the annotation file from being used
- Fix emission of annotation file to actually use YAML
- Change Driver.loadAnnotations to return annotations instead of mutating firrtlOptions
  - Should this be done differently? Perhaps deprecate old function and just write a new one? Is anyone else using this function?
- Support multiple annotation files passed via -faf
- Deprecate (via loud warning) implicit annotation file from sharing name with design
- Deprecate overriding annotation filename (which can't be done from commandline anymore)
- Always include BlackBoxTargetDirAnno
  - (unclear why this was only included if there was at least one other anno?)

TODO
 - [x] This currently warns if you have an annotation file with the topName even if you include it explicitly with faf, worse still it loads the file twice. Need to fix this before merging