### PR TITLE
Bug fix for single module Wiring Transform

### DIFF
--- a/src/main/scala/firrtl/graph/EulerTour.scala
+++ b/src/main/scala/firrtl/graph/EulerTour.scala
@@ -59,7 +59,7 @@ class EulerTour[T](r: Map[T, Int], e: Seq[T], h: Seq[Int]) {
   // n: the length of the Euler Tour
   // m: the size of blocks the Euler Tour is split into
   private val n = h.size
-  private val m = math.ceil(lg(n) / 2).toInt
+  private val m = math.max(1, math.ceil(lg(n) / 2).toInt)
 
   /** Split up the tour into blocks of size m, padding the last block to
     * be a multiple of m. Compute the minimum of each block, a, and

--- a/src/test/scala/firrtlTests/WiringTests.scala
+++ b/src/test/scala/firrtlTests/WiringTests.scala
@@ -395,16 +395,12 @@ class WiringTests extends FirrtlFlatSpec {
   }
 
   it should "wire with source and sink in the same module" in {
-    val sinks = Seq(ComponentName("s", ModuleName("A", CircuitName("Top"))))
-    val source = ComponentName("r", ModuleName("A", CircuitName("Top")))
+    val sinks = Seq(ComponentName("s", ModuleName("Top", CircuitName("Top"))))
+    val source = ComponentName("r", ModuleName("Top", CircuitName("Top")))
     val sas = WiringInfo(source, sinks, "pin")
     val input =
       """|circuit Top :
          |  module Top :
-         |    input clock: Clock
-         |    inst a of A
-         |    a.clock <= clock
-         |  module A :
          |    input clock: Clock
          |    wire s: UInt<5>
          |    reg r: UInt<5>, clock
@@ -412,10 +408,6 @@ class WiringTests extends FirrtlFlatSpec {
     val check =
       """|circuit Top :
          |  module Top :
-         |    input clock: Clock
-         |    inst a of A
-         |    a.clock <= clock
-         |  module A :
          |    input clock: Clock
          |    wire pin: UInt<5>
          |    wire s: UInt<5>


### PR DESCRIPTION
A circuit with a single module will not properly wire due to how `m` (the number of blocks an Euler Tour is broken up into) is calculated. A single module circuit will cause `m` to be set to zero and then happily throw divide by zero errors during RMQs.

This changes that to make it `max(1, XXX)` and changes one of the tests to hit this.