### PR TITLE
Change from Yosys 0.7 to master

### DIFF
--- a/.install_yosys.sh
+++ b/.install_yosys.sh
@@ -5,7 +5,7 @@ if [ ! -f $INSTALL_DIR/bin/yosys ]; then
   git clone https://github.com/cliffordwolf/yosys.git
   cd yosys
   git pull
-  git checkout yosys-0.7
+  git checkout master
   make
   make PREFIX=$INSTALL_DIR install
 fi


### PR DESCRIPTION
Yosys 0.7 build is broken because ABC moved repos and the link no longer
works

I cleared the Travis cache so that it would install the new version of Verilator, but Yosys no longer builds at the most recent release. This fixes that so that regressions will work again.