### PR TITLE
Fix FirrtlExecutionOptions backward incompatible change (#704).

### DIFF
--- a/src/main/scala/firrtl/ExecutionOptionsManager.scala
+++ b/src/main/scala/firrtl/ExecutionOptionsManager.scala
@@ -177,13 +177,13 @@ case class FirrtlExecutionOptions(
     firrtlSource:           Option[String] = None,
     customTransforms:       Seq[Transform] = List.empty,
     annotations:            List[Annotation] = List.empty,
-    annotationFileNames:    List[String] = List.empty,
     annotationFileNameOverride: String = "",
     outputAnnotationFileName: String = "",
     emitOneFilePerModule:   Boolean = false,
     dontCheckCombLoops:     Boolean = false,
-    noDCE:                  Boolean = false)
-  extends ComposableOptions {
+    noDCE:                  Boolean = false,
+    annotationFileNames:    List[String] = List.empty)
+extends ComposableOptions {
 
   require(!(emitOneFilePerModule && outputFileNameOverride.nonEmpty),
     "Cannot both specify the output filename and emit one file per module!!!")

--- a/src/main/scala/firrtl/ExecutionOptionsManager.scala
+++ b/src/main/scala/firrtl/ExecutionOptionsManager.scala
@@ -13,7 +13,9 @@ import scala.collection.Seq
 
 /**
   * Use this trait to define an options class that can add its private command line options to a externally
-  * declared parser
+  * declared parser.
+  * '''NOTE''' In all derived trait/classes, if you intend on maintaining backwards compatibility,
+  *  be sure to add new options at the end of the current ones and don't remove any existing ones.
   */
 trait ComposableOptions
 


### PR DESCRIPTION
New options should be added to the end of the list to reduce backward compatibility problems. The compiler generates copy methods for this case class and the version prior to cbe90114f7693d40aaf76151f7b132c09aa32859 produces the following generated method:
```scala
    <synthetic> def copy$default$9(): String = FirrtlExecutionOptions.this.annotationFileNameOverride();
```
cbe90114f7693d40aaf76151f7b132c09aa32859 contains this change:
```scala
      firrtlSource:           Option[String] = None,
      customTransforms:       Seq[Transform] = List.empty,
      annotations:            List[Annotation] = List.empty,
 +    annotationFileNames:    List[String] = List.empty,
      annotationFileNameOverride: String = "",
      outputAnnotationFileName: String = "",
      emitOneFilePerModule:   Boolean = false,
```
which bumps the compiler generated copy methods:
```scala
    <synthetic> def copy$default$9(): List = FirrtlExecutionOptions.this.annotationFileNames();
    <synthetic> def copy$default$10(): String = FirrtlExecutionOptions.this.annotationFileNameOverride();
    <synthetic> def copy$default$11(): String = FirrtlExecutionOptions.this.outputAnnotationFileName();
    <synthetic> def copy$default$12(): Boolean = FirrtlExecutionOptions.this.emitOneFilePerModule();
    <synthetic> def copy$default$13(): Boolean = FirrtlExecutionOptions.this.dontCheckCombLoops();
    <synthetic> def copy$default$14(): Boolean = FirrtlExecutionOptions.this.noDCE();
```
so old client code gets a runtime error when linked with the new firrtl jar at runtime:
```bash
[error] (run-main) java.lang.NoSuchMethodError: firrtl.FirrtlExecutionOptions.copy$default$9()Ljava/lang/String;
java.lang.NoSuchMethodError: firrtl.FirrtlExecutionOptions.copy$default$9()Ljava/lang/String;
	at chisel3.Driver$.execute(Driver.scala:174)
	at chisel3.Driver$.execute(Driver.scala:200)
 ...
```
The scary thing is this can silently (but drastically) fail if the member's type stays the same, but its order (and hence semantics) change.

Imagine the following evolution:
```scala
case class TesterOptions(directoryWhichMustBePreserved: string) {
 ...
}
```
at some point is modified to:
```scala
case class TesterOptions(directoryToDeleteBeforeTesting: string, directoryWhichMustBePreserved: string) {
 ...
}
```
Now, there won't be any compile or runtime error, but old code calling the new implementation will produce surprising results.