### PR TITLE
Enable top ports for singly-instantiated sources in WiringTransform 

### DIFF
--- a/src/main/scala/firrtl/passes/wiring/Wiring.scala
+++ b/src/main/scala/firrtl/passes/wiring/Wiring.scala
@@ -107,16 +107,17 @@ class Wiring(wiSeq: Seq[WiringInfo]) extends Pass {
         // Case where the sink is the LCA
         case Seq(WDefInstance(_,_,pm,_)) =>
           // Case where the source is also the LCA
+          val tpe = if (sinkComponents.contains(pm)) DecWire else DecOutput
           if (source.drop(lca.size).isEmpty) {
             meta(pm) = meta(pm).copy (
-              addPortOrWire = Some((portNames(pm), DecWire))
+              addPortOrWire = Some((portNames(pm), tpe))
             )
           } else {
             val WDefInstance(_,ci,cm,_) = source.drop(lca.size).head
             val to = s"${portNames(pm)}"
             val from = s"$ci.${portNames(cm)}"
             meta(pm) = meta(pm).copy(
-              addPortOrWire = Some((portNames(pm), DecWire)),
+              addPortOrWire = Some((portNames(pm), tpe)),
               cons = (meta(pm).cons :+ (to, from)).distinct
             )
           }
@@ -182,9 +183,8 @@ class Wiring(wiSeq: Seq[WiringInfo]) extends Pass {
         val defines = mutable.ArrayBuffer[Statement]()
         val connects = mutable.ArrayBuffer[Statement]()
         val ports = mutable.ArrayBuffer[Port]()
-        l.addPortOrWire match {
-          case None =>
-          case Some((s, dt)) => dt match {
+        l.addPortOrWire.foreach{ case (s, dt) =>
+          dt match {
             case DecInput  => ports += Port(NoInfo, s, Input, t)
             case DecOutput => ports += Port(NoInfo, s, Output, t)
             case DecWire   => defines += DefWire(NoInfo, s, t)


### PR DESCRIPTION
Practically, this enables functionality in the WiringTransform to wire signals all the way to the top. 

If the sink module is the lowest common ancestor, then the type of connection (a wire or a port) is a function of whether or not we're wiring to a component or a module. If the later, then the implied functionality is that we want a port on this module. This already happens when the sink module is not the LCA, but not for this case.

While not explicitly enabling blind "wire this signal to the top", this should provide the functionality for it.

@alonamid: I _think_ that this will give you all the functionality you need for your top annotations. I'm hoping that this will enable not having to maintain two wiring transforms.

See: https://github.com/freechipsproject/firrtl/pull/798