### PR TITLE
Add Circuit as option to FirrtlOptions

### DIFF
--- a/src/main/scala/firrtl/Driver.scala
+++ b/src/main/scala/firrtl/Driver.scala
@@ -158,14 +158,14 @@ object Driver {
   def getCircuit(optionsManager: ExecutionOptionsManager with HasFirrtlOptions): Try[ir.Circuit] = {
     val firrtlConfig = optionsManager.firrtlOptions
     Try {
-      // Check that only "override" is used
+      // Check that only one "override" is used
       val circuitSources = Map(
         "firrtlSource" -> firrtlConfig.firrtlSource.isDefined,
         "firrtlCircuit" -> firrtlConfig.firrtlCircuit.isDefined,
         "inputFileNameOverride" -> firrtlConfig.inputFileNameOverride.nonEmpty)
       if (circuitSources.values.count(x => x) > 1) {
         val msg = circuitSources.collect { case (s, true) => s }.mkString(" and ") +
-          "are set, only 1 can be set at a time!"
+          " are set, only 1 can be set at a time!"
         throw new OptionsException(msg)
       }
       firrtlConfig.firrtlCircuit.getOrElse {

--- a/src/main/scala/firrtl/Driver.scala
+++ b/src/main/scala/firrtl/Driver.scala
@@ -148,6 +148,54 @@ object Driver {
     LegacyAnnotation.convertLegacyAnnos(annos)
   }
 
+  // Useful for handling erros in the options
+  case class OptionsException(msg: String) extends Exception(msg)
+
+  /** Get the Circuit from the compile options
+    *
+    * Handles the myriad of ways it can be specified
+    */
+  def getCircuit(optionsManager: ExecutionOptionsManager with HasFirrtlOptions): Try[ir.Circuit] = {
+    val firrtlConfig = optionsManager.firrtlOptions
+    Try {
+      // Check that only "override" is used
+      val circuitSources = Map(
+        "firrtlSource" -> firrtlConfig.firrtlSource.isDefined,
+        "firrtlCircuit" -> firrtlConfig.firrtlCircuit.isDefined,
+        "inputFileNameOverride" -> firrtlConfig.inputFileNameOverride.nonEmpty)
+      if (circuitSources.values.count(x => x) > 1) {
+        val msg = circuitSources.collect { case (s, true) => s }.mkString(" and ") +
+          "are set, only 1 can be set at a time!"
+        throw new OptionsException(msg)
+      }
+      firrtlConfig.firrtlCircuit.getOrElse {
+        val source = firrtlConfig.firrtlSource.map(_.split("\n").toIterator).getOrElse {
+          if (optionsManager.topName.isEmpty && firrtlConfig.inputFileNameOverride.isEmpty) {
+            val message = "either top-name or input-file-override must be set"
+            throw new OptionsException(message)
+          }
+          if (
+            optionsManager.topName.isEmpty &&
+              firrtlConfig.inputFileNameOverride.nonEmpty &&
+              firrtlConfig.outputFileNameOverride.isEmpty) {
+            val message = "inputFileName set but neither top-name or output-file-override is set"
+            throw new OptionsException(message)
+          }
+          val inputFileName = firrtlConfig.getInputFileName(optionsManager)
+          try {
+            io.Source.fromFile(inputFileName).getLines()
+          }
+          catch {
+            case _: FileNotFoundException =>
+              val message = s"Input file $inputFileName not found"
+              throw new OptionsException(message)
+          }
+        }
+        Parser.parse(source, firrtlConfig.infoMode)
+      }
+    }
+  }
+
   /**
     * Run the firrtl compiler using the provided option
     *
@@ -160,49 +208,25 @@ object Driver {
     def firrtlConfig = optionsManager.firrtlOptions
 
     Logger.makeScope(optionsManager) {
-      val firrtlSource = firrtlConfig.firrtlSource match {
-        case Some(text) => text.split("\n").toIterator
-        case None =>
-          if (optionsManager.topName.isEmpty && firrtlConfig.inputFileNameOverride.isEmpty) {
-            val message = "either top-name or input-file-override must be set"
-            dramaticError(message)
-            return FirrtlExecutionFailure(message)
-          }
-          if (
-            optionsManager.topName.isEmpty &&
-              firrtlConfig.inputFileNameOverride.nonEmpty &&
-              firrtlConfig.outputFileNameOverride.isEmpty) {
-            val message = "inputFileName set but neither top-name or output-file-override is set"
-            dramaticError(message)
-            return FirrtlExecutionFailure(message)
-          }
-          val inputFileName = firrtlConfig.getInputFileName(optionsManager)
-          try {
-            io.Source.fromFile(inputFileName).getLines()
-          }
-          catch {
-            case _: FileNotFoundException =>
-              val message = s"Input file $inputFileName not found"
-              dramaticError(message)
-              return FirrtlExecutionFailure(message)
-          }
-      }
-
-      var maybeFinalState: Option[CircuitState] = None
-
       // Wrap compilation in a try/catch to present Scala MatchErrors in a more user-friendly format.
-      try {
-        val annos = getAnnotations(optionsManager)
+      val finalState = try {
+        val circuit = getCircuit(optionsManager) match {
+          case Success(c) => c
+          case Failure(OptionsException(msg)) =>
+            dramaticError(msg)
+            return FirrtlExecutionFailure(msg)
+          case Failure(e) => throw e
+        }
 
-        val parsedInput = Parser.parse(firrtlSource, firrtlConfig.infoMode)
+        val annos = getAnnotations(optionsManager)
 
         // Does this need to be before calling compiler?
         optionsManager.makeTargetDir()
 
-        maybeFinalState = Some(firrtlConfig.compiler.compile(
-          CircuitState(parsedInput, ChirrtlForm, annos),
+        firrtlConfig.compiler.compile(
+          CircuitState(circuit, ChirrtlForm, annos),
           firrtlConfig.customTransforms
-        ))
+        )
       }
       catch {
         // Rethrow the exceptions which are expected or due to the runtime environment (out of memory, stack overflow)
@@ -212,8 +236,6 @@ object Driver {
         // Treat remaining exceptions as internal errors.
         case e: Exception => throwInternalError(exception = Some(e))
       }
-
-      val finalState = maybeFinalState.get
 
       // Do emission
       // Note: Single emission target assumption is baked in here

--- a/src/main/scala/firrtl/ExecutionOptionsManager.scala
+++ b/src/main/scala/firrtl/ExecutionOptionsManager.scala
@@ -4,6 +4,7 @@ package firrtl
 
 import firrtl.annotations._
 import firrtl.Parser._
+import firrtl.ir.Circuit
 import firrtl.passes.memlib.{InferReadWriteAnnotation, ReplSeqMemAnnotation}
 import firrtl.passes.clocklist.ClockListAnnotation
 import logger.LogLevel
@@ -184,7 +185,8 @@ case class FirrtlExecutionOptions(
     emitOneFilePerModule:   Boolean = false,
     dontCheckCombLoops:     Boolean = false,
     noDCE:                  Boolean = false,
-    annotationFileNames:    List[String] = List.empty)
+    annotationFileNames:    List[String] = List.empty,
+    firrtlCircuit:          Option[Circuit] = None)
 extends ComposableOptions {
 
   require(!(emitOneFilePerModule && outputFileNameOverride.nonEmpty),


### PR DESCRIPTION
This allows providing the circuit as an option FIRRTL rather than having to parse. This will enable direct Chisel IR -> CHIRRTL in memory to bypass the ANTLR parser which has terrible memory use on large designs.

This does have a minor API change in that it firrtlSource would just silently override inputFileNameOverride and here I made that an error, so I'm not sure if it can be in 1.1.1. I'm also wondering if functions like `getCircuit` and `getAnnotations` should be defined on the FirrtlOptions? I'm not sure how this relates to https://github.com/freechipsproject/firrtl/pull/765, thoughts @seldridge?