### PR TITLE
Make submodule inputs void in ExpandWhens

### DIFF
--- a/src/test/scala/firrtlTests/CheckInitializationSpec.scala
+++ b/src/test/scala/firrtlTests/CheckInitializationSpec.scala
@@ -55,4 +55,20 @@ class CheckInitializationSpec extends FirrtlFlatSpec {
       }
     }
   }
+  "Missing assignment to submodule port" should "trigger a PassException" in {
+    val input =
+      """circuit Test :
+        |  module Child :
+        |    input in : UInt<32>
+        |  module Test :
+        |    input p : UInt<1>
+        |    inst c of Child
+        |    when p :
+        |      c.in <= UInt(1)""".stripMargin
+    intercept[CheckInitialization.RefNotInitializedException] {
+      passes.foldLeft(parse(input)) {
+        (c: Circuit, p: Pass) => p.run(c)
+      }
+    }
+  }
 }

--- a/src/test/scala/firrtlTests/DCETests.scala
+++ b/src/test/scala/firrtlTests/DCETests.scala
@@ -117,6 +117,7 @@ class DCETests extends FirrtlFlatSpec {
         |    output z : UInt<1>
         |    inst sub of Sub
         |    sub.x <= x
+        |    sub.y is invalid
         |    z <= sub.z""".stripMargin
     val check =
       """circuit Top :

--- a/src/test/scala/firrtlTests/ExpandWhensSpec.scala
+++ b/src/test/scala/firrtlTests/ExpandWhensSpec.scala
@@ -122,6 +122,22 @@ class ExpandWhensSpec extends FirrtlFlatSpec {
     val check = "w is invalid"
     executeTest(input, check, false)
   }
+  it should "correctly handle submodule inputs" in {
+    val input =
+      """circuit Test :
+        |  module Child :
+        |    input in : UInt<32>
+        |  module Test :
+        |    input in : UInt<32>[2]
+        |    input p : UInt<1>
+        |    inst c of Child
+        |    when p :
+        |      c.in <= in[0]
+        |    else :
+        |      c.in <= in[1]""".stripMargin
+    val check = "mux(p, in[0], in[1])"
+    executeTest(input, check, true)
+  }
 }
 
 class ExpandWhensExecutionTest extends ExecutionTest("ExpandWhens", "/passes/ExpandWhens")


### PR DESCRIPTION
Fixes #705 

The ports of submodules were not voided in ExpandWhens which means it does not error if they are not properly initialized. Worse still, since they don't have a default value in the netlist, the logic in ExpandWhens just picks the first connection and ignores all the rest.

I've added a test for each of the above cases.