### PR TITLE
Remove erroneous undef of RANDOMIZE in emitted Verilog

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -707,7 +707,6 @@ class VerilogEmitter extends SeqTransform with Emitter {
           for (x <- initials) emit(Seq(tab, x))
           emit(Seq("  end"))
           emit(Seq("`endif // RANDOMIZE"))
-          emit(Seq("`undef RANDOMIZE"))
         }
 
         for (clk_stream <- at_clock if clk_stream._2.nonEmpty) {


### PR DESCRIPTION
I think the undefing RANDOMIZE means that it is undefined for the rest of compilation (ie. for every other module). This introduces X's where they shouldn't be.