### PR TITLE
TopWiring Transform

### DIFF
--- a/src/main/scala/firrtl/analyses/InstanceGraph.scala
+++ b/src/main/scala/firrtl/analyses/InstanceGraph.scala
@@ -18,7 +18,7 @@ import firrtl.Mappers._
   */
 class InstanceGraph(c: Circuit) {
 
-  private val moduleMap = c.modules.map({m => (m.name,m) }).toMap
+  val moduleMap = c.modules.map({m => (m.name,m) }).toMap
   private val instantiated = new mutable.HashSet[String]
   private val childInstances =
     new mutable.HashMap[String,mutable.Set[WDefInstance]]
@@ -93,6 +93,14 @@ class InstanceGraph(c: Circuit) {
   def moduleOrder: Seq[DefModule] = {
     graph.transformNodes(_.module).linearize.map(moduleMap(_))
   }
+
+  
+  /** Given a circuit, returns a map from module name to children
+     * instance/module definitions
+     */
+  def getChildrenInstances: scala.collection.Map[String,mutable.Set[WDefInstance]] = childInstances 
+
+
 }
 
 object InstanceGraph {

--- a/src/main/scala/firrtl/transforms/TopWiring.scala
+++ b/src/main/scala/firrtl/transforms/TopWiring.scala
@@ -133,12 +133,10 @@ class TopWiringTransform extends Transform {
     // Map of component name to relative instance paths that result in a debug wire
     val sourcemods: mutable.Map[String, Seq[(ComponentName, Type, Boolean, InstPath)]] =
       mutable.Map(sSourcesModNames.map(_ -> Seq()): _*)
-      //mutable.Map(sSourcesModNames.map(_ -> Seq(ComponentName,UnknownType,false,Seq[String]())): _*)
 
     state.circuit.modules.foreach { m => m map getSourceTypes(sSourcesNames, sourcemods, ModuleName(m.name, CircuitName(state.circuit.main)) , state) }
     state.circuit.modules.foreach { m => m.ports.foreach { p => Seq(p) map getSourceTypesPorts(sSourcesNames, sourcemods, ModuleName(m.name, CircuitName(state.circuit.main)) , state) }}
 
-    // TODO make this code more clear
     for (mod <- topSort) {
       val seqChildren: Seq[(ComponentName,Type,Boolean,InstPath)] = cMap(mod.name).flatMap { case (inst, module) => 
         sourcemods.get(module).map( _.map { case (a,b,c,path) => (a,b,c, inst +: path)})
@@ -155,9 +153,9 @@ class TopWiringTransform extends Transform {
 
   /** Process a given DefModule
     *
-    * For Modules that contain or are in the parent hierarchy to modules containing SeqMems
-    * 1. Add ports for each SeqMem this module is parent to
-    * 2. Connect these ports to ports of instances that are parents to some number of SeqMems
+    * For Modules that contain or are in the parent hierarchy to modules containing target wires
+    * 1. Add ports for each target wire this module is parent to
+    * 2. Connect these ports to ports of instances that are parents to some number of target wires
     */
   // TODO Make code more clear
   private def onModule(prefix: String, sources: Map[String, Seq[(ComponentName, Type, Boolean, InstPath)]])
@@ -229,7 +227,6 @@ class TopWiringTransform extends Transform {
       case Some(prefix) =>
         // Do actual work of this transform
         val sources = getSourcesMap(state)
-        //val prefix = s"topwiring_"
         val modulesx = state.circuit.modules map onModule(prefix,sources)
         val newCircuit = state.circuit.copy(modules = modulesx)
         val fixedCircuit = fixupCircuit(newCircuit)

--- a/src/main/scala/firrtl/transforms/TopWiring.scala
+++ b/src/main/scala/firrtl/transforms/TopWiring.scala
@@ -17,8 +17,11 @@ import java.io._
 import scala.io.Source
 import collection.mutable
 
-/** Annotation for optional output files **/
-case class TopWiringOutputFilesAnnotation(dirName: String, outputFunction: (String,Seq[((ComponentName, Type, Boolean, Seq[String],String), Int)], CircuitState) => CircuitState) extends NoTargetAnnotation
+/** Annotation for optional output files, and what directory to put those files in (absolute path) **/
+case class TopWiringOutputFilesAnnotation(dirName: String,
+                                          outputFunction: (String,Seq[((ComponentName, Type, Boolean,
+                                                                         Seq[String],String), Int)],
+                                                           CircuitState) => CircuitState) extends NoTargetAnnotation
 
 /** Annotation for indicating component to be wired, and what prefix to add to the ports that are generated */
 case class TopWiringAnnotation(target: ComponentName, prefix: String) extends
@@ -28,30 +31,38 @@ case class TopWiringAnnotation(target: ComponentName, prefix: String) extends
 
 
 /** Punch out annotated ports out to the toplevel of the circuit.
-    This also has an option to pass a function as a parmeter to generate custom output files as a result of the additional ports
+    This also has an option to pass a function as a parmeter to generate
+    custom output files as a result of the additional ports
   * @note This *does* work for deduped modules
   */
-
 class TopWiringTransform extends Transform {
-  def inputForm: CircuitForm = MidForm
-  def outputForm: CircuitForm = MidForm
+  def inputForm: CircuitForm = LowForm
+  def outputForm: CircuitForm = LowForm
 
   type InstPath = Seq[String]
- 
-  /** Get the names of the targets that need to be wired */
 
+  /** Get the names of the targets that need to be wired */
   private def getSourceNames(state: CircuitState): Map[ComponentName, String] = {
-    state.annotations.collect { case TopWiringAnnotation(srcname,prefix) => (srcname -> prefix) }.toMap.withDefaultValue("")
+    state.annotations.collect { case TopWiringAnnotation(srcname,prefix) =>
+                                  (srcname -> prefix) }.toMap.withDefaultValue("")
   }
 
 
+  /** Get the names of the modules which include the  targets that need to be wired */
   private def getSourceModNames(state: CircuitState): Seq[String] = {
     state.annotations.collect { case TopWiringAnnotation(ComponentName(_,ModuleName(srcmodname, _)),_) => srcmodname }
   }
 
 
 
-  def getSourceTypes(sourceList: Map[ComponentName, String], sourceMap: mutable.Map[String, Seq[(ComponentName, Type, Boolean, InstPath, String)]], currentmodule: ModuleName, state: CircuitState)(s: Statement): Statement = s match {
+  /** Get the Type of each wire to be connected
+    *
+    * Find the definition of each wire in sourceList, and get the type and whether or not it's a port
+    * Update the results in sourceMap
+    */
+  private def getSourceTypes(sourceList: Map[ComponentName, String],
+                     sourceMap: mutable.Map[String, Seq[(ComponentName, Type, Boolean, InstPath, String)]],
+                     currentmodule: ModuleName, state: CircuitState)(s: Statement): Statement = s match {
     // If target wire, add name and size to to sourceMap
     case w: IsDeclaration =>
       if (sourceList.keys.toSeq.contains(ComponentName(w.name, currentmodule))) {
@@ -64,10 +75,13 @@ class TopWiringTransform extends Transform {
           }
           val name = w.name
           sourceMap.get(currentmodule.name) match {
-            case Some(xs:Seq[(ComponentName, Type, Boolean, InstPath, String)]) => sourceMap.update(currentmodule.name, xs :+ (ComponentName(w.name,currentmodule), tpe, isport ,Seq[String](w.name), prefix))
-            case None => sourceMap(currentmodule.name) = Seq((ComponentName(w.name,currentmodule), tpe, isport ,Seq[String](w.name), prefix))
+            case Some(xs:Seq[(ComponentName, Type, Boolean, InstPath, String)]) =>
+              sourceMap.update(currentmodule.name, xs :+
+                 (ComponentName(w.name,currentmodule), tpe, isport ,Seq[String](w.name), prefix))
+            case None =>
+              sourceMap(currentmodule.name) = Seq((ComponentName(w.name,currentmodule),
+                                                   tpe, isport ,Seq[String](w.name), prefix))
           }
-          //sourceMap(currentmodule.name) +: (ComponentName(w.name,currentmodule), tpe, isport ,Seq[String](currentmodule.name))
       }
       w // Return argument unchanged (ok because DefWire has no Statement children)
     // If not, apply to all children Statement
@@ -76,8 +90,15 @@ class TopWiringTransform extends Transform {
 
 
 
-
-  def getSourceTypesPorts(sourceList: Map[ComponentName, String], sourceMap: mutable.Map[String, Seq[(ComponentName, Type, Boolean, InstPath, String)]], currentmodule: ModuleName, state: CircuitState)(s: Port): CircuitState = s match {
+  /** Get the Type of each port to be connected
+    *
+    * Similar to getSourceTypes, but specifically for ports since they are not found in statements.
+    * Find the definition of each port in sourceList, and get the type and whether or not it's a port
+    * Update the results in sourceMap
+    */
+  private def getSourceTypesPorts(sourceList: Map[ComponentName, String], sourceMap: mutable.Map[String,
+                          Seq[(ComponentName, Type, Boolean, InstPath, String)]],
+                          currentmodule: ModuleName, state: CircuitState)(s: Port): CircuitState = s match {
     // If target port, add name and size to to sourceMap
     case w: IsDeclaration =>
       if (sourceList.keys.toSeq.contains(ComponentName(w.name, currentmodule))) {
@@ -87,10 +108,13 @@ class TopWiringTransform extends Transform {
           }
           val name = w.name
           sourceMap.get(currentmodule.name) match {
-            case Some(xs:Seq[(ComponentName, Type, Boolean, InstPath, String)]) => sourceMap.update(currentmodule.name, xs :+ (ComponentName(w.name,currentmodule), tpe, isport ,Seq[String](w.name), prefix))
-            case None => sourceMap(currentmodule.name) = Seq((ComponentName(w.name,currentmodule), tpe, isport ,Seq[String](w.name), prefix))
+            case Some(xs:Seq[(ComponentName, Type, Boolean, InstPath, String)]) =>
+                sourceMap.update(currentmodule.name, xs :+
+                  (ComponentName(w.name,currentmodule), tpe, isport ,Seq[String](w.name), prefix))
+            case None =>
+                sourceMap(currentmodule.name) = Seq((ComponentName(w.name,currentmodule),
+                                                     tpe, isport ,Seq[String](w.name), prefix))
           }
-          //sourceMap(currentmodule.name) +: (ComponentName(w.name,currentmodule), tpe, isport ,Seq[String](currentmodule.name))
       }
       state // Return argument unchanged (ok because DefWire has no Statement children)
     // If not, apply to all children Statement
@@ -98,33 +122,32 @@ class TopWiringTransform extends Transform {
   }
 
 
-
-
-
-
-
   /** Create a map of Module name to target wires under this module
     *
     * These paths are relative but cross module (they refer down through instance hierarchy)
     */
-  private def getSourcesMap(state: CircuitState): Map[String, Seq[(ComponentName, Type, Boolean, InstPath, String)]] = {
+  private def getSourcesMap(state: CircuitState): Map[String,Seq[(ComponentName, Type, Boolean, InstPath, String)]] = {
     val sSourcesModNames = getSourceModNames(state)
     val sSourcesNames = getSourceNames(state)
-     
     val instGraph = new firrtl.analyses.InstanceGraph(state.circuit)
-    val cMap = instGraph.getChildrenInstances.map{ case (m, wdis) => (m -> wdis.map{ case wdi => (wdi.name, wdi.module) }.toSeq) }.toMap
+    val cMap = instGraph.getChildrenInstances.map{ case (m, wdis) =>
+        (m -> wdis.map{ case wdi => (wdi.name, wdi.module) }.toSeq) }.toMap
     val topSort = instGraph.moduleOrder.reverse
 
     // Map of component name to relative instance paths that result in a debug wire
     val sourcemods: mutable.Map[String, Seq[(ComponentName, Type, Boolean, InstPath, String)]] =
       mutable.Map(sSourcesModNames.map(_ -> Seq()): _*)
 
-    state.circuit.modules.foreach { m => m map getSourceTypes(sSourcesNames, sourcemods, ModuleName(m.name, CircuitName(state.circuit.main)) , state) }
-    state.circuit.modules.foreach { m => m.ports.foreach { p => Seq(p) map getSourceTypesPorts(sSourcesNames, sourcemods, ModuleName(m.name, CircuitName(state.circuit.main)) , state) }}
+    state.circuit.modules.foreach { m => m map
+      getSourceTypes(sSourcesNames, sourcemods, ModuleName(m.name, CircuitName(state.circuit.main)) , state) }
+    state.circuit.modules.foreach { m => m.ports.foreach {
+       p => Seq(p) map
+          getSourceTypesPorts(sSourcesNames, sourcemods, ModuleName(m.name, CircuitName(state.circuit.main)) , state) }}
 
     for (mod <- topSort) {
-      val seqChildren: Seq[(ComponentName,Type,Boolean,InstPath,String)] = cMap(mod.name).flatMap { case (inst, module) => 
-        sourcemods.get(module).map( _.map { case (a,b,c,path,p) => (a,b,c, inst +: path, p)})
+      val seqChildren: Seq[(ComponentName,Type,Boolean,InstPath,String)] = cMap(mod.name).flatMap {
+        case (inst, module) =>
+          sourcemods.get(module).map( _.map { case (a,b,c,path,p) => (a,b,c, inst +: path, p)})
       }.flatten
       if (seqChildren.nonEmpty) {
         sourcemods(mod.name) = seqChildren
@@ -142,23 +165,25 @@ class TopWiringTransform extends Transform {
     * 1. Add ports for each target wire this module is parent to
     * 2. Connect these ports to ports of instances that are parents to some number of target wires
     */
-  // TODO Make code more clear
-  private def onModule(sources: Map[String, Seq[(ComponentName, Type, Boolean, InstPath, String)]], portnamesmap : mutable.Map[String,String], instgraph : firrtl.analyses.InstanceGraph, namespacemap : Map[String, Namespace])
+  private def onModule(sources: Map[String, Seq[(ComponentName, Type, Boolean, InstPath, String)]],
+                       portnamesmap : mutable.Map[String,String],
+                       instgraph : firrtl.analyses.InstanceGraph,
+                       namespacemap : Map[String, Namespace])
                       (module: DefModule): DefModule = {
-    val namespace = namespacemap(module.name) 
+    val namespace = namespacemap(module.name)
     sources.get(module.name) match {
       case Some(p) =>
-        val newPorts = p.map{ case (ComponentName(cname,_), tpe, _ , path, prefix) => {  
+        val newPorts = p.map{ case (ComponentName(cname,_), tpe, _ , path, prefix) => {
               val newportname = portnamesmap.get(prefix + path.mkString("_")) match {
                 case Some(pn) => pn
                  case None => {
                     val npn = namespace.newName(prefix + path.mkString("_"))
                     portnamesmap(prefix + path.mkString("_")) = npn
                     npn
-                 } 
-              }  
-              Port(NoInfo, newportname, Output, tpe) 
-        } } 
+                 }
+              }
+              Port(NoInfo, newportname, Output, tpe)
+        } }
 
         // Add connections to Module
         module match {
@@ -183,15 +208,16 @@ class TopWiringTransform extends Transform {
                              val instmod = instgraph.getChildrenInstances(module.name).collectFirst {
                                  case wdi if wdi.name == path.head => wdi.module}.get
                              val instnamespace = namespacemap(instmod)
-                             portnamesmap(prefix + path.tail.mkString("_")) = instnamespace.newName(prefix + path.tail.mkString("_"))
+                             portnamesmap(prefix + path.tail.mkString("_")) =
+                               instnamespace.newName(prefix + path.tail.mkString("_"))
                              portnamesmap(prefix + path.tail.mkString("_"))
                            }
-                       } 
+                       }
                        val instRef = WSubField(WRef(path.head), instportname)
                        Connect(NoInfo, modRef, instRef)
                   }
                 }
-            } 
+            }
             m.copy(ports = m.ports ++ newPorts, body = Block(Seq(m.body) ++ connections ))
           case e: ExtModule =>
             e.copy(ports = e.ports ++ newPorts)
@@ -200,6 +226,7 @@ class TopWiringTransform extends Transform {
     }
   }
 
+  /** Run passes to fix up the circuit of making the new connections  */
   private def fixupCircuit(circuit: Circuit): Circuit = {
     val passes = Seq(
       InferTypes,
@@ -210,22 +237,26 @@ class TopWiringTransform extends Transform {
   }
 
 
-  def TopWiringDummyOutputFilesFunction(dir: String, mapping: Seq[((ComponentName, Type, Boolean, InstPath, String), Int)], state: CircuitState): CircuitState = {
-     state  
+  /** Dummy function that is currently unused. Can be used to fill an outputFunction requirment in the future  */
+  def topWiringDummyOutputFilesFunction(dir: String,
+                                        mapping: Seq[((ComponentName, Type, Boolean, InstPath, String), Int)],
+                                        state: CircuitState): CircuitState = {
+     state
   }
 
 
   def execute(state: CircuitState): CircuitState = {
 
-    val outputTuples: Seq[(String,(String,Seq[((ComponentName, Type, Boolean, InstPath, String), Int)], CircuitState) => CircuitState)] = state.annotations.collect { 
-        case TopWiringOutputFilesAnnotation(td,of) => (td, of) }
-    
+    val outputTuples: Seq[(String,
+                          (String,Seq[((ComponentName, Type, Boolean, InstPath, String), Int)],
+                                        CircuitState) => CircuitState)] = state.annotations.collect {
+         case TopWiringOutputFilesAnnotation(td,of) => (td, of) }
+
     // Do actual work of this transform
-    val top=state.circuit.modules.collectFirst{case m: Module if m.name==state.circuit.main => m}.get
     val sources = getSourcesMap(state)
     val portnamesmap : mutable.Map[String,String] = mutable.Map()
     val instgraph = new firrtl.analyses.InstanceGraph(state.circuit)
-    val namespacemap = state.circuit.modules.map{ case m => (m.name -> Namespace(m)) }.toMap 
+    val namespacemap = state.circuit.modules.map{ case m => (m.name -> Namespace(m)) }.toMap
     val modulesx = state.circuit.modules map onModule(sources, portnamesmap, instgraph, namespacemap)
     val newCircuit = state.circuit.copy(modules = modulesx)
     val fixedCircuit = fixupCircuit(newCircuit)

--- a/src/main/scala/firrtl/transforms/TopWiring.scala
+++ b/src/main/scala/firrtl/transforms/TopWiring.scala
@@ -189,20 +189,6 @@ class TopWiringTransform extends Transform {
      state  
   }
 
-  def TopWiringTestOutputFilesFunction(dir: String, mapping: Seq[((ComponentName, Type, Boolean, InstPath, String), Int)], state: CircuitState): CircuitState = {
-     val testOutputFile = new PrintWriter(new File(dir, "TopWiringOutputTest.txt" )) 
-     mapping map {
-          case ((_, tpe, _, path,prefix), index) => {
-            val portwidth = tpe match { case GroundType(IntWidth(w)) => w }
-            val portnum = index
-            val portname = prefix + path.mkString("_")
-            testOutputFile.append(s"new top level port $portnum : $portname, with width $portwidth \n")
-          }
-     }
-     testOutputFile.close()
-     state 
-  }
-
 
   def execute(state: CircuitState): CircuitState = {
 

--- a/src/main/scala/firrtl/transforms/TopWiring.scala
+++ b/src/main/scala/firrtl/transforms/TopWiring.scala
@@ -1,0 +1,250 @@
+// See LICENSE for license details.
+package firrtl.transform
+package TopWiring
+
+import firrtl._
+import firrtl.ir._
+import firrtl.passes._
+import firrtl.annotations._
+import firrtl.Mappers._
+import firrtl.graph._
+
+import java.io._
+import scala.io.Source
+import collection.mutable
+
+import firrtl.passes.wiring._
+
+/** Annotation for optional output files **/
+case class TopWiringOutputFilesAnnotation(dirname: String, outputfunction: (String,String,Seq[((ComponentName, Type, Boolean, Seq[String]), Int)], CircuitState) => CircuitState) extends NoTargetAnnotation
+
+/** Annotation for a prefix that will be added to all the port names that are punched out to the top level **/
+case class TopWiringPrefixAnnotation(prefix: String) extends NoTargetAnnotation
+
+/** Annotation for indicating component to be wired */
+case class TopWiringAnnotation(target: ComponentName) extends
+    SingleTargetAnnotation[ComponentName] {
+  def duplicate(n: ComponentName) = this.copy(target = n)
+}
+
+
+
+/** Punch out annotated ports out to the toplevel of the circuit.
+    This also has an option to pass a function as a parmeter to generate custom output files as a result of the additional ports
+  * @note This *does* work for deduped modules
+  */
+
+class TopWiringTransform extends Transform {
+  def inputForm: CircuitForm = MidForm
+  def outputForm: CircuitForm = MidForm
+
+  type InstPath = Seq[String]
+ 
+  /** Get the names of the targets that need to be wired */
+
+  private def getSourceNames(state: CircuitState): Seq[ComponentName] = {
+    val annos = state.annotations.collect {
+      case a @ (_: TopWiringAnnotation) => a
+    }
+    annos match {
+      case p => p.map { case TopWiringAnnotation(srcname) => srcname }
+    }
+  }
+
+
+  private def getSourceModNames(state: CircuitState): Seq[String] = {
+    val annos = state.annotations.collect {
+      case a @ (_: TopWiringAnnotation) => a
+    }
+    annos match {
+      case p => p.map { case TopWiringAnnotation(ComponentName(_,ModuleName(srcmodname, _))) => srcmodname }
+    }
+  }
+
+
+
+  def getSourceTypes(sourceList: Seq[ComponentName], sourceMap: mutable.Map[String, Seq[(ComponentName, Type, Boolean, InstPath)]], currentmodule: ModuleName, state: CircuitState)(s: Statement): Statement = s match {
+    // If target wire, add name and size to to sourceMap
+    case w: IsDeclaration =>
+      if (sourceList.contains(ComponentName(w.name, currentmodule))) {
+          val (isport, tpe) = w match {
+            case d: DefWire => (false, d.tpe)
+            case d: DefNode => (false, d.value.tpe)
+            case d: DefRegister => (false, d.tpe)
+            case d: Port => (true, d.tpe)
+            case _ => sys.error(s"Cannot wire this type of declaration! ${w.serialize}")
+          }
+          val name = w.name
+          sourceMap.get(currentmodule.name) match {
+            case Some(xs:Seq[(ComponentName, Type, Boolean, InstPath)]) => sourceMap.update(currentmodule.name, xs :+ (ComponentName(w.name,currentmodule), tpe, isport ,Seq[String](w.name)))
+            case None => sourceMap(currentmodule.name) = Seq((ComponentName(w.name,currentmodule), tpe, isport ,Seq[String](w.name)))
+          }
+          //sourceMap(currentmodule.name) +: (ComponentName(w.name,currentmodule), tpe, isport ,Seq[String](currentmodule.name))
+      }
+      w // Return argument unchanged (ok because DefWire has no Statement children)
+    // If not, apply to all children Statement
+    case _ => s map getSourceTypes(sourceList, sourceMap, currentmodule, state)
+  }
+
+
+
+
+  def getSourceTypesPorts(sourceList: Seq[ComponentName], sourceMap: mutable.Map[String, Seq[(ComponentName, Type, Boolean, InstPath)]], currentmodule: ModuleName, state: CircuitState)(s: Port): CircuitState = s match {
+    // If target port, add name and size to to sourceMap
+    case w: IsDeclaration =>
+      if (sourceList.contains(ComponentName(w.name, currentmodule))) {
+          val (isport, tpe) = w match {
+            case d: Port => (true, d.tpe)
+            case _ => sys.error(s"Cannot wire this type of declaration! ${w.serialize}")
+          }
+          val name = w.name
+          sourceMap.get(currentmodule.name) match {
+            case Some(xs:Seq[(ComponentName, Type, Boolean, InstPath)]) => sourceMap.update(currentmodule.name, xs :+ (ComponentName(w.name,currentmodule), tpe, isport ,Seq[String](w.name)))
+            case None => sourceMap(currentmodule.name) = Seq((ComponentName(w.name,currentmodule), tpe, isport ,Seq[String](w.name)))
+          }
+          //sourceMap(currentmodule.name) +: (ComponentName(w.name,currentmodule), tpe, isport ,Seq[String](currentmodule.name))
+      }
+      state // Return argument unchanged (ok because DefWire has no Statement children)
+    // If not, apply to all children Statement
+    case _ => state
+  }
+
+
+
+
+
+
+
+  /** Create a map of Module name to target wires under this module
+    *
+    * These paths are relative but cross module (they refer down through instance hierarchy)
+    */
+  private def getSourcesMap(state: CircuitState): Map[String, Seq[(ComponentName, Type, Boolean, InstPath)]] = {
+    val sSourcesModNames = getSourceModNames(state)
+    val sSourcesNames = getSourceNames(state)
+     
+
+    val cMap = WiringUtils.getChildrenMap(state.circuit).toMap
+    //val digraph = DiGraph(cMap.mapValues(v => v.map(_._2).toSet))
+    //val topSort = digraph.linearize.reverse
+    //previous 2 line replaced by the following single line
+    val topSort = (new firrtl.analyses.InstanceGraph(state.circuit)).moduleOrder.reverse
+
+    // Map of component name to relative instance paths that result in a debug wire
+    val sourcemods: mutable.Map[String, Seq[(ComponentName, Type, Boolean, InstPath)]] =
+      mutable.Map(sSourcesModNames.map(_ -> Seq()): _*)
+      //mutable.Map(sSourcesModNames.map(_ -> Seq(ComponentName,UnknownType,false,Seq[String]())): _*)
+
+    state.circuit.modules.foreach { m => m map getSourceTypes(sSourcesNames, sourcemods, ModuleName(m.name, CircuitName(state.circuit.main)) , state) }
+    state.circuit.modules.foreach { m => m.ports.foreach { p => Seq(p) map getSourceTypesPorts(sSourcesNames, sourcemods, ModuleName(m.name, CircuitName(state.circuit.main)) , state) }}
+
+    // TODO make this code more clear
+    for (mod <- topSort) {
+      val seqChildren: Seq[(ComponentName,Type,Boolean,InstPath)] = cMap(mod.name).flatMap { case (inst, module) => 
+        sourcemods.get(module).map( _.map { case (a,b,c,path) => (a,b,c, inst +: path)})
+      }.flatten
+      if (seqChildren.nonEmpty) {
+        sourcemods(mod.name) = seqChildren
+      }
+    }
+
+    sourcemods.toMap
+  }
+
+
+
+  /** Process a given DefModule
+    *
+    * For Modules that contain or are in the parent hierarchy to modules containing SeqMems
+    * 1. Add ports for each SeqMem this module is parent to
+    * 2. Connect these ports to ports of instances that are parents to some number of SeqMems
+    */
+  // TODO Make code more clear
+  private def onModule(prefix: String, sources: Map[String, Seq[(ComponentName, Type, Boolean, InstPath)]])
+                      (module: DefModule): DefModule = {
+    sources.get(module.name) match {
+      case Some(p) => 
+        val newPorts = p.map{ case (ComponentName(cname,_), tpe, _ , path) => Port(NoInfo, prefix + path.mkString("_"), Output, tpe)}
+        
+
+        // Add connections to Module
+        module match {
+          case m: Module =>
+            val connections: Seq[Connect] = p.map { case (ComponentName(cname,_), _, _ , path) =>
+                val modRef = WRef(prefix + path.mkString("_"))
+                path.size match {
+                   case 1 => {
+                       val leafRef = WRef(path.head.mkString("_"))
+                       Connect(NoInfo, modRef, leafRef)
+                   }
+                   case _ =>  {
+                       val instRef = WSubField(WRef(path.head), prefix + path.tail.mkString("_"))
+                       Connect(NoInfo, modRef, instRef)
+                  }
+                }
+            } 
+            m.copy(ports = m.ports ++ newPorts, body = Block(Seq(m.body) ++ connections ))
+          case e: ExtModule =>
+            e.copy(ports = e.ports ++ newPorts)
+      }
+      case None => module // unchanged if no paths
+    }
+  }
+
+  private def fixupCircuit(circuit: Circuit): Circuit = {
+    val passes = Seq(
+      InferTypes,
+      ResolveKinds,
+      ResolveGenders
+    )
+    passes.foldLeft(circuit) { case (c: Circuit, p: Pass) => p.run(c) }
+  }
+
+
+  def TopWiringDummyOutputFilesFunction(prefix: String, dir: String, mapping: Seq[((ComponentName, Type, Boolean, InstPath), Int)], state: CircuitState): CircuitState = {
+     state  
+  }
+
+  def TopWiringTestOutputFilesFunction(prefix: String, dir: String, mapping: Seq[((ComponentName, Type, Boolean, InstPath), Int)], state: CircuitState): CircuitState = {
+     val testOutputFile = new PrintWriter(new File(dir, "TopWiringOutputTest.txt" )) 
+     mapping map {
+          case ((_, tpe, _, path), index) => {
+            val portwidth = tpe match { case GroundType(IntWidth(w)) => w }
+            val portnum = index
+            val portname = prefix + path.mkString("_")
+            testOutputFile.append(s"new top level port $portnum : $portname, with width $portwidth \n")
+          }
+     }
+     testOutputFile.close()
+     state 
+  }
+
+
+  def execute(state: CircuitState): CircuitState = {
+
+    lazy val outputTuple: Option[(String, (String,String,Seq[((ComponentName, Type, Boolean, InstPath), Int)], CircuitState) => CircuitState)] = state.annotations.collectFirst { case TopWiringOutputFilesAnnotation(td,of) => (td, of) }
+    lazy val prfix: Option[String] = state.annotations.collectFirst { case TopWiringPrefixAnnotation(pr) => pr }
+    
+    prfix match {
+      case Some(prefix) =>
+        // Do actual work of this transform
+        val sources = getSourcesMap(state)
+        //val prefix = s"topwiring_"
+        val modulesx = state.circuit.modules map onModule(prefix,sources)
+        val newCircuit = state.circuit.copy(modules = modulesx)
+        val fixedCircuit = fixupCircuit(newCircuit)
+        val mappings = sources(state.circuit.main).zipWithIndex
+        //Generate output files based on the mapping.
+        outputTuple match {
+          case Some((dir, outputfunction)) =>
+             outputfunction(prefix, dir, mappings, state)
+          case None => state 
+        }
+        // fin.
+        state.copy(circuit = fixedCircuit)
+      case None => // Don't run pass
+        throw new Exception("TopWiringAnnotation is specified so the transform should run, " +
+                            "but no prefix was found, so wiring naming collisions may occur")
+    }
+  }
+}

--- a/src/test/scala/firrtlTests/transforms/TopWiringTest.scala
+++ b/src/test/scala/firrtlTests/transforms/TopWiringTest.scala
@@ -28,14 +28,14 @@ import firrtl.transform.TopWiring._
  */
 class TopWiringTests extends LowTransformSpec {
 
-   def TopWiringDummyOutputFilesFunction(prefix: String, dir: String, mapping: Seq[((ComponentName, Type, Boolean, Seq[String]), Int)], state: CircuitState): CircuitState = {
+   def TopWiringDummyOutputFilesFunction(dir: String, mapping: Seq[((ComponentName, Type, Boolean, Seq[String], String), Int)], state: CircuitState): CircuitState = {
      state
    }
 
-   def TopWiringTestOutputFilesFunction(prefix: String, dir: String, mapping: Seq[((ComponentName, Type, Boolean, Seq[String]), Int)], state: CircuitState): CircuitState = {
+   def TopWiringTestOutputFilesFunction(dir: String, mapping: Seq[((ComponentName, Type, Boolean, Seq[String], String), Int)], state: CircuitState): CircuitState = {
      val testOutputFile = new PrintWriter(new File(dir, "TopWiringOutputTest.txt" ))
      mapping map {
-          case ((_, tpe, _, path), index) => {
+          case ((_, tpe, _, path, prefix), index) => {
             val portwidth = tpe match { case GroundType(IntWidth(w)) => w }
             val portnum = index
             val portname = prefix + path.mkString("_")
@@ -68,8 +68,7 @@ class TopWiringTests extends LowTransformSpec {
            |    output x: UInt<1>
            |    x <= UInt(0)
            """.stripMargin
-      val topwiringannos = Seq(TopWiringAnnotation(ComponentName(s"x", ModuleName(s"C", CircuitName(s"Top")))),
-                         TopWiringPrefixAnnotation(s"topwiring_"),
+      val topwiringannos = Seq(TopWiringAnnotation(ComponentName(s"x", ModuleName(s"C", CircuitName(s"Top"))), s"topwiring_"),
                          TopWiringOutputFilesAnnotation(s"/tmp", TopWiringTestOutputFilesFunction)) 
       val check =
          """circuit Top :
@@ -124,8 +123,7 @@ class TopWiringTests extends LowTransformSpec {
            |    output x: UInt<1>
            |    x <= UInt(0)
            """.stripMargin
-      val topwiringannos = Seq(TopWiringAnnotation(ComponentName(s"x", ModuleName(s"C", CircuitName(s"Top")))),
-                         TopWiringPrefixAnnotation(s"topwiring_"),
+      val topwiringannos = Seq(TopWiringAnnotation(ComponentName(s"x", ModuleName(s"C", CircuitName(s"Top"))), s"topwiring_"),
                          TopWiringOutputFilesAnnotation(s"/tmp", TopWiringTestOutputFilesFunction))
       val check =
          """circuit Top :

--- a/src/test/scala/firrtlTests/transforms/TopWiringTest.scala
+++ b/src/test/scala/firrtlTests/transforms/TopWiringTest.scala
@@ -222,4 +222,57 @@ class TopWiringTests extends LowTransformSpec {
            """.stripMargin
       execute(input, check, topwiringannos)
    }
+
+   "The signal x in module C" should "be connected to Top port with topwiring prefix and no output function" in {
+      val input =
+         """circuit Top :
+           |  module Top :
+           |    inst a1 of A
+           |    inst a2 of A_
+           |  module A :
+           |    output x: UInt<1>
+           |    x <= UInt(1)
+           |    inst b1 of B
+           |  module A_ :
+           |    output x: UInt<1>
+           |    x <= UInt(1)
+           |  module B :
+           |    output x: UInt<1>
+           |    x <= UInt(1)
+           |    inst c1 of C
+           |  module C:
+           |    output x: UInt<1>
+           |    x <= UInt(0)
+           """.stripMargin
+      val topwiringannos = Seq(TopWiringAnnotation(ComponentName(s"x", ModuleName(s"C", CircuitName(s"Top"))), s"topwiring_"))
+      val check =
+         """circuit Top :
+           |  module Top :
+           |    output topwiring_a1_b1_c1_x: UInt<1>
+           |    inst a1 of A
+           |    inst a2 of A_
+           |    topwiring_a1_b1_c1_x <= a1.topwiring_b1_c1_x
+           |  module A :
+           |    output x: UInt<1>
+           |    output topwiring_b1_c1_x: UInt<1>
+           |    inst b1 of B
+           |    x <= UInt(1)
+           |    topwiring_b1_c1_x <= b1.topwiring_c1_x
+           |  module A_ :
+	   |    output x: UInt<1>
+           |    x <= UInt(1)
+           |  module B :
+           |    output x: UInt<1>
+           |    output topwiring_c1_x: UInt<1>
+           |    inst c1 of C
+           |    x <= UInt(1)
+           |    topwiring_c1_x <= c1.topwiring_x
+           |  module C:
+           |    output x: UInt<1>
+           |    output topwiring_x: UInt<1>
+           |    x <= UInt(0)
+           |    topwiring_x <= x
+           """.stripMargin
+      execute(input, check, topwiringannos)
+   }
 }

--- a/src/test/scala/firrtlTests/transforms/TopWiringTest.scala
+++ b/src/test/scala/firrtlTests/transforms/TopWiringTest.scala
@@ -28,11 +28,15 @@ import firrtl.transform.TopWiring._
  */
 class TopWiringTests extends LowTransformSpec {
 
-   def TopWiringDummyOutputFilesFunction(dir: String, mapping: Seq[((ComponentName, Type, Boolean, Seq[String], String), Int)], state: CircuitState): CircuitState = {
+   def topWiringDummyOutputFilesFunction(dir: String, 
+                                         mapping: Seq[((ComponentName, Type, Boolean, Seq[String], String), Int)], 
+                                         state: CircuitState): CircuitState = {
      state
    }
 
-   def TopWiringTestOutputFilesFunction(dir: String, mapping: Seq[((ComponentName, Type, Boolean, Seq[String], String), Int)], state: CircuitState): CircuitState = {
+   def topWiringTestOutputFilesFunction(dir: String, 
+                                        mapping: Seq[((ComponentName, Type, Boolean, Seq[String], String), Int)], 
+                                        state: CircuitState): CircuitState = {
      val testOutputFile = new PrintWriter(new File(dir, "TopWiringOutputTest.txt" ))
      mapping map {
           case ((_, tpe, _, path, prefix), index) => {
@@ -68,8 +72,10 @@ class TopWiringTests extends LowTransformSpec {
            |    output x: UInt<1>
            |    x <= UInt(0)
            """.stripMargin
-      val topwiringannos = Seq(TopWiringAnnotation(ComponentName(s"x", ModuleName(s"C", CircuitName(s"Top"))), s"topwiring_"),
-                         TopWiringOutputFilesAnnotation(s"/tmp", TopWiringTestOutputFilesFunction)) 
+      val topwiringannos = Seq(TopWiringAnnotation(ComponentName(s"x", 
+                                                                 ModuleName(s"C", CircuitName(s"Top"))), 
+                                                   s"topwiring_"),
+                         TopWiringOutputFilesAnnotation(s"/tmp", topWiringTestOutputFilesFunction)) 
       val check =
          """circuit Top :
            |  module Top :
@@ -84,7 +90,7 @@ class TopWiringTests extends LowTransformSpec {
            |    x <= UInt(1)
            |    topwiring_b1_c1_x <= b1.topwiring_c1_x
            |  module A_ :
-	   |    output x: UInt<1>
+           |    output x: UInt<1>
            |    x <= UInt(1)
            |  module B :
            |    output x: UInt<1>
@@ -101,7 +107,8 @@ class TopWiringTests extends LowTransformSpec {
       execute(input, check, topwiringannos)
    }
 
-   "The signal x in module C inst c1 and c2" should "be connected to Top port with topwiring prefix and outfile in /tmp" in {
+   "The signal x in module C inst c1 and c2" should 
+    "be connected to Top port with topwiring prefix and outfile in /tmp" in {
       val input =
          """circuit Top :
            |  module Top :
@@ -123,8 +130,9 @@ class TopWiringTests extends LowTransformSpec {
            |    output x: UInt<1>
            |    x <= UInt(0)
            """.stripMargin
-      val topwiringannos = Seq(TopWiringAnnotation(ComponentName(s"x", ModuleName(s"C", CircuitName(s"Top"))), s"topwiring_"),
-                         TopWiringOutputFilesAnnotation(s"/tmp", TopWiringTestOutputFilesFunction))
+      val topwiringannos = Seq(TopWiringAnnotation(ComponentName(s"x",
+                                                    ModuleName(s"C", CircuitName(s"Top"))), s"topwiring_"),
+                               TopWiringOutputFilesAnnotation(s"/tmp", topWiringTestOutputFilesFunction))
       val check =
          """circuit Top :
            |  module Top :
@@ -163,7 +171,8 @@ class TopWiringTests extends LowTransformSpec {
       execute(input, check, topwiringannos)
    }
 
-   "The signal x in module C" should "be connected to Top port with topwiring prefix and outputfile in /tmp, after name colission" in {
+   "The signal x in module C" should 
+   "be connected to Top port with topwiring prefix and outputfile in /tmp, after name colission" in {
       val input =
          """circuit Top :
            |  module Top :
@@ -188,8 +197,10 @@ class TopWiringTests extends LowTransformSpec {
            |    output x: UInt<1>
            |    x <= UInt(0)
            """.stripMargin
-      val topwiringannos = Seq(TopWiringAnnotation(ComponentName(s"x", ModuleName(s"C", CircuitName(s"Top"))), s"topwiring_"),
-                         TopWiringOutputFilesAnnotation(s"/tmp", TopWiringTestOutputFilesFunction)) 
+      val topwiringannos = Seq(TopWiringAnnotation(ComponentName(s"x", 
+                                                                 ModuleName(s"C", CircuitName(s"Top"))), 
+                                                                 s"topwiring_"),
+                               TopWiringOutputFilesAnnotation(s"/tmp", topWiringTestOutputFilesFunction)) 
       val check =
          """circuit Top :
            |  module Top :
@@ -206,7 +217,7 @@ class TopWiringTests extends LowTransformSpec {
            |    x <= UInt(1)
            |    topwiring_b1_c1_x_0 <= b1.topwiring_c1_x
            |  module A_ :
-	   |    output x: UInt<1>
+           |    output x: UInt<1>
            |    x <= UInt(1)
            |  module B :
            |    output x: UInt<1>
@@ -223,7 +234,8 @@ class TopWiringTests extends LowTransformSpec {
       execute(input, check, topwiringannos)
    }
 
-   "The signal x in module C" should "be connected to Top port with topwiring prefix and no output function" in {
+   "The signal x in module C" should 
+   "be connected to Top port with topwiring prefix and no output function" in {
       val input =
          """circuit Top :
            |  module Top :
@@ -244,7 +256,9 @@ class TopWiringTests extends LowTransformSpec {
            |    output x: UInt<1>
            |    x <= UInt(0)
            """.stripMargin
-      val topwiringannos = Seq(TopWiringAnnotation(ComponentName(s"x", ModuleName(s"C", CircuitName(s"Top"))), s"topwiring_"))
+      val topwiringannos = Seq(TopWiringAnnotation(ComponentName(s"x", 
+                                                                 ModuleName(s"C", CircuitName(s"Top"))), 
+                                                   s"topwiring_"))
       val check =
          """circuit Top :
            |  module Top :
@@ -259,7 +273,7 @@ class TopWiringTests extends LowTransformSpec {
            |    x <= UInt(1)
            |    topwiring_b1_c1_x <= b1.topwiring_c1_x
            |  module A_ :
-	   |    output x: UInt<1>
+           |    output x: UInt<1>
            |    x <= UInt(1)
            |  module B :
            |    output x: UInt<1>
@@ -267,6 +281,156 @@ class TopWiringTests extends LowTransformSpec {
            |    inst c1 of C
            |    x <= UInt(1)
            |    topwiring_c1_x <= c1.topwiring_x
+           |  module C:
+           |    output x: UInt<1>
+           |    output topwiring_x: UInt<1>
+           |    x <= UInt(0)
+           |    topwiring_x <= x
+           """.stripMargin
+      execute(input, check, topwiringannos)
+   }
+
+   "The signal x in module C inst c1 and c2 and signal y in module A_" should 
+   "be connected to Top port with topwiring prefix and outfile in /tmp" in {
+      val input =
+         """circuit Top :
+           |  module Top :
+           |    inst a1 of A
+           |    inst a2 of A_
+           |  module A :
+           |    output x: UInt<1>
+           |    x <= UInt(1)
+           |    inst b1 of B
+           |  module A_ :
+           |    output x: UInt<1>
+           |    wire y : UInt<1>
+           |    y <= UInt(1)
+           |    x <= UInt(1)
+           |  module B :
+           |    output x: UInt<1>
+           |    x <= UInt(1)
+           |    inst c1 of C
+           |    inst c2 of C
+           |  module C:
+           |    output x: UInt<1>
+           |    x <= UInt(0)
+           """.stripMargin
+      val topwiringannos = Seq(TopWiringAnnotation(ComponentName(s"x", 
+                                                                 ModuleName(s"C", CircuitName(s"Top"))), 
+                                                   s"topwiring_"),
+                               TopWiringAnnotation(ComponentName(s"y", 
+                                                                 ModuleName(s"A_", CircuitName(s"Top"))), 
+                                                   s"topwiring_"),
+                         TopWiringOutputFilesAnnotation(s"/tmp", topWiringTestOutputFilesFunction))
+      val check =
+         """circuit Top :
+           |  module Top :
+           |    output topwiring_a1_b1_c1_x: UInt<1>
+           |    output topwiring_a1_b1_c2_x: UInt<1>
+           |    output topwiring_a2_y: UInt<1>
+           |    inst a1 of A
+           |    inst a2 of A_
+           |    topwiring_a1_b1_c1_x <= a1.topwiring_b1_c1_x
+           |    topwiring_a1_b1_c2_x <= a1.topwiring_b1_c2_x
+           |    topwiring_a2_y <= a2.topwiring_y
+           |  module A :
+           |    output x: UInt<1>
+           |    output topwiring_b1_c1_x: UInt<1>
+           |    output topwiring_b1_c2_x: UInt<1>
+           |    inst b1 of B
+           |    x <= UInt(1)
+           |    topwiring_b1_c1_x <= b1.topwiring_c1_x
+           |    topwiring_b1_c2_x <= b1.topwiring_c2_x
+           |  module A_ :
+           |    output x: UInt<1>
+           |    output topwiring_y: UInt<1>
+           |    node y = UInt<1>("h1")
+           |    x <= UInt(1)
+           |    topwiring_y <= y
+           |  module B :
+           |    output x: UInt<1>
+           |    output topwiring_c1_x: UInt<1>
+           |    output topwiring_c2_x: UInt<1>
+           |    inst c1 of C
+           |    inst c2 of C
+           |    x <= UInt(1)
+           |    topwiring_c1_x <= c1.topwiring_x
+           |    topwiring_c2_x <= c2.topwiring_x
+           |  module C:
+           |    output x: UInt<1>
+           |    output topwiring_x: UInt<1>
+           |    x <= UInt(0)
+           |    topwiring_x <= x
+           """.stripMargin
+      execute(input, check, topwiringannos)
+   }
+
+   "The signal x in module C inst c1 and c2 and signal y in module A_" should 
+   "be connected to Top port with topwiring and top2wiring prefix and outfile in /tmp" in {
+      val input =
+         """circuit Top :
+           |  module Top :
+           |    inst a1 of A
+           |    inst a2 of A_
+           |  module A :
+           |    output x: UInt<1>
+           |    x <= UInt(1)
+           |    inst b1 of B
+           |  module A_ :
+           |    output x: UInt<1>
+           |    wire y : UInt<1>
+           |    y <= UInt(1)
+           |    x <= UInt(1)
+           |  module B :
+           |    output x: UInt<1>
+           |    x <= UInt(1)
+           |    inst c1 of C
+           |    inst c2 of C
+           |  module C:
+           |    output x: UInt<1>
+           |    x <= UInt(0)
+           """.stripMargin
+      val topwiringannos = Seq(TopWiringAnnotation(ComponentName(s"x", 
+                                                                 ModuleName(s"C", CircuitName(s"Top"))), 
+                                                   s"topwiring_"),
+                               TopWiringAnnotation(ComponentName(s"y", 
+                                                                 ModuleName(s"A_", CircuitName(s"Top"))), 
+                                                   s"top2wiring_"),
+                         TopWiringOutputFilesAnnotation(s"/tmp", topWiringTestOutputFilesFunction))
+      val check =
+         """circuit Top :
+           |  module Top :
+           |    output topwiring_a1_b1_c1_x: UInt<1>
+           |    output topwiring_a1_b1_c2_x: UInt<1>
+           |    output top2wiring_a2_y: UInt<1>
+           |    inst a1 of A
+           |    inst a2 of A_
+           |    topwiring_a1_b1_c1_x <= a1.topwiring_b1_c1_x
+           |    topwiring_a1_b1_c2_x <= a1.topwiring_b1_c2_x
+           |    top2wiring_a2_y <= a2.top2wiring_y
+           |  module A :
+           |    output x: UInt<1>
+           |    output topwiring_b1_c1_x: UInt<1>
+           |    output topwiring_b1_c2_x: UInt<1>
+           |    inst b1 of B
+           |    x <= UInt(1)
+           |    topwiring_b1_c1_x <= b1.topwiring_c1_x
+           |    topwiring_b1_c2_x <= b1.topwiring_c2_x
+           |  module A_ :
+           |    output x: UInt<1>
+           |    output top2wiring_y: UInt<1>
+           |    node y = UInt<1>("h1")
+           |    x <= UInt(1)
+           |    top2wiring_y <= y
+           |  module B :
+           |    output x: UInt<1>
+           |    output topwiring_c1_x: UInt<1>
+           |    output topwiring_c2_x: UInt<1>
+           |    inst c1 of C
+           |    inst c2 of C
+           |    x <= UInt(1)
+           |    topwiring_c1_x <= c1.topwiring_x
+           |    topwiring_c2_x <= c2.topwiring_x
            |  module C:
            |    output x: UInt<1>
            |    output topwiring_x: UInt<1>

--- a/src/test/scala/firrtlTests/transforms/TopWiringTest.scala
+++ b/src/test/scala/firrtlTests/transforms/TopWiringTest.scala
@@ -1,0 +1,167 @@
+// See LICENSE for license details.
+
+package firrtlTests
+package transform
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+import org.scalatest.junit.JUnitRunner
+import scala.io.Source
+import java.io._
+
+import firrtl._
+import firrtl.ir.{Circuit, Type, GroundType, IntWidth}
+import firrtl.Parser
+import firrtl.passes.PassExceptions
+import firrtl.annotations.{
+   Named,
+   CircuitName,
+   ModuleName,
+   ComponentName,
+   Annotation
+}
+import firrtl.transform.TopWiring._
+
+
+/**
+ * Tests TopWiring transformation
+ */
+class TopWiringTests extends LowTransformSpec {
+
+   def TopWiringDummyOutputFilesFunction(prefix: String, dir: String, mapping: Seq[((ComponentName, Type, Boolean, Seq[String]), Int)], state: CircuitState): CircuitState = {
+     state
+   }
+
+   def TopWiringTestOutputFilesFunction(prefix: String, dir: String, mapping: Seq[((ComponentName, Type, Boolean, Seq[String]), Int)], state: CircuitState): CircuitState = {
+     val testOutputFile = new PrintWriter(new File(dir, "TopWiringOutputTest.txt" ))
+     mapping map {
+          case ((_, tpe, _, path), index) => {
+            val portwidth = tpe match { case GroundType(IntWidth(w)) => w }
+            val portnum = index
+            val portname = prefix + path.mkString("_")
+            testOutputFile.append(s"new top level port $portnum : $portname, with width $portwidth \n")
+          }
+     }
+     testOutputFile.close()
+     state
+   }
+
+   def transform = new TopWiringTransform
+   "The signal x in module C" should "be connected to Top port with topwiring prefix and outputfile in /tmp" in {
+      val input =
+         """circuit Top :
+           |  module Top :
+           |    inst a1 of A
+           |    inst a2 of A_
+           |  module A :
+           |    output x: UInt<1>
+           |    x <= UInt(1)
+           |    inst b1 of B
+           |  module A_ :
+           |    output x: UInt<1>
+           |    x <= UInt(1)
+           |  module B :
+           |    output x: UInt<1>
+           |    x <= UInt(1)
+           |    inst c1 of C
+           |  module C:
+           |    output x: UInt<1>
+           |    x <= UInt(0)
+           """.stripMargin
+      val topwiringannos = Seq(TopWiringAnnotation(ComponentName(s"x", ModuleName(s"C", CircuitName(s"Top")))),
+                         TopWiringPrefixAnnotation(s"topwiring_"),
+                         TopWiringOutputFilesAnnotation(s"/tmp", TopWiringTestOutputFilesFunction)) 
+      val check =
+         """circuit Top :
+           |  module Top :
+           |    output topwiring_a1_b1_c1_x: UInt<1>
+           |    inst a1 of A
+           |    inst a2 of A_
+           |    topwiring_a1_b1_c1_x <= a1.topwiring_b1_c1_x
+           |  module A :
+           |    output x: UInt<1>
+           |    output topwiring_b1_c1_x: UInt<1>
+           |    inst b1 of B
+           |    x <= UInt(1)
+           |    topwiring_b1_c1_x <= b1.topwiring_c1_x
+           |  module A_ :
+	   |    output x: UInt<1>
+           |    x <= UInt(1)
+           |  module B :
+           |    output x: UInt<1>
+           |    output topwiring_c1_x: UInt<1>
+           |    inst c1 of C
+           |    x <= UInt(1)
+           |    topwiring_c1_x <= c1.topwiring_x
+           |  module C:
+           |    output x: UInt<1>
+           |    output topwiring_x: UInt<1>
+           |    x <= UInt(0)
+           |    topwiring_x <= x
+           """.stripMargin
+      execute(input, check, topwiringannos)
+   }
+
+   "The signal x in module C inst c1 and c2" should "be connected to Top port with topwiring prefix and outfile in /tmp" in {
+      val input =
+         """circuit Top :
+           |  module Top :
+           |    inst a1 of A
+           |    inst a2 of A_
+           |  module A :
+           |    output x: UInt<1>
+           |    x <= UInt(1)
+           |    inst b1 of B
+           |  module A_ :
+           |    output x: UInt<1>
+           |    x <= UInt(1)
+           |  module B :
+           |    output x: UInt<1>
+           |    x <= UInt(1)
+           |    inst c1 of C
+           |    inst c2 of C
+           |  module C:
+           |    output x: UInt<1>
+           |    x <= UInt(0)
+           """.stripMargin
+      val topwiringannos = Seq(TopWiringAnnotation(ComponentName(s"x", ModuleName(s"C", CircuitName(s"Top")))),
+                         TopWiringPrefixAnnotation(s"topwiring_"),
+                         TopWiringOutputFilesAnnotation(s"/tmp", TopWiringTestOutputFilesFunction))
+      val check =
+         """circuit Top :
+           |  module Top :
+           |    output topwiring_a1_b1_c1_x: UInt<1>
+           |    output topwiring_a1_b1_c2_x: UInt<1>
+           |    inst a1 of A
+           |    inst a2 of A_
+           |    topwiring_a1_b1_c1_x <= a1.topwiring_b1_c1_x
+           |    topwiring_a1_b1_c2_x <= a1.topwiring_b1_c2_x
+           |  module A :
+           |    output x: UInt<1>
+           |    output topwiring_b1_c1_x: UInt<1>
+           |    output topwiring_b1_c2_x: UInt<1>
+           |    inst b1 of B
+           |    x <= UInt(1)
+           |    topwiring_b1_c1_x <= b1.topwiring_c1_x
+           |    topwiring_b1_c2_x <= b1.topwiring_c2_x
+           |  module A_ :
+           |    output x: UInt<1>
+           |    x <= UInt(1)
+           |  module B :
+           |    output x: UInt<1>
+           |    output topwiring_c1_x: UInt<1>
+           |    output topwiring_c2_x: UInt<1>
+           |    inst c1 of C
+           |    inst c2 of C
+           |    x <= UInt(1)
+           |    topwiring_c1_x <= c1.topwiring_x
+           |    topwiring_c2_x <= c2.topwiring_x
+           |  module C:
+           |    output x: UInt<1>
+           |    output topwiring_x: UInt<1>
+           |    x <= UInt(0)
+           |    topwiring_x <= x
+           """.stripMargin
+      execute(input, check, topwiringannos)
+   }
+}


### PR DESCRIPTION
A transform that punches out annotated wires hierarchically to the top level. This transform is complimentary to wiring utils, since it handles the case of punching out through multiple instantiations of modules.
The transform takes in target wires through annotations, and a prefix annotation to determine the name of the new top-level ports.
The transform can also take in an optional function parameter (through an annotation) to generate custom output files based on the new ports that were punched out (useful for future features).
@azidar @jackkoenig 