### PR TITLE
Make ExpandWhens implicitly invalidate submodule inputs (in 1.0.x)

### DIFF
--- a/src/main/scala/firrtl/passes/ExpandWhens.scala
+++ b/src/main/scala/firrtl/passes/ExpandWhens.scala
@@ -103,11 +103,15 @@ object ExpandWhens extends Pass {
                       defaults: Defaults,
                       p: Expression)
                       (s: Statement): Statement = s match {
+        case stmt @ (_: DefNode | EmptyStmt) => stmt
         case w: DefWire =>
           netlist ++= (getFemaleRefs(w.name, w.tpe, BIGENDER) map (ref => we(ref) -> WVoid))
           w
         case w: DefMemory =>
           netlist ++= (getFemaleRefs(w.name, MemPortUtils.memType(w), MALE) map (ref => we(ref) -> WVoid))
+          w
+        case w: WDefInstance =>
+          netlist ++= (getFemaleRefs(w.name, w.tpe, MALE).map(ref => we(ref) -> WInvalid))
           w
         case r: DefRegister =>
           netlist ++= (getFemaleRefs(r.name, r.tpe, BIGENDER) map (ref => we(ref) -> ref))
@@ -173,7 +177,8 @@ object ExpandWhens extends Pass {
         case sx: Stop =>
           simlist += (if (weq(p, one)) sx else Stop(sx.info, sx.ret, sx.clk, AND(p, sx.en)))
           EmptyStmt
-        case sx => sx map expandWhens(netlist, defaults, p)
+        case block: Block => block map expandWhens(netlist, defaults, p)
+        case _ => throwInternalError
       }
       val netlist = new Netlist
       // Add ports to netlist

--- a/src/main/scala/firrtl/passes/ExpandWhens.scala
+++ b/src/main/scala/firrtl/passes/ExpandWhens.scala
@@ -31,6 +31,23 @@ object ExpandWhens extends Pass {
   // Defaults ideally would be immutable.Map but conversion from mutable.LinkedHashMap to mutable.Map is VERY slow
   type Defaults = Seq[mutable.Map[WrappedExpression, Expression]]
 
+  // Helper for 1.0.x to warn if submodule ports aren't properly invalidated
+  // See https://github.com/freechipsproject/firrtl/pull/712
+  private case object WAutoInvalid extends Expression {
+    def tpe = UnknownType
+    def serialize: String = "INVALID"
+    def mapExpr(f: Expression => Expression): Expression = this
+    def mapType(f: Type => Type): Expression = this
+    def mapWidth(f: Width => Width): Expression = this
+  }
+  private def warnAutoInvalid(expr: Expression)(m: Module, lvalue: WrappedExpression): Expression = expr match {
+    case WAutoInvalid =>
+      logger.error(s"Warning: [module ${m.name}] ${lvalue.e1.serialize} is not fully initialized. " +
+                    "This will be an error in the next major release")
+      WInvalid
+    case other => other
+  }
+
   // ========== Expand When Utilz ==========
   private def getFemaleRefs(n: String, t: Type, g: Gender): Seq[Expression] = {
     def getGender(t: Type, i: Int, g: Gender): Gender = times(g, get_flip(t, i, Default))
@@ -47,7 +64,7 @@ object ExpandWhens extends Pass {
   }
   private def expandNetlist(netlist: Netlist, attached: Set[WrappedExpression]) =
     netlist map {
-      case (k, WInvalid) => // Remove IsInvalids on attached Analog types
+      case (k, WInvalid | WAutoInvalid) => // Remove IsInvalids on attached Analog types
         if (attached.contains(k)) EmptyStmt else IsInvalid(NoInfo, k.e1)
       case (k, v) => Connect(NoInfo, k.e1, v)
     }
@@ -111,7 +128,7 @@ object ExpandWhens extends Pass {
           netlist ++= (getFemaleRefs(w.name, MemPortUtils.memType(w), MALE) map (ref => we(ref) -> WVoid))
           w
         case w: WDefInstance =>
-          netlist ++= (getFemaleRefs(w.name, w.tpe, MALE).map(ref => we(ref) -> WInvalid))
+          netlist ++= (getFemaleRefs(w.name, w.tpe, MALE).map(ref => we(ref) -> WAutoInvalid))
           w
         case r: DefRegister =>
           netlist ++= (getFemaleRefs(r.name, r.tpe, BIGENDER) map (ref => we(ref) -> ref))
@@ -141,8 +158,8 @@ object ExpandWhens extends Pass {
             }
             val res = default match {
               case Some(defaultValue) =>
-                val trueValue = conseqNetlist getOrElse (lvalue, defaultValue)
-                val falseValue = altNetlist getOrElse (lvalue, defaultValue)
+                val trueValue = warnAutoInvalid(conseqNetlist.getOrElse(lvalue, defaultValue))(m, lvalue)
+                val falseValue = warnAutoInvalid(altNetlist.getOrElse(lvalue, defaultValue))(m, lvalue)
                 (trueValue, falseValue) match {
                   case (WInvalid, WInvalid) => WInvalid
                   case (WInvalid, fv) => ValidIf(NOT(sx.pred), fv, fv.tpe)

--- a/src/test/scala/firrtlTests/CheckInitializationSpec.scala
+++ b/src/test/scala/firrtlTests/CheckInitializationSpec.scala
@@ -55,4 +55,23 @@ class CheckInitializationSpec extends FirrtlFlatSpec {
       }
     }
   }
+  // This is special for 1.0.x
+  // https://github.com/freechipsproject/firrtl/pull/706 fixed a serious bug and started enforcing
+  // initialization checks on submodule ports. This is API-change-esque because code that used to
+  // compile no longer does. Instead for 1.0.x, Firrtl will just implicitly mark all submodule
+  // inputs as invalid so code still compiles.
+  "Missing assignment to submodule port" should "NOT trigger a PassException in 1.0.x" in {
+    val input =
+      """circuit Test :
+        |  module Child :
+        |    input in : UInt<32>
+        |  module Test :
+        |    input p : UInt<1>
+        |    inst c of Child
+        |    when p :
+        |      c.in <= UInt(1)""".stripMargin
+    passes.foldLeft(parse(input)) {
+      (c: Circuit, p: Pass) => p.run(c)
+    }
+  }
 }

--- a/src/test/scala/firrtlTests/DCETests.scala
+++ b/src/test/scala/firrtlTests/DCETests.scala
@@ -118,6 +118,7 @@ class DCETests extends FirrtlFlatSpec {
         |    output z : UInt<1>
         |    inst sub of Sub
         |    sub.x <= x
+        |    sub.y is invalid
         |    z <= sub.z""".stripMargin
     val check =
       """circuit Top :

--- a/src/test/scala/firrtlTests/ExpandWhensSpec.scala
+++ b/src/test/scala/firrtlTests/ExpandWhensSpec.scala
@@ -122,6 +122,22 @@ class ExpandWhensSpec extends FirrtlFlatSpec {
     val check = "w is invalid"
     executeTest(input, check, false)
   }
+  it should "correctly handle submodule inputs" in {
+    val input =
+      """circuit Test :
+        |  module Child :
+        |    input in : UInt<32>
+        |  module Test :
+        |    input in : UInt<32>[2]
+        |    input p : UInt<1>
+        |    inst c of Child
+        |    when p :
+        |      c.in <= in[0]
+        |    else :
+        |      c.in <= in[1]""".stripMargin
+    val check = "mux(p, in[0], in[1])"
+    executeTest(input, check, true)
+  }
 }
 
 class ExpandWhensExecutionTest extends ExecutionTest("ExpandWhens", "/passes/ExpandWhens")

--- a/src/test/scala/firrtlTests/FlattenTests.scala
+++ b/src/test/scala/firrtlTests/FlattenTests.scala
@@ -86,9 +86,9 @@ class FlattenTests extends LowTransformSpec {
           |    i2$b <= i2$a
           |    wire tmp : UInt<32>
           |    b <= i2$b
-          |    tmp <= i1$b
           |    i1$a <= a
           |    i2$a <= tmp
+          |    tmp <= i1$b
           |  module Inline1 :
           |    input a : UInt<32>
           |    output b : UInt<32>


### PR DESCRIPTION
This is a modified form of
https://github.com/freechipsproject/firrtl/pull/706 to preserve the
bugfix but preserve the [buggy] 1.0.x API that firrtl was not properly
enforcing initialization requirements for submodule inputs

The problem with #706 is that because Firrtl wasn't properly enforcing initialization requirements on submodules, code that used to work no longer does. This alternative version still fixes the incorrect Verilog generation bug but does not enforce the initialization requirement.