### PR TITLE
Fix Bugs in Constant Propagation

### DIFF
--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -367,7 +367,7 @@ class ConstantPropagation extends Transform {
         // Const prop registers that are fed only a constant or a mux between and constant and the
         // register itself
         // This requires that reset has been made explicit
-        case Connect(_, lref @ WRef(lname, ltpe, RegKind, _), expr) => expr match {
+        case Connect(_, lref @ WRef(lname, ltpe, RegKind, _), expr) if !dontTouches.contains(lname) => expr match {
           case lit: Literal =>
             nodeMap(lname) = constPropExpression(pad(lit, ltpe))
           case Mux(_, tval: WRef, fval: Literal, _) if weq(lref, tval) =>

--- a/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+++ b/src/test/scala/firrtlTests/ConstantPropagationTests.scala
@@ -67,9 +67,9 @@ s"""circuit Top :
     out <= in
   module Child :
     output out : UInt<1>
-    inst b of Bottom
-    b.in <= UInt(1)
-    out <= b.out
+    inst b0 of Bottom
+    b0.in <= UInt(1)
+    out <= b0.out
   module Top :
     input x : UInt<1>
     output z : UInt<1>
@@ -91,8 +91,8 @@ s"""circuit Top :
     out <= UInt(1)
   module Child :
     output out : UInt<1>
-    inst b of Bottom
-    b.in <= UInt(1)
+    inst b0 of Bottom
+    b0.in <= UInt(1)
     out <= UInt(1)
   module Top :
     input x : UInt<1>

--- a/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+++ b/src/test/scala/firrtlTests/ConstantPropagationTests.scala
@@ -712,6 +712,21 @@ class ConstantPropagationIntegrationSpec extends LowTransformSpec {
     execute(input, check, Seq(dontTouch("Top.z")))
   }
 
+  "ConstProp" should "NOT optimize across dontTouch on registers" in {
+      val input =
+        """circuit Top :
+          |  module Top :
+          |    input clk : Clock
+          |    input reset : UInt<1>
+          |    output y : UInt<1>
+          |    reg z : UInt<1>, clk
+          |    y <= z
+          |    z <= mux(reset, UInt<1>("h0"), z)""".stripMargin
+      val check = input
+    execute(input, check, Seq(dontTouch("Top.z")))
+  }
+
+
   it should "NOT optimize across dontTouch on wires" in {
       val input =
         """circuit Top :


### PR DESCRIPTION
In particular: 
Two instances of the same module could collide in counting the number of
instances of each Module. This could lead to constants being propagated
on inputs when it is incorrect to do so.

h/t @donggyukim for not only figuring out there was a problem, but providing a reduced test case

I also fixed another bug I came across although it is minor