### PR TITLE
Remove unneeded [String] argument to --infer-rw

### DIFF
--- a/src/main/scala/firrtl/ExecutionOptionsManager.scala
+++ b/src/main/scala/firrtl/ExecutionOptionsManager.scala
@@ -406,9 +406,8 @@ trait HasFirrtlOptions {
       """Inline one or more module (comma separated, no spaces) module looks like "MyModule" or "MyModule.myinstance"""
     }
 
-  parser.opt[String]("infer-rw")
+  parser.opt[Unit]("infer-rw")
     .abbr("firw")
-    .valueName ("<circuit>")
     .foreach { x =>
       firrtlOptions = firrtlOptions.copy(
         annotations = firrtlOptions.annotations :+ InferReadWriteAnnotation,
@@ -585,4 +584,3 @@ class ExecutionOptionsManager(val applicationName: String) extends HasParser(app
     s"$directoryName$baseName$normalizedSuffix"
   }
 }
-

--- a/src/test/scala/firrtlTests/DriverSpec.scala
+++ b/src/test/scala/firrtlTests/DriverSpec.scala
@@ -183,7 +183,7 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
         val optionsManager = new ExecutionOptionsManager("test") with HasFirrtlOptions
 
         optionsManager.parse(
-          Array("--infer-rw", "circuit")
+          Array("--infer-rw")
         ) should be(true)
 
         val firrtlOptions = optionsManager.firrtlOptions
@@ -334,7 +334,7 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
     val annoFile = new File(targetDir, "annotations.anno")
 
     optionsManager.parse(
-      Array("--infer-rw", "circuit", "-faf", annoFile.toString)
+      Array("--infer-rw", "-faf", annoFile.toString)
     ) should be(true)
 
     copyResourceToFile("/annotations/SampleAnnotations.anno.json", annoFile)


### PR DESCRIPTION
After the annotations refactor, `--infer-rw`/`-firw` no longer takes an argument. However, a vestigial `[String]` argument remained. This removes that.