### PR TITLE
Protobuf

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,6 +68,17 @@ libraryDependencies += "net.jcazevedo" %% "moultingyaml" % "0.4.0"
 
 libraryDependencies += "org.json4s" %% "json4s-native" % "3.5.3"
 
+// Java PB
+
+enablePlugins(ProtobufPlugin)
+
+sourceDirectory in ProtobufConfig := baseDirectory.value / "src" / "main" / "proto"
+
+protobufRunProtoc in ProtobufConfig := (args =>
+  com.github.os72.protocjar.Protoc.runProtoc("-v351" +: args.toArray))
+
+javaSource in ProtobufConfig := (sourceManaged in Compile).value
+
 // Assembly
 
 assemblyJarName in assembly := "firrtl.jar"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,3 +19,7 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 
 addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.1")
+
+addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.3")
+
+libraryDependencies += "com.github.os72" % "protoc-jar" % "3.5.1.1"

--- a/src/main/proto/firrtl.proto
+++ b/src/main/proto/firrtl.proto
@@ -34,6 +34,7 @@ message Firrtl {
     oneof source_info {
       None none = 1;
       Position position = 2;
+      string text = 3;
     }
   }
 

--- a/src/main/proto/firrtl.proto
+++ b/src/main/proto/firrtl.proto
@@ -38,6 +38,11 @@ message Firrtl {
     }
   }
 
