### PR TITLE
CyclicException identifies a problem node.

### DIFF
--- a/src/main/scala/firrtl/graph/DiGraph.scala
+++ b/src/main/scala/firrtl/graph/DiGraph.scala
@@ -7,7 +7,7 @@ import scala.collection.mutable
 import scala.collection.mutable.{LinkedHashSet, LinkedHashMap}
 
 /** An exception that is raised when an assumed DAG has a cycle */
-class CyclicException extends Exception("No valid linearization for cyclic graph")
+class CyclicException(val node: Any) extends Exception(s"No valid linearization for cyclic graph, found at $node")
 
 /** An exception that is raised when attempting to find an unreachable node */
 class PathNotFoundException extends Exception("Unreachable node")
@@ -79,7 +79,7 @@ class DiGraph[T] private[graph] (private[graph] val edges: LinkedHashMap[T, Link
 
     def visit(n: T): Unit = {
       if (tempMarked.contains(n)) {
-        throw new CyclicException
+        throw new CyclicException(n)
       }
       if (unmarked.contains(n)) {
         tempMarked += n

--- a/src/main/scala/firrtl/transforms/RemoveWires.scala
+++ b/src/main/scala/firrtl/transforms/RemoveWires.scala
@@ -111,9 +111,10 @@ class RemoveWires extends Transform {
           case Success(logic) =>
             Module(info, name, ports, Block(decls ++ logic ++ otherStmts))
           // If we hit a CyclicException, just abort removing wires
-          case Failure(_: CyclicException) =>
+          case Failure(c: CyclicException) =>
+            val problematicNode = c.node
             logger.warn(s"Cycle found in module $name, " +
-              "wires will not be removed which can prevent optimizations!")
+              s"wires will not be removed which can prevent optimizations! Problem node: $problematicNode")
             mod
           case Failure(other) => throw other
         }

--- a/src/test/scala/firrtlTests/graph/DiGraphTests.scala
+++ b/src/test/scala/firrtlTests/graph/DiGraphTests.scala
@@ -1,3 +1,5 @@
+// See LICENSE for license details.
+
 package firrtlTests.graph
 
 import java.io._
@@ -49,6 +51,16 @@ class DiGraphTests extends FirrtlFlatSpec {
   acyclicGraph.linearize.head should equal ("a")
 
   a [CyclicException] should be thrownBy cyclicGraph.linearize
+
+  try {
+    cyclicGraph.linearize
+  }
+  catch {
+    case c: CyclicException =>
+      c.getMessage.contains("found at a") should be (true)
+      c.node.asInstanceOf[String] should be ("a")
+    case _: Throwable =>
+  }
 
   acyclicGraph.reverse.getEdgeMap should equal (reversedAcyclicGraph.getEdgeMap)
 


### PR DESCRIPTION
Needed for special handling in Treadle.
Small refactor that allows users of DiGraph#linearize
to return the first node found in a cycle.
Fixed RemoveWiresTransfrom to handle this.
Added test to show usage of this feature.

If there's a better more canonical way of doing this please let me know.