### PR TITLE
Make InstanceGraph have defined iteration order

### DIFF
--- a/src/main/scala/firrtl/graph/DiGraph.scala
+++ b/src/main/scala/firrtl/graph/DiGraph.scala
@@ -263,7 +263,7 @@ class DiGraph[T] private[graph] (private[graph] val edges: LinkedHashMap[T, Link
     * @param start the node to start at
     * @return a Map[T,Seq[Seq[T]]] where the value associated with v is the Seq of all paths from start to v
     */
-  def pathsInDAG(start: T): Map[T,Seq[Seq[T]]] = {
+  def pathsInDAG(start: T): LinkedHashMap[T,Seq[Seq[T]]] = {
     // paths(v) holds the set of paths from start to v
     val paths = new LinkedHashMap[T, mutable.Set[Seq[T]]]
     val queue = new mutable.Queue[T]

--- a/src/test/scala/firrtlTests/analyses/InstanceGraphTests.scala
+++ b/src/test/scala/firrtlTests/analyses/InstanceGraphTests.scala
@@ -15,6 +15,8 @@ class InstanceGraphTests extends FirrtlFlatSpec {
     (graph.getVertices map {v => (v, graph.getEdges(v))}).toMap
   }
 
+  behavior of "InstanceGraph"
+
   it should "recognize a simple hierarchy" in {
     val input = """
 circuit Top :
@@ -94,5 +96,72 @@ circuit Top :
     // g2 combines
     //   (f1, Fizz) -> (f, Foo) and (f2, Fizz) -> (b, Bar)
     g2.getEdges("Fizz") shouldBe Set("Foo", "Bar")
+  }
+
+  // Note that due to optimized implementations of Map1-4, at least 5 entries are needed to
+  // experience non-determinism
+  it should "preserve Module declaration order" in {
+    val input = """
+      |circuit Top :
+      |  module Top :
+      |    inst c1 of Child1
+      |    inst c2 of Child2
+      |  module Child1 :
+      |    inst a of Child1a
+      |    inst b of Child1b
+      |    skip
+      |  module Child1a :
+      |    skip
+      |  module Child1b :
+      |    skip
+      |  module Child2 :
+      |    skip
+      |""".stripMargin
+    val circuit = ToWorkingIR.run(parse(input))
+    val instGraph = new InstanceGraph(circuit)
+    val childMap = instGraph.getChildrenInstances
+    childMap.keys.toSeq should equal (Seq("Top", "Child1", "Child1a", "Child1b", "Child2"))
+  }
+
+  // Note that due to optimized implementations of Map1-4, at least 5 entries are needed to
+  // experience non-determinism
+  it should "preserve Instance declaration order" in {
+    val input = """
+      |circuit Top :
+      |  module Top :
+      |    inst a of Child
+      |    inst b of Child
+      |    inst c of Child
+      |    inst d of Child
+      |    inst e of Child
+      |    inst f of Child
+      |  module Child :
+      |    skip
+      |""".stripMargin
+    val circuit = ToWorkingIR.run(parse(input))
+    val instGraph = new InstanceGraph(circuit)
+    val childMap = instGraph.getChildrenInstances
+    val insts = childMap("Top").toSeq.map(_.name)
+    insts should equal (Seq("a", "b", "c", "d", "e", "f"))
+  }
+
+  // Note that due to optimized implementations of Map1-4, at least 5 entries are needed to
+  // experience non-determinism
+  it should "have defined fullHierarchy order" in {
+    val input = """
+      |circuit Top :
+      |  module Top :
+      |    inst a of Child
+      |    inst b of Child
+      |    inst c of Child
+      |    inst d of Child
+      |    inst e of Child
+      |  module Child :
+      |    skip
+      |""".stripMargin
+    val circuit = ToWorkingIR.run(parse(input))
+    val instGraph = new InstanceGraph(circuit)
+    val hier = instGraph.fullHierarchy
+    hier.keys.toSeq.map(_.name) should equal (Seq("Top", "a", "b", "c", "d", "e"))
   }
 }


### PR DESCRIPTION
DiGraph is deterministic but the construction of them via InstanceGraph is not. This PR makes it so.

I'm not a fan of explicitly returning mutable data structures, but as we all know, Scala kind of bites us on this by making the only immutable Map with defined iteration order very slow (ListMap).

`SeqMap` may exist in Scala 2.13, and may even have a reasonable implementation with `VectorMap`: https://github.com/scala/scala/pull/6854. But as long as we're supporting Scala 2.12 we'll be stuck with this weird issue. We could copy the current implementation of VectorMap/LinkedMap (it's BSD licensed) https://github.com/mdedetrich/linked-map and use it within the compiler rather than returning LinkedHashMaps. I don't know, what do y'all think?