### PR TITLE
Rename loadAnnotations -> getAnnotations

### DIFF
--- a/src/main/scala/firrtl/Driver.scala
+++ b/src/main/scala/firrtl/Driver.scala
@@ -102,13 +102,26 @@ object Driver {
     println("-"*78 + Console.RESET)
   }
 
-  /** Load annotations from specified files and options
+  /** Load annotation file based on options
+    * @param optionsManager use optionsManager config to load annotation file if it exists
+    *                       update the firrtlOptions with new annotations if it does
+    */
+  @deprecated("Use side-effect free getAnnotation instead", "1.1")
+  def loadAnnotations(optionsManager: ExecutionOptionsManager with HasFirrtlOptions): Unit = {
+    val msg = "Driver.loadAnnotations is deprecated, use Driver.getAnnotations instead"
+    Driver.dramaticWarning(msg)
+    optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(
+      annotations = Driver.getAnnotations(optionsManager).toList
+    )
+  }
+
+  /** Get annotations from specified files and options
     *
     * @param optionsManager use optionsManager config to load annotation files
     * @return Annotations read from files
     */
   //scalastyle:off cyclomatic.complexity method.length
-  def loadAnnotations(
+  def getAnnotations(
       optionsManager: ExecutionOptionsManager with HasFirrtlOptions
   ): Seq[Annotation] = {
     val firrtlConfig = optionsManager.firrtlOptions
@@ -208,7 +221,7 @@ object Driver {
 
       // Wrap compilation in a try/catch to present Scala MatchErrors in a more user-friendly format.
       try {
-        val annos = loadAnnotations(optionsManager)
+        val annos = getAnnotations(optionsManager)
 
         val parsedInput = Parser.parse(firrtlSource, firrtlConfig.infoMode)
 

--- a/src/test/scala/firrtlTests/DriverSpec.scala
+++ b/src/test/scala/firrtlTests/DriverSpec.scala
@@ -159,7 +159,7 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
     val annoFile =  new File(optionsManager.commonOptions.targetDirName, top + ".anno")
     copyResourceToFile("/annotations/SampleAnnotations.anno", annoFile)
     optionsManager.firrtlOptions.annotations.length should be (0)
-    val annos = Driver.loadAnnotations(optionsManager)
+    val annos = Driver.getAnnotations(optionsManager)
     annos.length should be (12) // 9 from circuit plus 3 general purpose
     annos.count(_.transformClass == "firrtl.passes.InlineInstances") should be (9)
     annoFile.delete()
@@ -176,7 +176,7 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
     val annotationsTestFile =  new File(optionsManager.commonOptions.targetDirName, optionsManager.firrtlOptions.annotationFileNameOverride + ".anno")
     copyResourceToFile("/annotations/SampleAnnotations.anno", annotationsTestFile)
     optionsManager.firrtlOptions.annotations.length should be (0)
-    val annos = Driver.loadAnnotations(optionsManager)
+    val annos = Driver.getAnnotations(optionsManager)
     annos.length should be (12) // 9 from circuit plus 3 general purpose
     annos.count(_.transformClass == "firrtl.passes.InlineInstances") should be (9)
     annotationsTestFile.delete()
@@ -193,7 +193,7 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
     val annotationsTestFile = new File(optionsManager.commonOptions.targetDirName, filename)
     copyResourceToFile(s"/annotations/$filename", annotationsTestFile)
     optionsManager.firrtlOptions.annotations.length should be (0)
-    val annos = Driver.loadAnnotations(optionsManager)
+    val annos = Driver.getAnnotations(optionsManager)
     annos.length should be (21) // 18 from files plus 3 general purpose
     annos.count(_.transformClass == "firrtl.passes.InlineInstances") should be (18)
     annotationsTestFile.delete()
@@ -213,8 +213,8 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
     val firrtlOptions = optionsManager.firrtlOptions
     firrtlOptions.annotations.length should be (1) // infer-rw
 
-    val anns = Driver.loadAnnotations(optionsManager).groupBy(_.transform)
-    anns(classOf[BlackBoxSourceHelper]).length should be (1) // built in to loadAnnotations
+    val anns = Driver.getAnnotations(optionsManager).groupBy(_.transform)
+    anns(classOf[BlackBoxSourceHelper]).length should be (1) // built-in to getAnnotations
     anns(classOf[InferReadWrite]).length should be (1) // --infer-rw
     anns(classOf[InlineInstances]).length should be (9) // annotations file
 


### PR DESCRIPTION
This makes the API change explicit. Also reintroduce loadAnnotations as
a deprecated function.

Fixes https://github.com/freechipsproject/firrtl/issues/731