### PR TITLE
Fix bug in Constant Propagation for registers propped to zero

### DIFF
--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -379,7 +379,8 @@ class ConstantPropagation extends Transform {
           case Mux(_, tval: Literal, fval: WRef, _) if weq(lref, fval) =>
             nodeMap(lname) = constPropExpression(nodeMap, instMap, constSubOutputs)(pad(tval, ltpe))
           case WRef(`lname`, _,_,_) => // If a register is connected to itself, propagate zero
-            nodeMap(lname) = passes.RemoveValidIf.getGroundZero(ltpe)
+            val zero = passes.RemoveValidIf.getGroundZero(ltpe)
+            nodeMap(lname) = constPropExpression(nodeMap, instMap, constSubOutputs)(pad(zero, ltpe))
           case _ =>
         }
         // Mark instance inputs connected to a constant

--- a/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+++ b/src/test/scala/firrtlTests/ConstantPropagationTests.scala
@@ -836,6 +836,25 @@ class ConstantPropagationIntegrationSpec extends LowTransformSpec {
     execute(input, check, Seq.empty)
   }
 
+  it should "pad zero when constant propping a register replaced with zero" in {
+      val input =
+        """circuit Top :
+          |  module Top :
+          |    input clock : Clock
+          |    output z : UInt<16>
+          |    reg r : UInt<8>, clock
+          |    r <= or(r, UInt(0))
+          |    node n = UInt("hab")
+          |    z <= cat(n, r)""".stripMargin
+      val check =
+        """circuit Top :
+          |  module Top :
+          |    input clock : Clock
+          |    output z : UInt<16>
+          |    z <= UInt<16>("hab00")""".stripMargin
+    execute(input, check, Seq.empty)
+  }
+
   it should "pad constant connections to outputs when propagating" in {
       val input =
         """circuit Top :


### PR DESCRIPTION
It wasn't properly padding the width of the constant zero.
Also add a test that shows the buggy behavior.