### PR TITLE
Fix bug in zero-width renaming

### DIFF
--- a/src/main/scala/firrtl/passes/ZeroWidth.scala
+++ b/src/main/scala/firrtl/passes/ZeroWidth.scala
@@ -66,8 +66,12 @@ object ZeroWidth extends Transform {
       else fields.flatMap(f => findRemovable(WSubField(expr, f.name, f.tpe, MALE), f.tpe))
     case VectorType(vtpe, size) =>
       if (size == 0) List(expr)
-      else findRemovable(WSubIndex(expr, 0, vtpe, MALE), vtpe).flatMap { e =>
-        (0 until size).map(i => e.asInstanceOf[WSubIndex].copy(value = i))
+      else { // Only invoke findRemovable multiple times if a zero-width element is found
+        val es0 = findRemovable(WSubIndex(expr, 0, vtpe, MALE), vtpe)
+        if (es0.isEmpty) es0
+        else {
+          es0 ++ (1 until size).flatMap(i => findRemovable(WSubIndex(expr, i, vtpe, MALE), vtpe))
+        }
       }
   }
 

--- a/src/test/scala/firrtlTests/AnnotationTests.scala
+++ b/src/test/scala/firrtlTests/AnnotationTests.scala
@@ -430,10 +430,13 @@ abstract class AnnotationTests extends AnnotationSpec with Matchers {
         |    output y : { foo : UInt<8>, bar : {}, fizz : UInt<8>[0], buzz : UInt<0> }
         |    output a : {}
         |    output b : UInt<8>[0]
+        |    output c : { d : UInt<0>, e : UInt<8> }[2]
+        |    c is invalid
         |    y <= x
         |""".stripMargin
     val annos = Seq(
-      anno("x"), anno("y.bar"), anno("y.fizz"), anno("y.buzz"), anno("a"), anno("b")
+      anno("x"), anno("y.bar"), anno("y.fizz"), anno("y.buzz"), anno("a"), anno("b"), anno("c"),
+      anno("c[0].d"), anno("c[1].d")
     )
     val result = compiler.compile(CircuitState(parse(input), ChirrtlForm, annos), Nil)
     val resultAnno = result.annotations.toSeq
@@ -453,6 +456,13 @@ abstract class AnnotationTests extends AnnotationSpec with Matchers {
     resultAnno should not contain (anno("x_bar"))
     resultAnno should not contain (anno("x_fizz"))
     resultAnno should not contain (anno("x_buzz"))
+    resultAnno should not contain (anno("c"))
+    resultAnno should contain (anno("c_0_e"))
+    resultAnno should contain (anno("c_1_e"))
+    resultAnno should not contain (anno("c[0].d"))
+    resultAnno should not contain (anno("c[1].d"))
+    resultAnno should not contain (anno("c_0_d"))
+    resultAnno should not contain (anno("c_1_d"))
   }
 }
 


### PR DESCRIPTION
Previously, Vecs of Bundles that contained a zero-width element would
result in a ClassCastException

Fixes a bug introduced in https://github.com/freechipsproject/firrtl/pull/839