### PR TITLE
Cleaning up BlackBoxSourceHelper - use absolute file paths.

### DIFF
--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -116,8 +116,8 @@ object BlackBoxSourceHelper {
       // We need the absolute path here (or strip targetDir from the file path),
       //  so verilator will create a path to the file that works from the targetDir.
       //  Otherwise, when make tries to determine dependencies based on the *__ver.d file, we end up with errors like:
-      //    make[1]: *** No rule to make target `test_run_dir/examples.AccumBlackBox_PeekPokeTest_Verilator345491158/AccumBlackBox.v', needed by `/Volumes/ucbjrlNBP/jrl/clients/ucb/git/ucb-bar/chisel-release.worktree.master/chisel-testers/test_run_dir/examples.AccumBlackBox_PeekPokeTest_Verilator345491158/VAccumBlackBoxWrapper.h'.  Stop.
-      writeTextToFile((files map (_.getAbsolutePath)).mkString("\n"), new File(targetDir, fileListName))
+      //    make[1]: *** No rule to make target `test_run_dir/examples.AccumBlackBox_PeekPokeTest_Verilator345491158/AccumBlackBox.v', needed by `.../chisel-testers/test_run_dir/examples.AccumBlackBox_PeekPokeTest_Verilator345491158/VAccumBlackBoxWrapper.h'.  Stop.
+      writeTextToFile(files.map(_.getAbsolutePath).mkString("\n"), new File(targetDir, fileListName))
     }
   }
 

--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -113,7 +113,11 @@ object BlackBoxSourceHelper {
 
   def writeFileList(files: ListSet[File], targetDir: File) {
     if (files.nonEmpty) {
-      writeTextToFile(files.mkString("\n"), new File(targetDir, fileListName))
+      // We need the absolute path here (or strip targetDir from the file path),
+      //  so verilator will create a path to the file that works from the targetDir.
+      //  Otherwise, when make tries to determine dependencies based on the *__ver.d file, we end up with errors like:
+      //    make[1]: *** No rule to make target `test_run_dir/examples.AccumBlackBox_PeekPokeTest_Verilator345491158/AccumBlackBox.v', needed by `/Volumes/ucbjrlNBP/jrl/clients/ucb/git/ucb-bar/chisel-release.worktree.master/chisel-testers/test_run_dir/examples.AccumBlackBox_PeekPokeTest_Verilator345491158/VAccumBlackBoxWrapper.h'.  Stop.
+      writeTextToFile((files map (_.getAbsolutePath)).mkString("\n"), new File(targetDir, fileListName))
     }
   }
 


### PR DESCRIPTION
PR #786 introduces a subtle bug in verilator dependency generation. The paths enumerated in `firrtl_black_box_resource_files.f` must be valid from inside the targetDir (i.e., they should not include a relative targetDir prefix). This doesn't appear to matter as long as the targetDir is clean (possibly make finds a missing dependency early enough that it doesn't bother examining all the dependencies), but subsequent test runs will produce an error:
```bash
make[1]: *** No rule to make target `test_run_dir/examples.AccumBlackBox_PeekPokeTest_Verilator345491158/AccumBlackBox.v', needed by `/Users/john/chisel-testers/test_run_dir/examples.AccumBlackBox_PeekPokeTest_Verilator345491158/VAccumBlackBoxWrapper.h'.  Stop.
```
since the path `test_run_dir/examples.AccumBlackBox_PeekPokeTest_Verilator345491158/AccumBlackBox.v` does not exist inside `test_run_dir`.
We should either:
 - strip the targetDir prefix,
 - prepend a `../` to the path,
 - use absolute paths
I decided to go with the latter since this makes the least assumptions about the actual downstream processing and we already use absolute paths in other parts of this code.