### PR TITLE
Add SyntaxErrorsException as a type of ParserException

### DIFF
--- a/src/main/scala/firrtl/Parser.scala
+++ b/src/main/scala/firrtl/Parser.scala
@@ -11,15 +11,13 @@ import firrtl.ir._
 import firrtl.Utils.time
 import firrtl.antlr.{FIRRTLParser, _}
 
-class ParserException(message: String) extends Exception(message)
+class ParserException(message: String) extends FIRRTLException(message)
 
 case class ParameterNotSpecifiedException(message: String) extends ParserException(message)
-
 case class ParameterRedefinedException(message: String) extends ParserException(message)
-
 case class InvalidStringLitException(message: String) extends ParserException(message)
-
 case class InvalidEscapeCharException(message: String) extends ParserException(message)
+case class SyntaxErrorsException(message: String) extends ParserException(message)
 
 
 object Parser extends LazyLogging {
@@ -42,7 +40,7 @@ object Parser extends LazyLogging {
       val cst = parser.circuit
 
       val numSyntaxErrors = parser.getNumberOfSyntaxErrors
-      if (numSyntaxErrors > 0) throw new ParserException(s"$numSyntaxErrors syntax error(s) detected")
+      if (numSyntaxErrors > 0) throw new SyntaxErrorsException(s"$numSyntaxErrors syntax error(s) detected")
       cst
     }
 

--- a/src/test/scala/firrtlTests/ParserSpec.scala
+++ b/src/test/scala/firrtlTests/ParserSpec.scala
@@ -157,6 +157,20 @@ class ParserSpec extends FirrtlFlatSpec {
     val c = firrtl.Parser.parse(input)
     firrtl.Parser.parse(c.serialize)
   }
+
+  "Parsing errors" should "be reported as normal exceptions" in {
+    val input = s"""
+      |circuit Test
+      |  module Test :
+
+      |""".stripMargin
+    val manager = new ExecutionOptionsManager("test") with HasFirrtlOptions {
+      firrtlOptions = FirrtlExecutionOptions(firrtlSource = Some(input))
+    }
+    a [SyntaxErrorsException] shouldBe thrownBy {
+      Driver.execute(manager)
+    }
+  }
 }
 
 class ParserPropSpec extends FirrtlPropSpec {


### PR DESCRIPTION
Also make ParserException extend FIRRTLException to better report parsing
errors to the user

Minor change but ever since https://github.com/freechipsproject/firrtl/pull/424 if we throw Exceptions that don't extend FIRRTLException we get an internal error in cases when it should be reporting the actual issue to the user. This fixes that for Parser exceptions (and adds a new concrete subclass for more specificity).