### PR TITLE
Fix pad

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -264,7 +264,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
        case Pad =>
          val w = bitWidth(a0.tpe)
          val diff = c0 - w
-         if (w == BigInt(0)) Seq(a0)
+         if (w == BigInt(0) || diff <= 0) Seq(a0)
          else doprim.tpe match {
            // Either sign extend or zero extend.
            // If width == BigInt(1), don't extract bit

--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -212,7 +212,7 @@ class ConstantPropagation extends Transform {
     case Pad => e.args.head match {
       case UIntLiteral(v, IntWidth(w)) => UIntLiteral(v, IntWidth(e.consts.head max w))
       case SIntLiteral(v, IntWidth(w)) => SIntLiteral(v, IntWidth(e.consts.head max w))
-      case _ if bitWidth(e.args.head.tpe) == e.consts.head => e.args.head
+      case _ if bitWidth(e.args.head.tpe) >= e.consts.head => e.args.head
       case _ => e
     }
     case Bits => e.args.head match {

--- a/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+++ b/src/test/scala/firrtlTests/ConstantPropagationTests.scala
@@ -893,6 +893,23 @@ class ConstantPropagationIntegrationSpec extends LowTransformSpec {
     execute(input, check, Seq.empty)
   }
 
+  it should "remove pads if the width is <= the width of the argument" in {
+    def input(w: Int) =
+     s"""circuit Top :
+        |  module Top :
+        |    input x : UInt<8>
+        |    output z : UInt<8>
+        |    z <= pad(x, $w)""".stripMargin
+    val check =
+      """circuit Top :
+        |  module Top :
+        |    input x : UInt<8>
+        |    output z : UInt<8>
+        |    z <= x""".stripMargin
+    execute(input(6), check, Seq.empty)
+    execute(input(8), check, Seq.empty)
+  }
+
 
   "Registers with no reset or connections" should "be replaced with constant zero" in {
       val input =


### PR DESCRIPTION
Previously, FIRRTL does the wrong thing if you pad something to an amount less than the width of the arg. It tries to negative pad the argument in the emitted Verilog, but that's really just padding with a negative number. I believe this is merely a linting issue given that we emit simple expressions, but if we ever do emit complex expressions it could actually result in weird Verilog width inferencing and potentially incorrect Verilog (esp. on SInts where it's negating the the padded sign bit).

In any case, I fixed this in two places. 1. The Verilog Emitter because this is legal FIRRTL so the emitter should do the right thing and 2. ConstantPropagation since these PrimOps might as well be dropped.

There are tests for both.