### PR TITLE
InferWidths: improve performance

### DIFF
--- a/src/main/scala/firrtl/passes/InferWidths.scala
+++ b/src/main/scala/firrtl/passes/InferWidths.scala
@@ -41,12 +41,12 @@ object InferWidths extends Pass {
       case wx => wx
     }
     def collectMinMax(w: Width): Width = w map collectMinMax match {
-      case MinWidth(args) => MinWidth(unique((args.foldLeft(Seq[Width]())) {
-        case (res, wxx: MinWidth) => wxx.args ++ res
+      case MinWidth(args) => MinWidth(unique(args.foldLeft(List[Width]()) {
+        case (res, wxx: MinWidth) => wxx.args ++: res
         case (res, wxx) => wxx +: res
       }))
-      case MaxWidth(args) => MaxWidth(unique((args.foldLeft(Seq[Width]())) {
-        case (res, wxx: MaxWidth) => wxx.args ++ res
+      case MaxWidth(args) => MaxWidth(unique(args.foldLeft(List[Width]()) {
+        case (res, wxx: MaxWidth) => wxx.args ++: res
         case (res, wxx) => wxx +: res
       }))
       case wx => wx

--- a/src/main/scala/firrtl/passes/InferWidths.scala
+++ b/src/main/scala/firrtl/passes/InferWidths.scala
@@ -42,12 +42,12 @@ object InferWidths extends Pass {
     }
     def collectMinMax(w: Width): Width = w map collectMinMax match {
       case MinWidth(args) => MinWidth(unique((args.foldLeft(Seq[Width]())) {
-        case (res, wxx: MinWidth) => res ++ wxx.args
-        case (res, wxx) => res :+ wxx
+        case (res, wxx: MinWidth) => wxx.args ++ res
+        case (res, wxx) => wxx +: res
       }))
       case MaxWidth(args) => MaxWidth(unique((args.foldLeft(Seq[Width]())) {
-        case (res, wxx: MaxWidth) => res ++ wxx.args
-        case (res, wxx) => res :+ wxx
+        case (res, wxx: MaxWidth) => wxx.args ++ res
+        case (res, wxx) => wxx +: res
       }))
       case wx => wx
     }


### PR DESCRIPTION
On circuits with large numbers of width inferences, prepend to a linked list instead of appending and having to make a copy.

Thanks @azidar for the catch

Close #842