### PR TITLE
Allow escaped single quotes in RawParams

### DIFF
--- a/src/main/antlr4/FIRRTL.g4
+++ b/src/main/antlr4/FIRRTL.g4
@@ -324,7 +324,7 @@ RawString
 
 fragment
 UnquotedString
-  : ('\\"'|~[\r\n])+?
+  : ( '\\\'' | '\\"' | ~[\r\n] )+?
   ;
 
 FileInfo

--- a/src/main/scala/firrtl/Visitor.scala
+++ b/src/main/scala/firrtl/Visitor.scala
@@ -92,7 +92,7 @@ class Visitor(infoMode: InfoMode) extends FIRRTLBaseVisitor[FirrtlNode] {
       case (int, null, null, null) => IntParam(name, string2BigInt(int.getText))
       case (null, str, null, null) => StringParam(name, visitStringLit(str))
       case (null, null, dbl, null) => DoubleParam(name, dbl.getText.toDouble)
-      case (null, null, null, raw) => RawStringParam(name, raw.getText.tail.init) // Remove "\'"s
+      case (null, null, null, raw) => RawStringParam(name, raw.getText.tail.init.replace("\\'", "'")) // Remove "\'"s
       case _ => throwInternalError(s"visiting impossible parameter ${ctx.getText}")
     }
   }

--- a/src/main/scala/firrtl/ir/IR.scala
+++ b/src/main/scala/firrtl/ir/IR.scala
@@ -518,7 +518,7 @@ case class StringParam(name: String, value: StringLit) extends Param {
   * @note Firrtl doesn't guarantee anything about this String being legal in any backend
   */
 case class RawStringParam(name: String, value: String) extends Param {
-  override def serialize: String = super.serialize + s"'$value'"
+  override def serialize: String = super.serialize + s"'${value.replace("'", "\\'")}'"
 }
 
 /** Base class for modules */

--- a/src/test/resources/blackboxes/ParameterizedExtModuleTester.fir
+++ b/src/test/resources/blackboxes/ParameterizedExtModuleTester.fir
@@ -15,7 +15,7 @@ circuit ParameterizedExtModuleTester :
     output bar : UInt<16>
 
     defname = ParameterizedExtModule
-    parameter VALUE = 2
+    parameter VALUE = '2\'d2'
     parameter STRING = "two"
     parameter REAL = 2.6E50
     parameter TYP = 'bit [1:0]'

--- a/src/test/scala/firrtlTests/ExtModuleTests.scala
+++ b/src/test/scala/firrtlTests/ExtModuleTests.scala
@@ -1,0 +1,27 @@
+// See LICENSE for license details.
+
+package firrtlTests
+
+import org.scalatest.Matchers
+import firrtl._
+
+class ExtModuleTests extends FirrtlFlatSpec {
+  "extmodule" should "serialize and re-parse equivalently" in {
+    val input =
+      """circuit Top :
+        |  extmodule Top :
+        |    input y : UInt<0>
+        |    output x : UInt<1>
+        |
+        |    defname = ParameterizedExtModule
+        |    parameter VALUE = 1
+        |    parameter VALUE2 = '2\'d2'
+        |    parameter STRING = "one"
+        |    parameter REAL = -1.7
+        |    parameter TYP = 'bit'
+        |    """.stripMargin
+    val parsed = parse(input)
+    (parse(parsed.serialize)) should be (parsed)
+  }
+}
+


### PR DESCRIPTION
If, for instance, your FPGA tools (COUGH iCEcube2 COUGH) happens to be inexplicably sensitive to the particular formatting of parameters, so you couldn't just plop down an IntParam and call it a day, but needed `6'b0110_01`. Or if you just wanted to pass through binary parameters from Chisel through FIRRTL without needing to convert them to hex or decimal, since Scala doesn't support binary literals.

The escaping framework isn't completely general (and I don't know if this is the right way), though it seems to be no worse than how `\"` is handled. (I know, really low bar, suggestions on how to improve are welcome though)

FIRRTL part of the fix for freechipsproject/chisel3#830