### PR TITLE
Add log-level debug message for modules that get deduped

### DIFF
--- a/src/main/scala/firrtl/transforms/Dedup.scala
+++ b/src/main/scala/firrtl/transforms/Dedup.scala
@@ -142,6 +142,7 @@ class DedupModules extends Transform {
 
     val cname = CircuitName(c.main)
     val renameMap = RenameMap(dedupMap.map { case (from, to) =>
+      logger.debug(s"[Dedup] $from -> $to")
       ModuleName(from, cname) -> List(ModuleName(to, cname))
     })
 


### PR DESCRIPTION
h/t @colinschmidt for the idea

Pretty straightforward, makes it possible to easily see what modules get deduplicated.

You can use this by setting the log-level to debug `-ll debug` or if you just want debug info for dedup, you can use `-cll firrtl.transforms.DedupModules:Debug`