### PR TITLE
Add firrtl-mode to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ sbt assembly
 
 #### Other Tools
 * Firrtl syntax highlighting for Vim users: https://github.com/azidar/firrtl-syntax
+* Firrtl mode for Emacs users: https://github.com/ibm/firrtl-mode
 * Chisel3, an embedded hardware DSL that generates Firrtl: https://github.com/ucb-bar/chisel3
 * Firrtl Interpreter: https://github.com/ucb-bar/firrtl-interpreter
 * Yosys Verilog-to-Firrtl Front-end: https://github.com/cliffordwolf/yosys


### PR DESCRIPTION
Add a pointer to [`firrtl-mode`](https://github.com/ibm/firrtl-mode) to the README (I've used this for a while, but only went through open source hoops recently). The linked package currently supports syntax highlighting and indentation, but it's been enough for me to not lose my mind looking at FIRRTL files directly.

It's not in MELPA yet, but I have an outstanding PR to add it.