### PR TITLE
Masks for zero-width fields of mems should be width zero.

### DIFF
--- a/src/main/scala/firrtl/passes/memlib/MemUtils.scala
+++ b/src/main/scala/firrtl/passes/memlib/MemUtils.scala
@@ -46,6 +46,7 @@ object createMask {
   def apply(dt: Type): Type = dt match {
     case t: VectorType => VectorType(apply(t.tpe), t.size)
     case t: BundleType => BundleType(t.fields map (f => f copy (tpe=apply(f.tpe))))
+    case GroundType(w) if w == IntWidth(0) => UIntType(IntWidth(0))
     case t: GroundType => BoolType
   }
 }

--- a/src/test/resources/features/ZeroWidthMem.fir
+++ b/src/test/resources/features/ZeroWidthMem.fir
@@ -1,0 +1,28 @@
+; See LICENSE for license details.
+circuit ZeroWidthMem :
+  module ZeroWidthMem :
+    input clock : Clock
+    input reset : UInt<1>
+    input waddr : UInt<4>
+    input in   : {0: UInt<10>, 1: UInt<0>}
+    input raddr : UInt<4>
+    output out : {0: UInt<10>, 1: UInt<0>}
+
+    cmem ram : {0: UInt<10>, 1: UInt<0>}[16]
+    infer mport ramin = ram[waddr], clock
+    infer mport ramout = ram[raddr], clock
+
+    ramin.0 <= in.0
+    ramin.1 <= in.1
+    out <= ramout
+
+    wire foo : UInt<32>
+    foo <= UInt<32>("hdeadbeef")
+
+    when not(reset) :
+      when eq(foo, UInt<32>("hdeadbeef")) :
+        stop(clock, UInt(1), 0) ; Success !
+      else :
+        printf(clock, UInt(1), "Assertion failed!\n")
+        stop(clock, UInt(1), 1) ; Failure!
+

--- a/src/test/scala/firrtlTests/MemSpec.scala
+++ b/src/test/scala/firrtlTests/MemSpec.scala
@@ -7,5 +7,9 @@ class MemSpec extends FirrtlPropSpec {
   property("Zero-ported mems should be supported!") {
     runFirrtlTest("ZeroPortMem", "/features")
   }
+
+  property("Mems with zero-width elements should be supported!") {
+    runFirrtlTest("ZeroWidthMem", "/features")
+  }
 }
 


### PR DESCRIPTION
Closes #666.