### PR TITLE
Demonstrate using Eta to build a simple compiler transform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ test_run_dir
 .cache
 .history
 .lib/
+dist/
 dist/*
 target/
 lib_managed/

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -24,4 +24,4 @@ addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.3")
 
 libraryDependencies += "com.github.os72" % "protoc-jar" % "3.5.1.1"
 
-addSbtPlugin("com.typelead" % "sbt-eta" % "0.1.1-SNAPSHOT")
+addSbtPlugin("com.typelead" % "sbt-eta" % "0.2.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,3 +23,5 @@ addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.1")
 addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.3")
 
 libraryDependencies += "com.github.os72" % "protoc-jar" % "3.5.1.1"
+
+addSbtPlugin("com.typelead" % "sbt-eta" % "0.1.1-SNAPSHOT")

--- a/src/main/eta/LICENSE
+++ b/src/main/eta/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2018 John Wiegley
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/main/eta/Lib/FIRRTL.hs
+++ b/src/main/eta/Lib/FIRRTL.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Lib.FIRRTL where
+
+import Java
+import Lib.Scala
+
+data Transform    = Transform    @firrtl.Transform     deriving Class
+data CircuitForm  = CircuitForm  @firrtl.CircuitForm   deriving Class
+data LowForm      = LowForm      @firrtl.LowForm$      deriving Class
+data CircuitState = CircuitState @firrtl.CircuitState  deriving Class
+data Utils        = Utils        @firrtl.Utils         deriving Class
+data Circuit      = Circuit      @firrtl.ir.Circuit    deriving Class
+data DefModule    = DefModule    @firrtl.ir.DefModule  deriving Class
+data FirrtlNode   = FirrtlNode   @firrtl.ir.FirrtlNode deriving Class
+data Statement    = Statement    @firrtl.ir.Statement  deriving Class
+data Expression   = Expression   @firrtl.ir.Expression deriving Class
+data Type         = Type         @firrtl.ir.Type       deriving Class
+data Mux          = Mux          @firrtl.ir.Mux        deriving Class
+
+type instance Inherits Statement  = '[FirrtlNode]
+type instance Inherits Expression = '[FirrtlNode]
+type instance Inherits Type       = '[FirrtlNode]
+
+type instance Inherits LowForm = '[CircuitForm]
+
+foreign import java unsafe "@static @field firrtl.LowForm$.MODULE$"
+    lowForm :: LowForm
+
+type instance Inherits Mux = '[Expression]
+
+foreign import java unsafe circuit :: Java CircuitState Circuit
+
+foreign import java unsafe name :: Java DefModule String
+
+foreign import java unsafe "mapModule"
+    mapModule :: Function1 DefModule DefModule -> Java Circuit Circuit
+foreign import java unsafe "mapStmt"
+    mapModStmt :: Function1 Statement Statement -> Java DefModule DefModule
+foreign import java unsafe "mapStmt"
+    mapStmtStmt :: Function1 Statement Statement -> Java Statement Statement
+foreign import java unsafe "mapExpr"
+    mapStmtExpr :: Function1 Expression Expression -> Java Statement Statement
+foreign import java unsafe "mapExpr"
+    mapExprExpr :: Function1 Expression Expression -> Java Expression Expression

--- a/src/main/eta/Lib/Scala.hs
+++ b/src/main/eta/Lib/Scala.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Lib.Scala where
+
+import Java hiding (Iterable)
+import Prelude hiding (Traversable)
+
+data Any    = Any    @scala.Any    deriving Class
+data AnyVal = AnyVal @scala.AnyVal deriving Class
+data Unit   = Unit   @scala.Unit   deriving Class
+
+type instance Inherits AnyVal = '[Any]
+type instance Inherits Unit   = '[AnyVal]
+
+foreign import java unsafe "@new" unit :: Unit
+
+data Function1 t r = Function1 (@scala.Function1 t r)
+    deriving Class
+
+foreign import java unsafe "@wrapper apply"
+    fun1 :: (t <: Object, r <: Object)
+         => (t -> Java (Function1 t r) r) -> Function1 t r
+foreign import java unsafe "apply"
+    fun1Apply :: (t <: Object, r <: Object) => Function1 t r -> t -> r
+
+data Traversable a       = Traversable     (@scala.collection.Traversable a)       deriving Class
+data GenIterableLike a b = GenIterableLike (@scala.collection.GenIterableLike a b) deriving Class
+data IterableLike a b    = IterableLike    (@scala.collection.IterableLike a b)    deriving Class
+data GenIterable a       = GenIterable     (@scala.collection.GenIterable a)       deriving Class
+data Iterable a          = Iterable        (@scala.collection.Iterable a)          deriving Class
+data GenSeqLike a b      = GenSeqLike      (@scala.collection.GenSeqLike a b)      deriving Class
+data SeqLike a b         = SeqLike         (@scala.collection.SeqLike a b)         deriving Class
+data Seq a               = Seq             (@scala.collection.Seq a)               deriving Class
+
+type instance Inherits (Iterable a)     = '[Traversable a, IterableLike a (Iterable a),
+                                            GenIterable a]
+type instance Inherits (GenSeqLike a b) = '[GenIterableLike a b]
+type instance Inherits (SeqLike a b)    = '[GenSeqLike a b]
+type instance Inherits (Seq a)          = '[Iterable a, SeqLike a (Seq a)]
+
+foreign import java unsafe "@interface foreach"
+    foreach :: (a <: Object, t <: IterableLike a (Iterable a))
+            => Function1 (Seq a) b -> Java t ()
+
+foreign import java unsafe "@interface map"
+    seqMap :: (a <: Object, b <: Object,
+               t <: GenIterableLike a (Seq a), u <: GenIterableLike b (Seq b))
+            => Function1 a b -> Java t u

--- a/src/main/eta/Lib/Scala.hs
+++ b/src/main/eta/Lib/Scala.hs
@@ -10,15 +10,6 @@ module Lib.Scala where
 import Java hiding (Iterable)
 import Prelude hiding (Traversable)
 
-data Any    = Any    @scala.Any    deriving Class
-data AnyVal = AnyVal @scala.AnyVal deriving Class
-data Unit   = Unit   @scala.Unit   deriving Class
-
-type instance Inherits AnyVal = '[Any]
-type instance Inherits Unit   = '[AnyVal]
-
-foreign import java unsafe "@new" unit :: Unit
-
 data Function1 t r = Function1 (@scala.Function1 t r)
     deriving Class
 

--- a/src/main/eta/Setup.hs
+++ b/src/main/eta/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/src/main/eta/Transform/AnalyzeCircuit.hs
+++ b/src/main/eta/Transform/AnalyzeCircuit.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Transform.AnalyzeCircuit where
+
+import           Data.Foldable
+import           Data.IORef
+import           Data.Map (Map)
+import qualified Data.Map as M
+import           Data.Maybe (fromMaybe)
+import           Data.Set (Set)
+import qualified Data.Set as S
+import           Java hiding (Set, Map)
+import           Lib.FIRRTL
+import           Lib.Scala
+
+-- Our Ledger helper class, to track modules that have been seen. Note that
+-- this uses only Haskell features, not Java or Scala.
+
+data Ledger = Ledger
+    { moduleName   :: Maybe String
+    , moduleSet    :: Set String
+    , moduleMuxMap :: Map String Int
+    }
+
+newLedger :: Ledger
+newLedger = Ledger
+    { moduleName   = Nothing
+    , moduleSet    = mempty
+    , moduleMuxMap = mempty
+    }
+
+foundMux :: Ledger -> Ledger
+foundMux l = l
+    { moduleMuxMap =
+        case moduleName l of
+            Nothing   -> error "Module name not defined in Ledger!"
+            Just name ->
+                M.insert name
+                    (succ (fromMaybe 0 (M.lookup name (moduleMuxMap l))))
+                    (moduleMuxMap l)
+    }
+
+getModuleName :: Ledger -> String
+getModuleName l = case moduleName l of
+    Nothing   -> error "Module name not defined in Ledger!"
+    Just name -> name
+
+setModuleName :: String -> Ledger -> Ledger
+setModuleName myName l = l
+    { moduleSet = S.insert myName (moduleSet l)
+    , moduleName = Just myName
+    }
+
+serializeLedger :: Ledger -> String
+serializeLedger l =
+    concatMap
+        (\myName ->
+             let muxes = fromMaybe 0 (M.lookup myName (moduleMuxMap l))
+             in myName ++ " => " ++ show muxes ++ " muxes!\n")
+        (moduleSet l)
+
+-- The compiler transform, exported so it is visible to Scala
+
+data AnalyzeCircuit = AnalyzeCircuit @tutorial.lesson3.AnalyzeCircuit
+   deriving Class
+
+type instance Inherits AnalyzeCircuit = '[Transform]
+
+inputForm :: Java AnalyzeCircuit CircuitForm
+inputForm = return $ superCast lowForm
+
+outputForm :: Java AnalyzeCircuit CircuitForm
+outputForm = return $ superCast lowForm
+
+execute :: CircuitState -> Java AnalyzeCircuit CircuitState
+execute state = do
+    ledger <- io $ newIORef newLedger
+
+    _circuit' <- state <.> circuit >- mapModule (fun1 (walkModule ledger))
+
+    ledger' <- io $ readIORef ledger
+    let result = serializeLedger ledger'
+    io $ putStrLn result
+
+    return state
+  where
+    walkModule ledger m = do
+        nm <- m <.> name
+        io $ modifyIORef ledger $ setModuleName nm
+        m <.> mapModStmt (fun1 (walkStatement ledger))
+        return m
+
+    walkStatement ledger s = do
+        s <.> mapStmtStmt (fun1 (walkStatement ledger))
+        s <.> mapStmtExpr (fun1 (walkExpression ledger))
+        return s
+
+    walkExpression ledger e = do
+        e <.> mapExprExpr (fun1 (walkExpression ledger))
+
+        -- If e is a [[Mux]], increment our ledger and return e.
+        case safeDowncast e :: Maybe Mux of
+            Just _ ->
+                io $ modifyIORef ledger foundMux
+            _ -> return ()
+
+        return e
+
+foreign export java inputForm  :: Java AnalyzeCircuit CircuitForm
+foreign export java outputForm :: Java AnalyzeCircuit CircuitForm
+foreign export java execute    :: CircuitState -> Java AnalyzeCircuit CircuitState

--- a/src/main/eta/transforms.cabal
+++ b/src/main/eta/transforms.cabal
@@ -1,0 +1,22 @@
+name:          transforms
+version:       0.1.0.0
+synopsis:      Compiler transforms written using Eta
+license:       MIT
+license-file:  LICENSE
+author:        John Wiegley
+maintainer:    john.wiegley@baesystems.com
+copyright:     Copyright (c) 2018, BAE Systems
+build-type:    Simple
+cabal-version: >=1.10
+
+library
+  default-language: Haskell2010
+  exposed-modules:
+    Transform.AnalyzeCircuit
+  other-modules:
+    Lib.Scala
+    Lib.FIRRTL
+  build-depends:
+      base >=4.8 && <4.9
+    , containers
+    , transformers


### PR DESCRIPTION
This PR re-implements the `tutorial.lesson1.AnalyzeCircuit` compiler transform (under the name `tutoral.lesson3.AnalyzeCircuit`) using the [Eta](https://eta-lang.org/) implementation of the Haskell language to both interact with Scala, and to implement the "meat" of the analysis without recourse to the Scala library (for example, module summation is done using the Haskell data structures `Data.Set` and `Data.Map`).

Many thanks are due to @puffnfresh and @rahulmutt from the Eta development team, who helped with both advice and rapid fixes in `eta` and `sbt-eta` to get this working.