### PR TITLE
Remove #0.002 delay to initial rand assignments

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -631,12 +631,6 @@ class VerilogEmitter extends SeqTransform with Emitter {
           emit(Seq("`ifdef RANDOMIZE"))
           emit(Seq("  integer initvar;"))
           emit(Seq("  initial begin"))
-          // This enables test benches to set the random values at time 0.001,
-          //  then start the simulation later
-          // Verilator does not support delay statements, so they are omitted.
-          emit(Seq("    `ifndef verilator"))
-          emit(Seq("      #0.002 begin end"))
-          emit(Seq("    `endif"))
           for (x <- initials) emit(Seq(tab, x))
           emit(Seq("  end"))
           emit(Seq("`endif // RANDOMIZE"))


### PR DESCRIPTION
This delay no longer appears to be required, and is introducing issues to simulation behavior