### PR TITLE
Bump ANTLR version and change directory to play nice with IntelliJ

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,9 @@ antlr4GenListener in Antlr4 := false // default = true
 
 antlr4PackageName in Antlr4 := Option("firrtl.antlr")
 
-antlr4Version in Antlr4 := "4.7"
+antlr4Version in Antlr4 := "4.7.1"
+
+javaSource in Antlr4 := (sourceManaged in Compile).value
 
 publishMavenStyle := true
 publishArtifact in Test := false


### PR DESCRIPTION
This changes where the ANTLR plugin emits the generated Java source which plays a little nicer with IntelliJ. With this change the steps I followed are:
`clone firrtl` (whether inside IntelliJ or not)
in the command line:
`sbt "antlr4:antlr4Generate"`
In IntelliJ build and do whatever you want!

I suspect the manual command to the `antlr4Generate` task is required with any changes to the grammar, but those are rare anyway.

Also bump ANTLR for good measure