### PR TITLE
Attach through wire

### DIFF
--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -397,7 +397,7 @@ class ConstantPropagation extends Transform {
         case Connect(info, lhs, rref @ WRef(rname, _, NodeKind, _)) if !dontTouches.contains(rname) =>
           Connect(info, lhs, nodeMap(rname))
         // If an Attach has at least 1 port, any wires are redundant and can be removed
-        case Attach(info, exprs) if exprs.map(kind(_)).contains(PortKind) =>
+        case Attach(info, exprs) if exprs.exists(kind(_) == PortKind) =>
           Attach(info, exprs.filterNot(kind(_) == WireKind))
         case other => other
       }

--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -396,6 +396,9 @@ class ConstantPropagation extends Transform {
         // Propagate connections to references
         case Connect(info, lhs, rref @ WRef(rname, _, NodeKind, _)) if !dontTouches.contains(rname) =>
           Connect(info, lhs, nodeMap(rname))
+        // If an Attach has at least 1 port, any wires are redundant and can be removed
+        case Attach(info, exprs) if exprs.map(kind(_)).contains(PortKind) =>
+          Attach(info, exprs.filterNot(kind(_) == WireKind))
         case other => other
       }
     }


### PR DESCRIPTION
This change enables the pattern of attaching a module port to an instance port via a wire, eg.
```scala
attach(io.analog, analogWire)
attach(analogWire, io.analog)
```
(You can also use bulk connects)

While this "works" before this PR, it emits Verilog that does not work in Verilator. By constant propagating the wire away, we can emit Verilog like that shown in the test.