### PR TITLE
ucb-bar -> freechipsproject in clone instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ sbt assembly
 
 ##### Installation
  1. Clone the repository:
-    ```git clone https://github.com/ucb-bar/firrtl.git && cd firrtl```
+    ```git clone https://github.com/freechipsproject/firrtl.git && cd firrtl```
  1. Compile firrtl: ```sbt compile```
  1. Run tests: ```sbt test```
  1. Build executable (`utils/bin/firrtl`): ```sbt assembly```


### PR DESCRIPTION
Should be self explanatory, updates installation instructions to refer to what I think should be the canonical repository remote.