### PR TITLE
Make DiGraph.linearize be iterative instead of recursive

### DIFF
--- a/src/main/scala/firrtl/transforms/RemoveWires.scala
+++ b/src/main/scala/firrtl/transforms/RemoveWires.scala
@@ -42,9 +42,9 @@ class RemoveWires extends Transform {
   private def getOrderedNodes(
       netlist: mutable.LinkedHashMap[WrappedExpression, (Expression, Info)]): Try[Seq[DefNode]] = {
     val digraph = new MutableDiGraph[WrappedExpression]
-    for ((sink, (expr, _)) <- netlist) {
-      digraph.addVertex(sink)
-      for (source <- extractNodeWireRefs(expr)) {
+    for ((source, (expr, _)) <- netlist) {
+      digraph.addVertex(source)
+      for (sink <- extractNodeWireRefs(expr)) {
         digraph.addPairWithEdge(sink, source)
       }
     }
@@ -53,7 +53,7 @@ class RemoveWires extends Transform {
     // a MUCH better job of preserving the logic order as expressed by the designer
     // See RemoveWireTests for illustration
     Try {
-      val ordered = digraph.linearize.reverse
+      val ordered = digraph.linearize
       ordered.map { key =>
         val WRef(name, _,_,_) = key.e1
         val (rhs, info) = netlist(key)

--- a/src/main/scala/firrtl/transforms/RemoveWires.scala
+++ b/src/main/scala/firrtl/transforms/RemoveWires.scala
@@ -42,9 +42,9 @@ class RemoveWires extends Transform {
   private def getOrderedNodes(
       netlist: mutable.LinkedHashMap[WrappedExpression, (Expression, Info)]): Try[Seq[DefNode]] = {
     val digraph = new MutableDiGraph[WrappedExpression]
-    for ((source, (expr, _)) <- netlist) {
-      digraph.addVertex(source)
-      for (sink <- extractNodeWireRefs(expr)) {
+    for ((sink, (expr, _)) <- netlist) {
+      digraph.addVertex(sink)
+      for (source <- extractNodeWireRefs(expr)) {
         digraph.addPairWithEdge(sink, source)
       }
     }
@@ -53,7 +53,7 @@ class RemoveWires extends Transform {
     // a MUCH better job of preserving the logic order as expressed by the designer
     // See RemoveWireTests for illustration
     Try {
-      val ordered = digraph.linearize
+      val ordered = digraph.linearize.reverse
       ordered.map { key =>
         val WRef(name, _,_,_) = key.e1
         val (rhs, info) = netlist(key)

--- a/src/test/scala/firrtlTests/graph/DiGraphTests.scala
+++ b/src/test/scala/firrtlTests/graph/DiGraphTests.scala
@@ -40,31 +40,45 @@ class DiGraphTests extends FirrtlFlatSpec {
 
   val degenerateGraph = DiGraph(Map("a" -> Set.empty[String]))
 
-  acyclicGraph.findSCCs.filter(_.length > 1) shouldBe empty
-
-  cyclicGraph.findSCCs.filter(_.length > 1) should not be empty
-
-  acyclicGraph.path("a","e") should not be empty
-
-  an [PathNotFoundException] should be thrownBy acyclicGraph.path("e","a")
-
-  acyclicGraph.linearize.head should equal ("a")
-
-  a [CyclicException] should be thrownBy cyclicGraph.linearize
-
-  try {
-    cyclicGraph.linearize
-  }
-  catch {
-    case c: CyclicException =>
-      c.getMessage.contains("found at a") should be (true)
-      c.node.asInstanceOf[String] should be ("a")
-    case _: Throwable =>
+  "A graph without cycles" should "have NOT SCCs" in {
+    acyclicGraph.findSCCs.filter(_.length > 1) shouldBe empty
   }
 
-  acyclicGraph.reverse.getEdgeMap should equal (reversedAcyclicGraph.getEdgeMap)
+  "A graph with cycles" should "have SCCs" in {
+    cyclicGraph.findSCCs.filter(_.length > 1) should not be empty
+  }
 
-  degenerateGraph.getEdgeMap should equal (degenerateGraph.reverse.getEdgeMap)
+  "Asking a DiGraph for a path that exists" should "work" in {
+    acyclicGraph.path("a","e") should not be empty
+  }
+
+  "Asking a DiGraph for a path from one node to another with no path" should "error" in {
+    an [PathNotFoundException] should be thrownBy acyclicGraph.path("e","a")
+  }
+
+  "The first element in a linearized graph with a single root node" should "be the root" in {
+    acyclicGraph.linearize.head should equal ("a")
+  }
+
+  "A DiGraph with a cycle" should "error when linearized" in {
+    a [CyclicException] should be thrownBy cyclicGraph.linearize
+  }
+
+  "CyclicExceptions" should "contain information about the cycle" in {
+    val c = the [CyclicException] thrownBy {
+      cyclicGraph.linearize
+    }
+    c.getMessage.contains("found at a") should be (true)
+    c.node.asInstanceOf[String] should be ("a")
+  }
+
+  "Reversing a graph" should "reverse all of the edges" in {
+    acyclicGraph.reverse.getEdgeMap should equal (reversedAcyclicGraph.getEdgeMap)
+  }
+
+  "Reversing a graph with no edges" should "equal the graph itself" in {
+    degenerateGraph.getEdgeMap should equal (degenerateGraph.reverse.getEdgeMap)
+  }
 
   "transformNodes" should "combine vertices that collide, not drop them" in {
     tupleGraph.transformNodes(_._1).getEdgeMap should contain ("a" -> Set("b", "c"))

--- a/src/test/scala/firrtlTests/graph/DiGraphTests.scala
+++ b/src/test/scala/firrtlTests/graph/DiGraphTests.scala
@@ -98,4 +98,16 @@ class DiGraphTests extends FirrtlFlatSpec {
     (first + second + second + second).getEdgeMap should equal (acyclicGraph.getEdgeMap)
   }
 
+  "linearize" should "not cause a stack overflow on very large graphs" in {
+    // Graph of 0 -> 1, 1 -> 2, etc.
+    val N = 10000
+    val edges = (1 to N).zipWithIndex.map({ case (n, idx) => idx -> Set(n)}).toMap
+    val bigGraph = DiGraph(edges + (N -> Set.empty[Int]))
+    bigGraph.linearize should be (0 to N)
+  }
+
+  it should "work on multi-rooted graphs" in {
+    val graph = DiGraph(Map("a" -> Set[String](), "b" -> Set[String]()))
+    graph.linearize.toSet should be (graph.getVertices)
+  }
 }


### PR DESCRIPTION
Now insanely long chains will no longer cause a stack overflow. 

~~This does change the ordering in RemoveWires a bit, using a breadth-first traversal rather than a depth-first traversal.~~

Edit: The below is no longer relevent

For example:
```
circuit foo :
  module foo :
    input x : UInt<8>
    output z : UInt
    node a = add(x, UInt(1))
    node b = add(a, UInt(2))
    node c = add(b, UInt(3))
    node d = add(a, UInt(4))
    z <= and(c, d)
```
This ordering used to be maintained, but now it swaps the order of `c` and `d` because `d` depends directly on `a` whereas `c` depends on `b` which depends on `a`.
```
circuit foo :
  module foo : 
    input x : UInt<8> 
    output z : UInt<11> 
  
    node a = add(x, UInt<1>("h1")) 
    node b = add(a, UInt<2>("h2")) 
    node d = add(a, UInt<3>("h4")) 
    node c = add(b, UInt<2>("h3"))
    z <= and(c, d)
```