### PR TITLE
Improve Parser and Visitor

### DIFF
--- a/src/main/scala/firrtl/Driver.scala
+++ b/src/main/scala/firrtl/Driver.scala
@@ -169,7 +169,7 @@ object Driver {
         throw new OptionsException(msg)
       }
       firrtlConfig.firrtlCircuit.getOrElse {
-        val source = firrtlConfig.firrtlSource.map(_.split("\n").toIterator).getOrElse {
+        firrtlConfig.firrtlSource.map(x => Parser.parseString(x, firrtlConfig.infoMode)).getOrElse {
           if (optionsManager.topName.isEmpty && firrtlConfig.inputFileNameOverride.isEmpty) {
             val message = "either top-name or input-file-override must be set"
             throw new OptionsException(message)
@@ -183,7 +183,7 @@ object Driver {
           }
           val inputFileName = firrtlConfig.getInputFileName(optionsManager)
           try {
-            io.Source.fromFile(inputFileName).getLines()
+            Parser.parseFile(inputFileName, firrtlConfig.infoMode)
           }
           catch {
             case _: FileNotFoundException =>
@@ -191,7 +191,6 @@ object Driver {
               throw new OptionsException(message)
           }
         }
-        Parser.parse(source, firrtlConfig.infoMode)
       }
     }
   }

--- a/src/main/scala/firrtl/Visitor.scala
+++ b/src/main/scala/firrtl/Visitor.scala
@@ -144,10 +144,10 @@ class Visitor(infoMode: InfoMode) extends FIRRTLBaseVisitor[FirrtlNode] {
   }
 
   private def visitBlock[FirrtlNode](ctx: FIRRTLParser.ModuleBlockContext): Statement =
-    Block(ctx.simple_stmt().asScala.map(_.stmt).filter(_ != null).map(visitStmt))
+    Block(ctx.simple_stmt().asScala.flatMap(x => Option(x.stmt).map(visitStmt)))
 
   private def visitSuite[FirrtlNode](ctx: FIRRTLParser.SuiteContext): Statement =
-    Block(ctx.simple_stmt().asScala.map(_.stmt).filter(_ != null).map(visitStmt))
+    Block(ctx.simple_stmt().asScala.flatMap(x => Option(x.stmt).map(visitStmt)))
 
 
   // Memories are fairly complicated to translate thus have a dedicated method


### PR DESCRIPTION
These changes are relatively minor but do give some performance and memory improvements.

Summary of Changes
* Switch from deprecated `ANTLRInputStream` to antlr `CharStreams` approach
* Add new Parser functions that eliminate unnecessary copying of input
* Remove unnecessary traversals when transforming ANTLR CST to FIRRTL AST in the Visitor

For a ~700 MB input .fir file, this improves ANTLR parsing time from ~78s to ~52s and Visiting time from ~62s to ~54s. Modest but real improvements. The size of the ANTLR CST remains around ~36GB so while this helps reduce unnecessary object creation, the fundamental motivation for https://github.com/freechipsproject/chisel3/pull/829 remains