### PR TITLE
Make WiringTransform remove its used annotations

### DIFF
--- a/src/main/scala/firrtl/passes/wiring/WiringTransform.scala
+++ b/src/main/scala/firrtl/passes/wiring/WiringTransform.scala
@@ -69,7 +69,7 @@ class WiringTransform extends Transform {
             val wis = sources.foldLeft(Seq[WiringInfo]()) { case (seq, (pin, source)) =>
               seq :+ WiringInfo(source, sinks(pin), pin)
             }
-            val annosx = AnnotationSeq((state.annotations.toSeq.toSet -- annos).toSeq)
+            val annosx = state.annotations.filterNot(annos.toSet.contains)
             transforms(wis)
               .foldLeft(state) { (in, xform) => xform.runTransform(in) }
               .copy(annotations = annosx)

--- a/src/main/scala/firrtl/passes/wiring/WiringTransform.scala
+++ b/src/main/scala/firrtl/passes/wiring/WiringTransform.scala
@@ -69,7 +69,10 @@ class WiringTransform extends Transform {
             val wis = sources.foldLeft(Seq[WiringInfo]()) { case (seq, (pin, source)) =>
               seq :+ WiringInfo(source, sinks(pin), pin)
             }
-            transforms(wis).foldLeft(state) { (in, xform) => xform.runTransform(in) }
+            val annosx = AnnotationSeq((state.annotations.toSeq.toSet -- annos).toSeq)
+            transforms(wis)
+              .foldLeft(state) { (in, xform) => xform.runTransform(in) }
+              .copy(annotations = annosx)
           case _ => error("Wrong number of sources or sinks!")
         }
     }


### PR DESCRIPTION
This modifies the WiringTransform to actually delete its annotations (if they wind up being used). Without this, the WiringTransform could be run multiple times with the same annotations (e.g., if some other Transform runs the WiringTransform directly).