### PR TITLE
Reduce Statement nesting in Wiring Pass

### DIFF
--- a/src/main/scala/firrtl/passes/wiring/Wiring.scala
+++ b/src/main/scala/firrtl/passes/wiring/Wiring.scala
@@ -194,8 +194,12 @@ class Wiring(wiSeq: Seq[WiringInfo]) extends Pass {
           Connect(NoInfo, toExp(l), toExp(r))
         })
         m match {
-          case Module(i, n, ps, s) => Module(i, n, ps ++ ports,
-            Block(defines ++ Seq(s) ++ connects))
+          case Module(i, n, ps, body) =>
+            val stmts = body match {
+              case Block(sx) => sx
+              case s => Seq(s)
+            }
+            Module(i, n, ps ++ ports, Block(defines ++ stmts ++ connects))
           case ExtModule(i, n, ps, dn, p) => ExtModule(i, n, ps ++ ports, dn, p)
         }
     }


### PR DESCRIPTION
Large amounts of Wiring could result in huge nesting of Statements. This could
cause stack overflows using the Mappers. Fixed by no longer nesting Statements
in Wiring Pass.