+  message BigInt {
+    // 2's complement binary representation
+    bytes value = 1;
+  }
+
   message Top {
     // Required.
     string name = 1;
@@ -50,9 +55,20 @@ message Firrtl {
 
   message Module {
     message ExternalModule {
+      message Parameter {
+        string id = 1;
+        oneof value {
+          BigInt integer = 2;
+          double double = 3;
+          string string = 4;
+          string raw_string = 5;
+        }
+      }
       // Required.
       string id = 1;
       repeated Port port = 2;
+      string defined_name = 3;
+      repeated Parameter parameter = 4;
     }
 
     message UserModule {
@@ -199,6 +215,10 @@ message Firrtl {
       Expression expression = 5;
     }
 
+    message Attach {
+      repeated Expression expression = 1;
+    }
+
     // Required.
     oneof statement {
       Wire wire = 1;
@@ -215,6 +235,7 @@ message Firrtl {
       PartialConnect partial_connect = 16;
       IsInvalid is_invalid = 17;
       MemoryPort memory_port = 18;
+      Attach attach = 20;
     }
 
     SourceInfo source_info = 19;
@@ -260,6 +281,15 @@ message Firrtl {
       uint32 size = 2;
     }
 
+    message FixedType {
+      Width width = 1;
+      Width point = 2;
+    }
+
+    message AnalogType {
+      Width width = 3;
+    }
+
     // Required.
     oneof type {
       UIntType uint_type = 2;
@@ -267,6 +297,8 @@ message Firrtl {
       ClockType clock_type = 4;
       BundleType bundle_type = 5;
       VectorType vector_type = 6;
+      FixedType fixed_type = 7;
+      AnalogType analog_type = 8;
     }
   }
 
@@ -308,6 +340,12 @@ message Firrtl {
       // Required.
       IntegerLiteral value = 1;
       Width width = 2;
+    }
+
+    message FixedLiteral {
+      BigInt value = 1;
+      Width width = 2;
+      Width point = 3;
     }
 
     message ValidIf {
@@ -380,6 +418,13 @@ message Firrtl {
         OP_AS_UINT = 28;
         OP_AS_SINT = 29;
         OP_EXTRACT_BITS = 30;
+        OP_AS_CLOCK = 31;
+        OP_AS_FIXED_POINT = 32;
+        OP_AND_REDUCE = 33;
+        OP_OR_REDUCE = 34;
+        OP_SHIFT_BINARY_POINT_LEFT = 35;
+        OP_SHIFT_BINARY_POINT_RIGHT = 36;
+        OP_SET_BINARY_POINT = 37;
       }
 
       // Required.
@@ -388,11 +433,14 @@ message Firrtl {
       repeated IntegerLiteral const = 3;
     }
 
+    reserved 5;
+
     // Required.
     oneof expression {
       Reference reference = 1;
       UIntLiteral uint_literal = 2;
       SIntLiteral sint_literal = 3;
+      FixedLiteral fixed_literal = 11;
       ValidIf valid_if = 4;
       //ExtractBits extract_bits = 5;
       Mux mux = 6;

--- a/src/main/proto/firrtl.proto
+++ b/src/main/proto/firrtl.proto
@@ -100,6 +100,7 @@ message Firrtl {
       uint32 read_latency = 5;
       repeated string reader_id = 6;
       repeated string writer_id = 7;
+      repeated string readwriter_id = 8;
     }
 
     message CMemory {
@@ -107,6 +108,8 @@ message Firrtl {
       string id = 1;
       // Required.
       Type.VectorType type = 2;
+      // Required.
+      bool sync_read = 3;
     }
 
     message Instance {
@@ -141,7 +144,7 @@ message Firrtl {
 
     message Printf {
       // Required.
-      bytes value = 1;
+      string value = 1;
       repeated Expression arg = 2;
       // Required.
       Expression clk = 3;
@@ -261,7 +264,7 @@ message Firrtl {
       UIntType uint_type = 2;
       SIntType sint_type = 3;
       ClockType clock_type = 4;
-      RecordType record_type = 5;
+      BundleType bundle_type = 5;
       VectorType vector_type = 6;
     }
   }
@@ -390,7 +393,7 @@ message Firrtl {
       UIntLiteral uint_literal = 2;
       SIntLiteral sint_literal = 3;
       ValidIf valid_if = 4;
-      ExtractBits extract_bits = 5;
+      //ExtractBits extract_bits = 5;
       Mux mux = 6;
       SubField sub_field = 7;
       SubIndex sub_index = 8;

--- a/src/main/scala/firrtl/WIR.scala
+++ b/src/main/scala/firrtl/WIR.scala
@@ -275,7 +275,7 @@ case class CDefMemory(
     name: String,
     tpe: Type,
     size: Int,
-    seq: Boolean) extends Statement {
+    seq: Boolean) extends Statement with HasInfo {
   def serialize: String = (if (seq) "smem" else "cmem") +
     s" $name : ${tpe.serialize} [$size]" + info.serialize
   def mapExpr(f: Expression => Expression): Statement = this
@@ -289,7 +289,7 @@ case class CDefMPort(info: Info,
     tpe: Type,
     mem: String,
     exps: Seq[Expression],
-    direction: MPortDir) extends Statement {
+    direction: MPortDir) extends Statement with HasInfo {
   def serialize: String = {
     val dir = direction.serialize
     s"$dir mport $name = $mem[${exps.head.serialize}], ${exps(1).serialize}" + info.serialize

--- a/src/main/scala/proto/FromProto.scala
+++ b/src/main/scala/proto/FromProto.scala
@@ -1,0 +1,219 @@
+// See LICENSE for license details.
+
+package firrtl
+package proto
+
+import collection.JavaConverters._
+
+import FirrtlProtos._
+
+case class ProtoDeserializationException(msg: String) extends FIRRTLException(msg)
+
+// TODO Change requires to handled exceptions
+object FromProto {
+
+  private def compressStmts(stmts: Seq[ir.Statement]): ir.Statement = stmts match {
+    case Seq() => ir.EmptyStmt
+    case Seq(stmt) => stmt
+    case multiple => ir.Block(multiple)
+  }
+
+  val convert: Map[Firrtl.Expression.PrimOp.Op, ir.PrimOp] =
+    ToProto.convert.map { case (k, v) => v -> k }
+
+  def convert(literal: Firrtl.Expression.IntegerLiteral): BigInt =
+    BigInt(literal.getValue)
+
+  def convert(uint: Firrtl.Expression.UIntLiteral): ir.UIntLiteral = {
+    val width = if (uint.hasWidth) convert(uint.getWidth) else ir.UnknownWidth
+    ir.UIntLiteral(convert(uint.getValue), width)
+  }
+
+  def convert(sint: Firrtl.Expression.SIntLiteral): ir.SIntLiteral = {
+    val width = if (sint.hasWidth) convert(sint.getWidth) else ir.UnknownWidth
+    ir.SIntLiteral(convert(sint.getValue), width)
+  }
+
+  def convert(subfield: Firrtl.Expression.SubField): ir.SubField =
+    ir.SubField(convert(subfield.getExpression), subfield.getField, ir.UnknownType)
+
+  def convert(index: Firrtl.Expression.SubIndex): ir.SubIndex =
+    ir.SubIndex(convert(index.getExpression), convert(index.getIndex).toInt, ir.UnknownType)
+
+  def convert(access: Firrtl.Expression.SubAccess): ir.SubAccess =
+    ir.SubAccess(convert(access.getExpression), convert(access.getIndex), ir.UnknownType)
+
+  def convert(primop: Firrtl.Expression.PrimOp): ir.DoPrim = {
+    val args = primop.getArgList.asScala.map(convert(_))
+    val consts = primop.getConstList.asScala.map(convert(_))
+    ir.DoPrim(convert(primop.getOp), args, consts, ir.UnknownType)
+  }
+
+  def convert(mux: Firrtl.Expression.Mux): ir.Mux =
+    ir.Mux(convert(mux.getCondition), convert(mux.getTValue), convert(mux.getFValue), ir.UnknownType)
+
+  def convert(expr: Firrtl.Expression): ir.Expression =
+    if (expr.hasReference) ir.Reference(expr.getReference.getId, ir.UnknownType)
+    else if (expr.hasSubField) convert(expr.getSubField)
+    else if (expr.hasSubIndex) convert(expr.getSubIndex)
+    else if (expr.hasSubAccess) convert(expr.getSubAccess)
+    else if (expr.hasUintLiteral) convert(expr.getUintLiteral)
+    else if (expr.hasSintLiteral) convert(expr.getSintLiteral)
+    else if (expr.hasPrimOp) convert(expr.getPrimOp)
+    else if (expr.hasMux) convert(expr.getMux)
+    else throw new Exception(s"Got $expr")
+
+  def convert(con: Firrtl.Statement.Connect): ir.Connect =
+    ir.Connect(ir.NoInfo, convert(con.getLocation), convert(con.getExpression))
+
+  def convert(con: Firrtl.Statement.PartialConnect): ir.PartialConnect =
+    ir.PartialConnect(ir.NoInfo, convert(con.getLocation), convert(con.getExpression))
+
+  def convert(wire: Firrtl.Statement.Wire): ir.DefWire =
+    ir.DefWire(ir.NoInfo, wire.getId, convert(wire.getType))
+
+  def convert(reg: Firrtl.Statement.Register): ir.DefRegister =
+    ir.DefRegister(ir.NoInfo, reg.getId, convert(reg.getType), convert(reg.getClock),
+                   convert(reg.getReset), convert(reg.getInit))
+
+  def convert(node: Firrtl.Statement.Node): ir.DefNode =
+    ir.DefNode(ir.NoInfo, node.getId, convert(node.getExpression))
+
+  def convert(inst: Firrtl.Statement.Instance): ir.DefInstance =
+    ir.DefInstance(ir.NoInfo, inst.getId, inst.getModuleId)
+
+  def convert(when: Firrtl.Statement.When): ir.Conditionally = {
+    val conseq = compressStmts(when.getConsequentList.asScala.map(convert(_)))
+    val alt = compressStmts(when.getOtherwiseList.asScala.map(convert(_)))
+    ir.Conditionally(ir.NoInfo, convert(when.getPredicate), conseq, alt)
+  }
+
+  def convert(cmem: Firrtl.Statement.CMemory): ir.Statement = {
+    val vtpe = convert(cmem.getType)
+    CDefMemory(ir.NoInfo, cmem.getId, vtpe.tpe, vtpe.size, cmem.getSyncRead)
+  }
+
+  import Firrtl.Statement.MemoryPort.Direction._
+  def convert(mportdir: Firrtl.Statement.MemoryPort.Direction) = mportdir match {
+    case MEMORY_PORT_DIRECTION_INFER => MInfer
+    case MEMORY_PORT_DIRECTION_READ => MRead
+    case MEMORY_PORT_DIRECTION_WRITE => MWrite
+    case MEMORY_PORT_DIRECTION_READ_WRITE => MReadWrite
+  }
+
+  def convert(port: Firrtl.Statement.MemoryPort): CDefMPort = {
+    val exprs = Seq(convert(port.getMemoryIndex), convert(port.getExpression))
+    CDefMPort(ir.NoInfo, port.getId, ir.UnknownType, port.getMemoryId, exprs, convert(port.getDirection))
+  }
+
+  def convert(printf: Firrtl.Statement.Printf): ir.Print = {
+    val args = printf.getArgList.asScala.map(convert(_))
+    val str = ir.StringLit(printf.getValue)
+    ir.Print(ir.NoInfo, str, args, convert(printf.getClk), convert(printf.getEn))
+  }
+
+  def convert(stop: Firrtl.Statement.Stop): ir.Stop =
+    ir.Stop(ir.NoInfo, stop.getReturnValue, convert(stop.getClk), convert(stop.getEn))
+
+  def convert(mem: Firrtl.Statement.Memory): ir.DefMemory = {
+    val dtype = convert(mem.getType)
+    val rs = mem.getReaderIdList.asScala
+    val ws = mem.getWriterIdList.asScala
+    val rws = mem.getReadwriterIdList.asScala
+    ir.DefMemory(ir.NoInfo, mem.getId, dtype, mem.getDepth, mem.getWriteLatency, mem.getReadLatency,
+                 rs, ws, rws, None)
+  }
+
+  def convert(stmt: Firrtl.Statement): ir.Statement =
+    if (stmt.hasNode) convert(stmt.getNode)
+    else if (stmt.hasConnect) convert(stmt.getConnect)
+    else if (stmt.hasPartialConnect) convert(stmt.getPartialConnect)
+    else if (stmt.hasWire) convert(stmt.getWire)
+    else if (stmt.hasRegister) convert(stmt.getRegister)
+    else if (stmt.hasWhen) convert(stmt.getWhen)
+    else if (stmt.hasInstance) convert(stmt.getInstance)
+    else if (stmt.hasPrintf) convert(stmt.getPrintf)
+    else if (stmt.hasStop) convert(stmt.getStop)
+    else if (stmt.hasMemory) convert(stmt.getMemory)
+    else if (stmt.hasIsInvalid) ir.IsInvalid(ir.NoInfo, convert(stmt.getIsInvalid.getExpression))
+    else if (stmt.hasCmemory) convert(stmt.getCmemory)
+    else if (stmt.hasMemoryPort) convert(stmt.getMemoryPort)
+    else throw new Exception(s"Got $stmt")
+
+
+  def convert(width: Firrtl.Width): ir.Width = {
+    if (width.isInitialized) ir.IntWidth(width.getValue)
+    else ir.UnknownWidth
+  }
+
+  def convert(ut: Firrtl.Type.UIntType): ir.UIntType = {
+    val w = if (ut.hasWidth) convert(ut.getWidth) else ir.UnknownWidth
+    ir.UIntType(w)
+  }
+  
+  def convert(ut: Firrtl.Type.SIntType): ir.SIntType = {
+    val w = if (ut.hasWidth) convert(ut.getWidth) else ir.UnknownWidth
+    ir.SIntType(w)
+  }
+
+  def convert(field: Firrtl.Type.BundleType.Field): ir.Field = {
+    val flip = if (field.getIsFlipped) ir.Flip else ir.Default
+    ir.Field(field.getId, flip, convert(field.getType))
+  }
+
+  def convert(vtpe: Firrtl.Type.VectorType): ir.VectorType =
+    ir.VectorType(convert(vtpe.getType), vtpe.getSize)
+
+  def convert(tpe: Firrtl.Type): ir.Type = {
+    if (tpe.hasUintType) convert(tpe.getUintType)
+    else if (tpe.hasSintType) convert(tpe.getSintType)
+    else if (tpe.hasClockType) ir.ClockType
+    else if (tpe.hasBundleType) ir.BundleType(tpe.getBundleType.getFieldList.asScala.map(convert(_)))
+    else if (tpe.hasVectorType) convert(tpe.getVectorType)
+    else throw new Exception("deleteme")
+  }
+
+  def convert(dir: Firrtl.Port.Direction): ir.Direction = {
+    dir match {
+      case Firrtl.Port.Direction.PORT_DIRECTION_IN => ir.Input
+      case Firrtl.Port.Direction.PORT_DIRECTION_OUT => ir.Output
+      case unknown =>
+        throw ProtoDeserializationException(s"Direction must be Input or Output, got $unknown")
+    }
+  }
+
+  def convert(port: Firrtl.Port): ir.Port = {
+    val dir = convert(port.getDirection)
+    val tpe = convert(port.getType)
+    ir.Port(ir.NoInfo, port.getId, dir, tpe)
+  }
+
+  def convert(module: Firrtl.Module.UserModule): ir.Module = {
+    val name = module.getId
+    val ports = module.getPortList.asScala.map(convert(_))
+    val stmts = module.getStatementList.asScala.map(convert(_))
+    ir.Module(ir.NoInfo, name, ports, ir.Block(stmts))
+  }
+
+  def convert(module: Firrtl.Module.ExternalModule): ir.ExtModule = {
+    val name = module.getId
+    val ports = module.getPortList.asScala.map(convert(_))
+    ir.ExtModule(ir.NoInfo, name, ports, name, Seq.empty)
+  }
+
+  def convert(module: Firrtl.Module): ir.DefModule =
+    if (module.hasUserModule) convert(module.getUserModule)
+    else {
+      require(module.hasExternalModule, "Module must have Module or ExtModule")
+      convert(module.getExternalModule)
+    }
+
+  def convert(proto: Firrtl): ir.Circuit = {
+    require(proto.getCircuitCount == 1, "Only 1 circuit is currently supported")
+    val c = proto.getCircuit(0)
+    require(c.getTopCount == 1, "Only 1 top is currently supported")
+    val modules = c.getModuleList.asScala.map(convert(_))
+    val top = c.getTop(0).getName
+    ir.Circuit(ir.NoInfo, modules, top)
+  }
+}

--- a/src/main/scala/proto/ToProto.scala
+++ b/src/main/scala/proto/ToProto.scala
@@ -1,0 +1,306 @@
+// See LICENSE for license details.
+
+package firrtl
+package proto
+
+import FirrtlProtos._
+import Firrtl.Expression.PrimOp.Op
+import firrtl.PrimOps._
+
+import scala.collection.JavaConverters._
+
+object ToProto {
+
+  val convert: Map[ir.PrimOp, Op] = Map(
+    Add -> Op.OP_ADD,
+    Sub -> Op.OP_SUB,
+    Mul -> Op.OP_TIMES,
+    Div -> Op.OP_DIVIDE,
+    Rem -> Op.OP_REM,
+    Lt -> Op.OP_LESS,
+    Leq -> Op.OP_LESS_EQ,
+    Gt -> Op.OP_GREATER,
+    Geq -> Op.OP_GREATER_EQ,
+    Eq -> Op.OP_EQUAL,
+    Neq -> Op.OP_NOT_EQUAL,
+    Pad -> Op.OP_PAD,
+    AsUInt -> Op.OP_AS_UINT,
+    AsSInt -> Op.OP_AS_SINT,
+    //AsClock ->
+    Shl -> Op.OP_SHIFT_LEFT,
+    Shr -> Op.OP_SHIFT_RIGHT,
+    Dshl -> Op.OP_DYNAMIC_SHIFT_LEFT,
+    Dshr -> Op.OP_DYNAMIC_SHIFT_RIGHT,
+    Cvt -> Op.OP_CONVERT,
+    Neg -> Op.OP_NEG,
+    Not -> Op.OP_BIT_NOT,
+    And -> Op.OP_BIT_AND,
+    Or -> Op.OP_BIT_OR,
+    Xor -> Op.OP_BIT_XOR,
+    //Andr
+    //Orr ->
+    Xorr -> Op.OP_XOR_REDUCE,
+    Cat -> Op.OP_CONCAT,
+    Bits -> Op.OP_EXTRACT_BITS,
+    Head -> Op.OP_HEAD,
+    Tail -> Op.OP_TAIL
+    //AsFixedPoint ->
+    //BPShl ->
+    //BPShr ->
+    //BPSet ->
+  )
+
+  def convert(value: BigInt): Firrtl.Expression.IntegerLiteral.Builder = {
+    Firrtl.Expression.IntegerLiteral.newBuilder()
+      .setValue(value.toString)
+  }
+
+  def convert(expr: ir.Expression): Firrtl.Expression.Builder = {
+    val eb = Firrtl.Expression.newBuilder()
+    expr match {
+      case WRef(name, tpe, _, _) =>
+        val rb = Firrtl.Expression.Reference.newBuilder()
+          .setId(name)
+        eb.setReference(rb)
+      case ir.Reference(name, tpe) =>
+        val rb = Firrtl.Expression.Reference.newBuilder()
+          .setId(name)
+        eb.setReference(rb)
+      case ir.SubField(expr, name, tpe) =>
+        val sb = Firrtl.Expression.SubField.newBuilder()
+          .setExpression(convert(expr))
+          .setField(name)
+        eb.setSubField(sb)
+      case ir.SubIndex(expr, value, tpe) =>
+        val sb = Firrtl.Expression.SubIndex.newBuilder()
+          .setExpression(convert(expr))
+          .setIndex(convert(value))
+        eb.setSubIndex(sb)
+      case ir.SubAccess(expr, index, tpe) =>
+        val sb = Firrtl.Expression.SubAccess.newBuilder()
+          .setExpression(convert(expr))
+          .setIndex(convert(index))
+        eb.setSubAccess(sb)
+      case ir.UIntLiteral(value, width) =>
+        val ub = Firrtl.Expression.UIntLiteral.newBuilder()
+          .setValue(convert(value))
+        convert(width).foreach(ub.setWidth(_))
+        eb.setUintLiteral(ub)
+      case ir.SIntLiteral(value, width) =>
+        val sb = Firrtl.Expression.SIntLiteral.newBuilder()
+          .setValue(convert(value))
+        convert(width).foreach(sb.setWidth(_))
+        eb.setSintLiteral(sb)
+      case ir.DoPrim(op, args, consts, tpe) =>
+        val db = Firrtl.Expression.PrimOp.newBuilder()
+          .setOp(convert(op))
+        consts.foreach(c => db.addConst(convert(c)))
+        args.foreach(a => db.addArg(convert(a)))
+        eb.setPrimOp(db)
+      case ir.Mux(cond, tval, fval, tpe) =>
+        val mb = Firrtl.Expression.Mux.newBuilder()
+          .setCondition(convert(cond))
+          .setTValue(convert(tval))
+          .setFValue(convert(fval))
+        eb.setMux(mb)
+    }
+  }
+
+  def convert(dir: MPortDir): Firrtl.Statement.MemoryPort.Direction = {
+    import Firrtl.Statement.MemoryPort.Direction._
+    dir match {
+      case MInfer => MEMORY_PORT_DIRECTION_INFER
+      case MRead => MEMORY_PORT_DIRECTION_READ
+      case MWrite => MEMORY_PORT_DIRECTION_WRITE
+      case MReadWrite => MEMORY_PORT_DIRECTION_READ_WRITE
+    }
+  }
+
+  def convert(stmt: ir.Statement): Seq[Firrtl.Statement.Builder] = {
+    stmt match {
+      case ir.Block(stmts) => stmts.flatMap(convert(_))
+      case ir.EmptyStmt => Seq.empty
+      case other =>
+        val sb = Firrtl.Statement.newBuilder()
+        other match {
+          case ir.DefNode(info, name, expr) =>
+            val nb = Firrtl.Statement.Node.newBuilder()
+              .setId(name)
+              .setExpression(convert(expr))
+            sb.setNode(nb)
+          case ir.DefWire(info, name, tpe) =>
+            val wb = Firrtl.Statement.Wire.newBuilder()
+              .setId(name)
+              .setType(convert(tpe))
+            sb.setWire(wb)
+          case ir.DefRegister(info, name, tpe, clock, reset, init) =>
+            val rb = Firrtl.Statement.Register.newBuilder()
+              .setId(name)
+              .setType(convert(tpe))
+              .setClock(convert(clock))
+              .setReset(convert(reset))
+              .setInit(convert(init))
+            sb.setRegister(rb)
+          case ir.DefInstance(info, name, module) =>
+            val ib = Firrtl.Statement.Instance.newBuilder()
+              .setId(name)
+              .setModuleId(module)
+            sb.setInstance(ib)
+          case ir.Connect(info, loc, expr) =>
+            val cb = Firrtl.Statement.Connect.newBuilder()
+              .setLocation(convert(loc))
+              .setExpression(convert(expr))
+            sb.setConnect(cb)
+          case ir.PartialConnect(info, loc, expr) =>
+            val cb = Firrtl.Statement.PartialConnect.newBuilder()
+              .setLocation(convert(loc))
+              .setExpression(convert(expr))
+            sb.setPartialConnect(cb)
+          case ir.Conditionally(info, pred, conseq, alt) =>
+            val cs = convert(conseq)
+            val as = convert(alt)
+            val wb = Firrtl.Statement.When.newBuilder()
+              .setPredicate(convert(pred))
+            cs.foreach(wb.addConsequent(_))
+            as.foreach(wb.addOtherwise(_))
+            sb.setWhen(wb)
+          case ir.Print(info, string, args, clk, en) =>
+            val pb = Firrtl.Statement.Printf.newBuilder()
+              .setValue(string.string)
+              .setClk(convert(clk))
+              .setEn(convert(en))
+            args.foreach(a => pb.addArg(convert(a)))
+            sb.setPrintf(pb)
+          case ir.Stop(info, ret, clk, en) =>
+            val stopb = Firrtl.Statement.Stop.newBuilder()
+              .setReturnValue(ret)
+              .setClk(convert(clk))
+              .setEn(convert(en))
+            sb.setStop(stopb)
+          case ir.IsInvalid(info, expr) =>
+            val ib = Firrtl.Statement.IsInvalid.newBuilder()
+              .setExpression(convert(expr))
+            sb.setIsInvalid(ib)
+          case m @ ir.DefMemory(info, name, dtype, depth, wlat, rlat, rs, ws, rws, ruw) =>
+            val mem = Firrtl.Statement.Memory.newBuilder()
+              .setId(name)
+              .setType(convert(dtype))
+              .setDepth(depth)
+              .setWriteLatency(wlat)
+              .setReadLatency(rlat)
+            mem.addAllReaderId(rs.asJava)
+            mem.addAllWriterId(ws.asJava)
+            mem.addAllReadwriterId(rws.asJava)
+            sb.setMemory(mem)
+          case CDefMemory(info, name, tpe, size, seq) =>
+            val tpeb = convert(ir.VectorType(tpe, size))
+            val mb = Firrtl.Statement.CMemory.newBuilder()
+              .setId(name)
+              .setType(tpeb)
+              .setSyncRead(seq)
+            sb.setCmemory(mb)
+          case CDefMPort(info, name, _, mem, exprs, dir) =>
+            val pb = Firrtl.Statement.MemoryPort.newBuilder()
+              .setId(name)
+              .setMemoryId(mem)
+              .setMemoryIndex(convert(exprs(0)))
+              .setExpression(convert(exprs(1)))
+              .setDirection(convert(dir))
+            sb.setMemoryPort(pb)
+        }
+        Seq(sb)
+    }
+  }
+
+  def convert(field: ir.Field): Firrtl.Type.BundleType.Field.Builder = {
+    val b = Firrtl.Type.BundleType.Field.newBuilder()
+      .setId(field.name)
+      .setIsFlipped(field.flip == ir.Flip)
+      .setType(convert(field.tpe))
+    b
+  }
+
+  /** Converts a Width to a ProtoBuf Width Builder
+    *
+    * @param width
+    * @return Option width where None means the width field should be cleared in the parent object
+    */
+  def convert(width: ir.Width): Option[Firrtl.Width.Builder] = width match {
+    case ir.IntWidth(w) => Some(Firrtl.Width.newBuilder().setValue(w.toInt))
+    case ir.UnknownWidth => None
+  }
+
+  def convert(vtpe: ir.VectorType): Firrtl.Type.VectorType.Builder =
+    Firrtl.Type.VectorType.newBuilder()
+      .setType(convert(vtpe.tpe))
+      .setSize(vtpe.size)
+
+
+  def convert(tpe: ir.Type): Firrtl.Type.Builder = {
+    val tb = Firrtl.Type.newBuilder()
+    tpe match {
+      case ir.UIntType(width) =>
+        val ut = Firrtl.Type.UIntType.newBuilder()
+        convert(width).foreach(ut.setWidth(_))
+        tb.setUintType(ut)
+      case ir.SIntType(width) =>
+        val st = Firrtl.Type.SIntType.newBuilder()
+        convert(width).foreach(st.setWidth(_))
+        tb.setSintType(st)
+      case ir.ClockType =>
+        val ct = Firrtl.Type.ClockType.newBuilder()
+        tb.setClockType(ct)
+      case ir.BundleType(fields) =>
+        val bt = Firrtl.Type.BundleType.newBuilder()
+        fields.foreach(f => bt.addField(convert(f)))
+        tb.setBundleType(bt)
+      case vtpe: ir.VectorType =>
+        val vtb = convert(vtpe)
+        tb.setVectorType(vtb)
+      case ir.UnknownType =>
+        tb.clearType()
+    }
+  }
+
+  def convert(direction: ir.Direction): Firrtl.Port.Direction = direction match {
+    case ir.Input => Firrtl.Port.Direction.PORT_DIRECTION_IN
+    case ir.Output => Firrtl.Port.Direction.PORT_DIRECTION_OUT
+  }
+
+  def convert(port: ir.Port): Firrtl.Port.Builder = {
+    Firrtl.Port.newBuilder()
+      .setId(port.name)
+      .setDirection(convert(port.direction))
+      .setType(convert(port.tpe))
+  }
+
+  def convert(module: ir.DefModule): Firrtl.Module.Builder = {
+    val ports = module.ports.map(convert(_))
+    val b = Firrtl.Module.newBuilder()
+    module match {
+      case mod: ir.Module =>
+        val stmts = convert(mod.body)
+        val mb = Firrtl.Module.UserModule.newBuilder()
+          .setId(mod.name)
+        ports.foreach(mb.addPort(_))
+        stmts.foreach(mb.addStatement(_))
+        b.setUserModule(mb)
+      case ext: ir.ExtModule =>
+        val eb = Firrtl.Module.ExternalModule.newBuilder()
+          .setId(ext.name)
+        b.setExternalModule(eb)
+    }
+  }
+
+  def convert(circuit: ir.Circuit): Firrtl = {
+    val moduleBuilders = circuit.modules.map(convert(_))
+    val cb = Firrtl.Circuit.newBuilder
+      .addTop(Firrtl.Top.newBuilder().setName(circuit.main))
+    for (m <- moduleBuilders) {
+      cb.addModule(m)
+    }
+    Firrtl.newBuilder()
+      .addCircuit(cb.build())
+      .build()
+  }
+}

--- a/src/test/scala/firrtlTests/ProtoBufSpec.scala
+++ b/src/test/scala/firrtlTests/ProtoBufSpec.scala
@@ -42,8 +42,13 @@ class ProtoBufSpec extends FirrtlFlatSpec {
     }
   }
 
-  "Unknown Widths" should "serialize and deserialize as unknown" in {
-    import firrtl.proto._
+  // ********** Focused Tests **********
+  // The goal is to fill coverage holes left after the above
+
+  behavior of "ProtoBuf serialization and deserialization"
+  import firrtl.proto._
+
+  it should "support UnknownWidth" in {
     // Note that this has to be handled in the parent object so we need to test everything that has a width
     val uint = ir.UIntType(ir.UnknownWidth)
     FromProto.convert(ToProto.convert(uint).build) should equal (uint)
@@ -51,10 +56,73 @@ class ProtoBufSpec extends FirrtlFlatSpec {
     val sint = ir.SIntType(ir.UnknownWidth)
     FromProto.convert(ToProto.convert(sint).build) should equal (sint)
 
+    val ftpe = ir.FixedType(ir.UnknownWidth, ir.UnknownWidth)
+    FromProto.convert(ToProto.convert(ftpe).build) should equal (ftpe)
+
+    val atpe = ir.AnalogType(ir.UnknownWidth)
+    FromProto.convert(ToProto.convert(atpe).build) should equal (atpe)
+
     val ulit = ir.UIntLiteral(123, ir.UnknownWidth)
     FromProto.convert(ToProto.convert(ulit).build) should equal (ulit)
 
     val slit = ir.SIntLiteral(-123, ir.UnknownWidth)
+    FromProto.convert(ToProto.convert(slit).build) should equal (slit)
+
+    val flit = ir.FixedLiteral(-123, ir.UnknownWidth, ir.UnknownWidth)
+    FromProto.convert(ToProto.convert(flit).build) should equal (flit)
+  }
+
+  it should "support all Primops" in {
+    val builtInOps = PrimOps.listing.map(PrimOps.fromString(_))
+    for (op <- builtInOps) {
+      val expr = DoPrim(op, List.empty, List.empty, ir.UnknownType)
+      FromProto.convert(ToProto.convert(expr).build) should equal (expr)
+    }
+  }
+
+  it should "support all ExtModule features (except info which isn't yet supported by Chisel)" in {
+    val ports = Seq(
+      Port(ir.NoInfo, "port1", ir.Input, ir.UIntType(ir.IntWidth(8))),
+      Port(ir.NoInfo, "port2", ir.Output, ir.SIntType(ir.IntWidth(8)))
+    )
+    val params = Seq(
+      IntParam("param1", BigInt(Long.MinValue)),
+      DoubleParam("param2", Double.NegativeInfinity),
+      StringParam("param3", ir.StringLit("quite the string!")),
+      RawStringParam("param4", "get some raw strings")
+    )
+    val ext = ir.ExtModule(ir.NoInfo, "MyModule", ports, "DefNameHere", params)
+    FromProto.convert(ToProto.convert(ext).build) should equal (ext)
+  }
+
+  it should "supported FixedType" in {
+    val ftpe = ir.FixedType(IntWidth(8), IntWidth(4))
+    FromProto.convert(ToProto.convert(ftpe).build) should equal (ftpe)
+  }
+
+  it should "supported FixedLiteral" in {
+    val flit = ir.FixedLiteral(3, IntWidth(8), IntWidth(4))
+    FromProto.convert(ToProto.convert(flit).build) should equal (flit)
+  }
+
+  it should "support Analog and Attach" in {
+    val analog = ir.AnalogType(IntWidth(8))
+    FromProto.convert(ToProto.convert(analog).build) should equal (analog)
+
+    val attach = ir.Attach(ir.NoInfo, Seq(Reference("hi", ir.UnknownType)))
+    FromProto.convert(ToProto.convert(attach).head.build) should equal (attach)
+  }
+
+  // Regression tests were generated before Chisel could emit else
+  it should "support whens with elses" in {
+    val expr = Reference("hi", ir.UnknownType)
+    val stmt = Connect(ir.NoInfo, expr, expr)
+    val when = ir.Conditionally(ir.NoInfo, expr, stmt, stmt)
+    FromProto.convert(ToProto.convert(when).head.build) should equal (when)
+  }
+
+  it should "support SIntLiteral with a width" in {
+    val slit = ir.SIntLiteral(-123)
     FromProto.convert(ToProto.convert(slit).build) should equal (slit)
   }
 }

--- a/src/test/scala/firrtlTests/ProtoBufSpec.scala
+++ b/src/test/scala/firrtlTests/ProtoBufSpec.scala
@@ -19,18 +19,16 @@ class ProtoBufSpec extends FirrtlFlatSpec {
     FirrtlResourceTest("GCDTester", "/integration"),
     FirrtlResourceTest("RightShiftTester", "/integration"),
     FirrtlResourceTest("MemTester", "/integration"),
-    FirrtlResourceTest("PipeTester", "/integration")
-    // TODO Info
-    //FirrtlResourceTest("Rob", "/regress"),
-    //FirrtlResourceTest("RocketCore", "/regress"),
-    //FirrtlResourceTest("ICache", "/regress"),
-    //FirrtlResourceTest("FPU", "/regress")
+    FirrtlResourceTest("PipeTester", "/integration"),
+    FirrtlResourceTest("Rob", "/regress"),
+    FirrtlResourceTest("RocketCore", "/regress"),
+    FirrtlResourceTest("ICache", "/regress"),
+    FirrtlResourceTest("FPU", "/regress")
   )
 
   /** Helper to make circuits that are the same appear the same */
   def canonicalize(circuit: Circuit): Circuit = {
     def onModule(mod: DefModule) = mod.map(Utils.squashEmpty)
-
     circuit.map(onModule)
   }
 
@@ -59,6 +57,4 @@ class ProtoBufSpec extends FirrtlFlatSpec {
     val slit = ir.SIntLiteral(-123, ir.UnknownWidth)
     FromProto.convert(ToProto.convert(slit).build) should equal (slit)
   }
-
-
 }

--- a/src/test/scala/firrtlTests/ProtoBufSpec.scala
+++ b/src/test/scala/firrtlTests/ProtoBufSpec.scala
@@ -1,0 +1,64 @@
+// See LICENSE for license details.
+
+package firrtlTests
+
+import firrtl.FirrtlProtos.Firrtl
+import firrtl._
+import firrtl.ir._
+import firrtl.Mappers._
+
+class ProtoBufSpec extends FirrtlFlatSpec {
+
+  /** Tests in src/test/resource/ in .fir format
+    *
+    * @note These tests rely on the ANTLR Parser
+    */
+  case class FirrtlResourceTest(name: String, resourceDir: String)
+
+  val firrtlResourceTests = List(
+    FirrtlResourceTest("GCDTester", "/integration"),
+    FirrtlResourceTest("RightShiftTester", "/integration"),
+    FirrtlResourceTest("MemTester", "/integration"),
+    FirrtlResourceTest("PipeTester", "/integration")
+    // TODO Info
+    //FirrtlResourceTest("Rob", "/regress"),
+    //FirrtlResourceTest("RocketCore", "/regress"),
+    //FirrtlResourceTest("ICache", "/regress"),
+    //FirrtlResourceTest("FPU", "/regress")
+  )
+
+  /** Helper to make circuits that are the same appear the same */
+  def canonicalize(circuit: Circuit): Circuit = {
+    def onModule(mod: DefModule) = mod.map(Utils.squashEmpty)
+
+    circuit.map(onModule)
+  }
+
+  for (FirrtlResourceTest(name, dir) <- firrtlResourceTests) {
+    s"$name" should "work with Protobuf serialization and deserialization" in {
+      val stream = getClass.getResourceAsStream(s"$dir/$name.fir")
+      val circuit = parse(scala.io.Source.fromInputStream(stream).getLines.mkString("\n"))
+      val protobuf = proto.ToProto.convert(circuit)
+      val circuit2 = proto.FromProto.convert(protobuf)
+      canonicalize(circuit).serialize should equal(canonicalize(circuit2).serialize)
+    }
+  }
+
+  "Unknown Widths" should "serialize and deserialize as unknown" in {
+    import firrtl.proto._
+    // Note that this has to be handled in the parent object so we need to test everything that has a width
+    val uint = ir.UIntType(ir.UnknownWidth)
+    FromProto.convert(ToProto.convert(uint).build) should equal (uint)
+
+    val sint = ir.SIntType(ir.UnknownWidth)
+    FromProto.convert(ToProto.convert(sint).build) should equal (sint)
+
+    val ulit = ir.UIntLiteral(123, ir.UnknownWidth)
+    FromProto.convert(ToProto.convert(ulit).build) should equal (ulit)
+
+    val slit = ir.SIntLiteral(-123, ir.UnknownWidth)
+    FromProto.convert(ToProto.convert(slit).build) should equal (slit)
+  }
+
+
+}


### PR DESCRIPTION
At long last, here is actual protobuf serialization and deserialization.

It's a lot of code because translating to and from the ProtoBuf generated classes is just repetitive and verbose.

Some decisions I made and the justification
* No support for WIR
    * I see it as a follow on, this is enough to get Chisel -> FIRRTL via protobuf working which is my main goal
* Using Java Protobuf instead of ScalaPB
    * ScalaPB provides nice Scala-y datastructures from the protobuf. It doesn't provide much if anything over the default Java implementation because we're just converting to and from it anyway (note this code would be just as verbose). The Java implementation is supported by the protobuf team so I didn't see sufficient reason to use ScalaPB

I still need to add support for protobuf input and output but I figured I should PR this now since it is ready for overall code review and this is enough for some performance benchmarking (which I haven't done yet).