### PR TITLE
Fix bug in VerilogMemDelays

### DIFF
--- a/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
+++ b/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
@@ -10,6 +10,8 @@ import firrtl.Mappers._
 import firrtl.PrimOps._
 import MemPortUtils._
 
+import collection.mutable
+
 /** This pass generates delay reigsters for memories for verilog */
 object VerilogMemDelays extends Pass {
   val ug = UNKNOWNGENDER
@@ -32,8 +34,9 @@ object VerilogMemDelays extends Pass {
   def memDelayStmt(
       netlist: Netlist,
       namespace: Namespace,
-      repl: Netlist)
-      (s: Statement): Statement = s map memDelayStmt(netlist, namespace, repl) match {
+      repl: Netlist,
+      stmts: mutable.ArrayBuffer[Statement])
+      (s: Statement): Statement = s.map(memDelayStmt(netlist, namespace, repl, stmts)) match {
     case sx: DefMemory =>
       val ports = (sx.readers ++ sx.writers).toSet
       def newPortName(rw: String, p: String) = (for {
@@ -96,8 +99,7 @@ object VerilogMemDelays extends Pass {
         Connect(NoInfo, memPortField(mem, writer, "data"), data)
       )
  
-
-      Block(mem +: ((sx.readers flatMap {reader =>
+      stmts ++= ((sx.readers flatMap {reader =>
         // generate latency pipes for read ports (enable & addr)
         val clk = netlist(memPortField(sx, reader, "clk"))
         val (en, ss1) = pipe(memPortField(sx, reader, "en"), sx.readLatency - 1, clk, one)
@@ -125,7 +127,8 @@ object VerilogMemDelays extends Pass {
         ss1 ++ ss2 ++ ss3 ++ ss4 ++ ss5 ++ ss6 ++
         readPortConnects(reader, clk, en, raddr) ++
         writePortConnects(writer, clk, AND(en, wmode), wmask, waddr, wdata)
-      })))
+      }))
+      mem // The mem stays put
     case sx: Connect => kind(sx.loc) match {
       case MemKind => EmptyStmt
       case _ => sx
@@ -144,13 +147,17 @@ object VerilogMemDelays extends Pass {
   def replaceStmt(repl: Netlist)(s: Statement): Statement =
     s map replaceStmt(repl) map replaceExp(repl)
 
+  def appendStmts(sx: Seq[Statement])(s: Statement): Statement = Block(s +: sx)
+
   def memDelayMod(m: DefModule): DefModule = {
     val netlist = new Netlist
     val namespace = Namespace(m)
     val repl = new Netlist
-    (m map buildNetlist(netlist)
-       map memDelayStmt(netlist, namespace, repl)
-       map replaceStmt(repl))
+    val extraStmts = mutable.ArrayBuffer.empty[Statement]
+    m.map(buildNetlist(netlist))
+     .map(memDelayStmt(netlist, namespace, repl, extraStmts))
+     .map(replaceStmt(repl))
+     .map(appendStmts(extraStmts))
   }
 
   def run(c: Circuit): Circuit =

--- a/src/test/scala/firrtlTests/VerilogMemDelaySpec.scala
+++ b/src/test/scala/firrtlTests/VerilogMemDelaySpec.scala
@@ -1,0 +1,53 @@
+// See LICENSE for license details.
+
+package firrtlTests
+
+import firrtl.{AnnotationSeq, ChirrtlForm, LowFirrtlCompiler, Parser}
+import firrtl.passes.memlib.VerilogMemDelays
+import org.scalatest.{FreeSpec, Matchers}
+
+class VerilogMemDelaySpec extends FreeSpec with Matchers {
+  "The following low FIRRTL should be parsed by VerilogMemDelays" in {
+    val input =
+      """
+        |circuit Test :
+        |  module Test :
+        |    input clock : Clock
+        |    input a : UInt<1>
+        |    input b : UInt<1>
+        |    input select : UInt<1>
+        |    output c : UInt<1>
+        |    mem m :
+        |      data-type => { a : UInt<8>, b : UInt<8>}[2]
+        |      depth => 32
+        |      read-latency => 0
+        |      write-latency => 1
+        |      reader => read
+        |      writer => write
+        |    m.read.clk <= clock
+        |    m.read.en <= UInt<1>(1)
+        |    m.read.addr is invalid
+        |    node x = m.read.data
+        |    node y = m.read.data[0].b
+        |
+        |    m.write.clk <= clock
+        |    m.write.en <= UInt<1>(0)
+        |    m.write.mask is invalid
+        |    m.write.addr is invalid
+        |    wire w : { a : UInt<8>, b : UInt<8>}[2]
+        |    w[0].a <= UInt<4>(2)
+        |    w[0].b <= UInt<4>(3)
+        |    w[1].a <= UInt<4>(4)
+        |    w[1].b <= UInt<4>(5)
+        |    m.write.data <= w
+        |    c <= a
+      """.stripMargin
+
+    val circuit = Parser.parse(input)
+    val compiler = new LowFirrtlCompiler
+
+    val compileResult = compiler.compileAndEmit(firrtl.CircuitState(circuit, ChirrtlForm, AnnotationSeq(Seq.empty)))
+    val circuit2 = VerilogMemDelays.run(compileResult.circuit)
+    circuit2.serialize.length > 0 should be (true)
+  }
+}


### PR DESCRIPTION
VerilogMemDelays sometimes issues Statements in an illegal order, this makes sure that doesn't happen. See test case for example.