### PR TITLE
Add high form check that MSB >= LSB

### DIFF
--- a/src/test/scala/firrtlTests/CheckSpec.scala
+++ b/src/test/scala/firrtlTests/CheckSpec.scala
@@ -157,27 +157,27 @@ class CheckSpec extends FlatSpec with Matchers {
       CheckWidths)
     val input =
       """
-          |circuit TheRealTop : 
-          |    
-          |  module Top : 
+          |circuit TheRealTop :
+          |
+          |  module Top :
           |    output io : {flip debug_clk : Clock}
-          |        
-          |  extmodule BlackBoxTop : 
+          |
+          |  extmodule BlackBoxTop :
           |    input jtag : {TCK : Clock}
-          | 
-          |  module TheRealTop : 
+          |
+          |  module TheRealTop :
           |    input clock : Clock
           |    input reset : UInt<1>
           |    output io : {flip jtag : {TCK : Clock}}
-          |    
+          |
           |    io is invalid
           |    inst sub of Top
           |    sub.io is invalid
           |    inst bb of BlackBoxTop
           |    bb.jtag is invalid
-          |    bb.jtag <- io.jtag 
-          | 
-          |    sub.io.debug_clk <= io.jtag.TCK 
+          |    bb.jtag <- io.jtag
+          |
+          |    sub.io.debug_clk <= io.jtag.TCK
           |
           |""".stripMargin
     passes.foldLeft(Parser.parse(input.split("\n").toIterator)) {
@@ -194,8 +194,8 @@ class CheckSpec extends FlatSpec with Matchers {
       CheckTypes)
     val input =
       """
-          |circuit Top : 
-          |    
+          |circuit Top :
+          |
           |  module Top :
           |    input clk : UInt<1>
           |    input i : UInt<1>
@@ -222,8 +222,8 @@ class CheckSpec extends FlatSpec with Matchers {
       CheckTypes)
     val input =
       """
-          |circuit Top : 
-          |    
+          |circuit Top :
+          |
           |  module Top :
           |    input clk : Clock
           |    input reset : UInt<2>
@@ -261,6 +261,25 @@ class CheckSpec extends FlatSpec with Matchers {
         }
       }
       exception.getMessage should include (s"Primop $op argument $amount < 0")
+    }
+  }
+
+  "LSB larger than MSB in bits" should "throw an exception" in {
+    val input =
+      """|circuit bar :
+         |  module bar :
+         |    input in : UInt<8>
+         |    output foo : UInt
+         |    foo <= bits(in, 3, 4)
+         |      """.stripMargin
+    val passes = Seq(
+      ToWorkingIR,
+      CheckHighForm
+    )
+    val exception = intercept[PassException] {
+      passes.foldLeft(Parser.parse(input.split("\n").toIterator)) {
+        (c: Circuit, p: Pass) => p.run(c)
+      }
     }
   }
 }


### PR DESCRIPTION
Adds a high form check for #700 (some low hanging fruit that I didn't see anybody working on for 1.1.0).

I'm assuming that `CheckHighForm` is the right place to be doing this. Alternatively, the check can be moved to `CheckWidths`. I'm unclear on what makes the most sense here...