### PR TITLE
Pass up annotations in return value from Driver.execute

### DIFF
--- a/src/main/scala/firrtl/Driver.scala
+++ b/src/main/scala/firrtl/Driver.scala
@@ -248,7 +248,7 @@ object Driver {
           outputFile.close()
       }
 
-      FirrtlExecutionSuccess(firrtlConfig.compilerName, emittedRes)
+      FirrtlExecutionSuccess(firrtlConfig.compilerName, emittedRes, finalState)
     }
   }
 

--- a/src/main/scala/firrtl/ExecutionOptionsManager.scala
+++ b/src/main/scala/firrtl/ExecutionOptionsManager.scala
@@ -473,6 +473,18 @@ trait HasFirrtlOptions {
 
 sealed trait FirrtlExecutionResult
 
+object FirrtlExecutionSuccess {
+  def apply(
+    emitType    : String,
+    emitted     : String,
+    circuitState: CircuitState
+  ): FirrtlExecutionSuccess = new FirrtlExecutionSuccess(emitType, emitted, circuitState)
+
+
+  def unapply(arg: FirrtlExecutionSuccess): Option[(String, String)] = {
+    Some((arg.emitType, arg.emitted))
+  }
+}
 /**
   * Indicates a successful execution of the firrtl compiler, returning the compiled result and
   * the type of compile
@@ -480,7 +492,11 @@ sealed trait FirrtlExecutionResult
   * @param emitType  The name of the compiler used, currently "high", "middle", "low", "verilog", or "sverilog"
   * @param emitted   The emitted result of compilation
   */
-case class FirrtlExecutionSuccess(emitType: String, emitted: String) extends FirrtlExecutionResult
+class FirrtlExecutionSuccess(
+  val emitType: String,
+  val emitted : String,
+  val circuitState: CircuitState
+) extends FirrtlExecutionResult
 
 /**
   * The firrtl compilation failed.

--- a/src/test/scala/firrtlTests/DriverSpec.scala
+++ b/src/test/scala/firrtlTests/DriverSpec.scala
@@ -355,7 +355,12 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
                                                  emitOneFilePerModule = true)
         }
 
-        firrtl.Driver.execute(manager)
+        firrtl.Driver.execute(manager) match {
+          case success: FirrtlExecutionSuccess =>
+            success.circuitState.annotations.length should be > (0)
+          case _ =>
+
+        }
 
         for (name <- expectedOutputFileNames) {
           val file = new File(name)


### PR DESCRIPTION
Backward compatible with existing usage.
Adds CircuitState to FirrtlExecutionSuccess, but
that member is not part of the unapply.
"To a single file per module if OneFilePerModule is specified"
test shows example of getting access to annotations