### PR TITLE
Bugfix: ports of a temporary name would break const-prop

### DIFF
--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -347,7 +347,7 @@ class ConstantPropagation extends Transform {
     // When propagating a reference, check if we want to keep the name that would be deleted
     def propagateRef(lname: String, value: Expression): Unit = {
       value match {
-        case WRef(rname,_,_,_) if betterName(lname, rname) && !swapMap.contains(rname) =>
+        case WRef(rname,_,kind,_) if betterName(lname, rname) && !swapMap.contains(rname) && kind != PortKind =>
           assert(!swapMap.contains(lname)) // <- Shouldn't be possible because lname is either a
           // node declaration or the single connection to a wire or register
           swapMap += (lname -> rname, rname -> lname)

--- a/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+++ b/src/test/scala/firrtlTests/ConstantPropagationTests.scala
@@ -1030,4 +1030,21 @@ class ConstantPropagationIntegrationSpec extends LowTransformSpec {
           |""".stripMargin
     execute(input, check, Seq.empty)
   }
+
+  "Temporary named port" should "not be declared as a node" in {
+    val input =
+      """circuit Top :
+        |  module Top :
+        |    input _T_61 : UInt<1>
+        |    output z : UInt<1>
+        |    node a = _T_61
+        |    z <= a""".stripMargin
+    val check =
+      """circuit Top :
+        |  module Top :
+        |    input _T_61 : UInt<1>
+        |    output z : UInt<1>
+        |    z <= _T_61""".stripMargin
+    execute(input, check, Seq.empty)
+  }
 }


### PR DESCRIPTION
Sort of funny bug, but it ended up producing incorrect Verilog. ConstProp was assuming ports would never have a temporary-like name, and so was freely swapping names to find the best for constant propagation.

Bug:
```
input _T_61 : UInt<1>
node a = _T_61
out <= a
```
would constant prop to:
```
input _T_61 : UInt<1>
node _T_61 = a
out <= a
```