### PR TITLE
Make Dedup properly dedup ExtModules

### DIFF
--- a/src/main/scala/firrtl/transforms/Dedup.scala
+++ b/src/main/scala/firrtl/transforms/Dedup.scala
@@ -126,11 +126,7 @@ object DedupModules {
       case h: IsDeclaration => h map rename map retype(h.name) map onExp map reinfo
       case other => other map reinfo map onExp map onStmt
     }
-    val finalModule = module match {
-      case m: Module => m map onPort map onStmt
-      case other => other
-    }
-    finalModule
+    module map onPort map onStmt
   }
 
   /**


### PR DESCRIPTION
If you look at the small diff for `Dedup.scala`, the issue was that source locators were not stripped for ExtModules (on Ports). This PR makes `changeInternals` treat Modules and ExtModules the same way. The Mappers already know not to do anything when you call `.map(Statement => Statement)` on an ExtModule so everything is good.