### PR TITLE
Cleaning up BlackBoxSourceHelper

### DIFF
--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -113,8 +113,7 @@ object BlackBoxSourceHelper {
 
   def writeFileList(files: Set[File], targetDir: File) {
     if (files.nonEmpty) {
-      val text = files.map { fileName => s"-v $fileName" }.mkString("\n")
-      writeTextToFile(text, new File(targetDir, fileListName))
+      writeTextToFile(files.mkString("\n"), new File(targetDir, fileListName))
     }
   }
 

--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -109,7 +109,7 @@ object BlackBoxSourceHelper {
     out.close()
   }
 
-  val fileListName = "black_box_verilog_files.f"
+  val fileListName = "firrtl_black_box_resource_files.f"
 
   def writeFileList(files: Set[File], targetDir: File) {
     if (files.nonEmpty) {

--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -8,7 +8,7 @@ import firrtl._
 import firrtl.Utils.throwInternalError
 import firrtl.annotations._
 
-import scala.collection.mutable.ArrayBuffer
+import scala.collection.immutable.ListSet
 
 sealed trait BlackBoxHelperAnno extends Annotation
 
@@ -47,8 +47,8 @@ class BlackBoxSourceHelper extends firrtl.Transform {
     * @param annos a list of generic annotations for this transform
     * @return BlackBoxHelperAnnos and target directory
     */
-  def collectAnnos(annos: Seq[Annotation]): (Set[BlackBoxHelperAnno], File) =
-    annos.foldLeft((Set.empty[BlackBoxHelperAnno], DefaultTargetDir)) {
+  def collectAnnos(annos: Seq[Annotation]): (ListSet[BlackBoxHelperAnno], File) =
+    annos.foldLeft((ListSet.empty[BlackBoxHelperAnno], DefaultTargetDir)) {
       case ((acc, tdir), anno) => anno match {
         case BlackBoxTargetDirAnno(dir) =>
           val targetDir = new File(dir)
@@ -68,7 +68,7 @@ class BlackBoxSourceHelper extends firrtl.Transform {
   override def execute(state: CircuitState): CircuitState = {
     val (annos, targetDir) = collectAnnos(state.annotations)
 
-    val resourceFiles: Set[File] = annos.collect {
+    val resourceFiles: ListSet[File] = annos.collect {
       case BlackBoxResourceAnno(_, resourceId) =>
         val name = resourceId.split("/").last
         val outFile = new File(targetDir, name)
@@ -78,7 +78,7 @@ class BlackBoxSourceHelper extends firrtl.Transform {
       file
     }
 
-    val inlineFiles: Set[File] = annos.collect {
+    val inlineFiles: ListSet[File] = annos.collect {
       case BlackBoxInlineAnno(_, name, text) =>
         val outFile = new File(targetDir, name)
         (text, outFile)
@@ -111,7 +111,7 @@ object BlackBoxSourceHelper {
 
   val fileListName = "firrtl_black_box_resource_files.f"
 
-  def writeFileList(files: Set[File], targetDir: File) {
+  def writeFileList(files: ListSet[File], targetDir: File) {
     if (files.nonEmpty) {
       writeTextToFile(files.mkString("\n"), new File(targetDir, fileListName))
     }

--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -87,26 +87,13 @@ class BlackBoxSourceHelper extends firrtl.Transform {
       file
     }
 
-    val fileList = resourceFiles ++ inlineFiles
-
-    // If we have BlackBoxes, generate the helper file.
-    // If we don't, make sure it doesn't exist or we'll confuse downstream processing
-    //  that triggers behavior on the existence of the file
-    val helperFile = new File(targetDir, BlackBoxSourceHelper.FileListName)
-    if (fileList.nonEmpty) {
-      val writer = new PrintWriter(helperFile)
-      writer.write(fileList.map { fileName => s"-v $fileName" }.mkString("\n"))
-      writer.close()
-    } else {
-      helperFile.delete()
-    }
+    BlackBoxSourceHelper.writeFileList(resourceFiles ++ inlineFiles, targetDir)
 
     state
   }
 }
 
 object BlackBoxSourceHelper {
-  val FileListName = "black_box_verilog_files.f"
   /**
     * finds the named resource and writes into the directory
     * @param name the name of the resource
@@ -120,6 +107,15 @@ object BlackBoxSourceHelper {
     val out = new FileOutputStream(file)
     Iterator.continually(in.read).takeWhile(-1 != _).foreach(out.write)
     out.close()
+  }
+
+  val fileListName = "black_box_verilog_files.f"
+
+  def writeFileList(files: Set[File], targetDir: File) {
+    if (files.nonEmpty) {
+      val text = files.map { fileName => s"-v $fileName" }.mkString("\n")
+      writeTextToFile(text, new File(targetDir, fileListName))
+    }
   }
 
   def writeTextToFile(text: String, file: File) {

--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -73,7 +73,7 @@ class BlackBoxSourceHelper extends firrtl.Transform {
         val name = resourceId.split("/").last
         val outFile = new File(targetDir, name)
         (resourceId, outFile)
-    }.toSet[(String, File)].map { case (res, file) =>
+    }.map { case (res, file) =>
       BlackBoxSourceHelper.copyResourceToFile(res, file)
       file
     }
@@ -82,7 +82,7 @@ class BlackBoxSourceHelper extends firrtl.Transform {
       case BlackBoxInlineAnno(_, name, text) =>
         val outFile = new File(targetDir, name)
         (text, outFile)
-    }.toSet[(String, File)].map { case (text, file) =>
+    }.map { case (text, file) =>
       BlackBoxSourceHelper.writeTextToFile(text, file)
       file
     }

--- a/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
+++ b/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
@@ -91,7 +91,7 @@ trait BackendCompilationUtilities {
     val topModule = dutFile
 
     val blackBoxVerilogList = {
-      val list_file = new File(dir, firrtl.transforms.BlackBoxSourceHelper.FileListName)
+      val list_file = new File(dir, firrtl.transforms.BlackBoxSourceHelper.fileListName)
       if(list_file.exists()) {
         Seq("-f", list_file.getAbsolutePath)
       }

--- a/src/test/scala/firrtlTests/transforms/BlacklBoxSourceHelperSpec.scala
+++ b/src/test/scala/firrtlTests/transforms/BlacklBoxSourceHelperSpec.scala
@@ -59,7 +59,7 @@ class BlacklBoxSourceHelperTransformSpec extends LowTransformSpec {
     execute(input, output, annos)
 
     new java.io.File("test_run_dir/AdderExtModule.v").exists should be (true)
-    new java.io.File(s"test_run_dir/${BlackBoxSourceHelper.FileListName}").exists should be (true)
+    new java.io.File(s"test_run_dir/${BlackBoxSourceHelper.fileListName}").exists should be (true)
   }
 
   "verilog compiler" should "have BlackBoxSourceHelper transform" in {


### PR DESCRIPTION
The implementation had a few quirks, all addressed by this PR:
* It copied over the resource file once-per-instance, not once-per-module-annotation
* The resulting file list listed files once-per-instance, not once-per-file
* The file list contained a `-v` prefix per line, which is not standard for `.f` files AFAIK
* The file list file name assumed that all resources are verilog (they might be `.cc`, `.h`, `.tab` etc)
* The file list file name scala constant used a capital letter while not being a class
