### PR TITLE
Force RemoveWires to retain clock and analog wires

### DIFF
--- a/src/test/scala/firrtlTests/RemoveWiresSpec.scala
+++ b/src/test/scala/firrtlTests/RemoveWiresSpec.scala
@@ -120,4 +120,19 @@ class RemoveWiresSpec extends FirrtlFlatSpec {
           "node y = not(b)")
     )
   }
+
+  it should "not break clock wires in emitted Low FIRRTL" in {
+    // Compiling the output of compilation lets us check its legality
+    val compiledOnce = compileBody(s"""
+      |input ext_clock : Clock
+      |input in : UInt<1>
+      |output out : UInt<1>
+      |wire int_clock : Clock
+      |reg r : UInt<1>, int_clock
+      |int_clock <= ext_clock
+      |r <= in
+      |out <= r""".stripMargin
+    )
+    val compiledTwice = compile(compiledOnce.emittedCircuitOption.get.value)
+  }
 }


### PR DESCRIPTION
This fixes #749 and #767 (#767 has a minimal non-working example that breaks on master).

The change is the simplest possible fix of filtering all clock wires in addition to all analog wires. It would be possible to be more selective, but this would slow compile time with an extra pre-processing scan and provide marginal benefit in emitted verilog.

One interesting thing to note is that the original bug in `RemoveWires` would also theoretically affect reset wires, but the pass is run after `RemoveReset`. As a result, this pass ordering is required for correctness. I can add more code to handle the reset case if this ordering constraint is undesirable.