### PR TITLE
Use LinkedHashSet in propagateAnnotations

### DIFF
--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -283,10 +283,8 @@ abstract class Transform extends LazyLogging {
       resAnno: AnnotationSeq,
       renameOpt: Option[RenameMap]): AnnotationSeq = {
     val newAnnotations = {
-      val inSet = new mutable.LinkedHashSet[Annotation]
-      inSet ++= inAnno
-      val resSet = new mutable.LinkedHashSet[Annotation]
-      resSet ++= resAnno
+      val inSet = mutable.LinkedHashSet() ++ inAnno
+      val resSet = mutable.LinkedHashSet() ++ resAnno
       val deleted = (inSet -- resSet).map {
         case DeletedAnnotation(xFormName, delAnno) => DeletedAnnotation(s"$xFormName+$name", delAnno)
         case anno => DeletedAnnotation(name, anno)

--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -283,8 +283,10 @@ abstract class Transform extends LazyLogging {
       resAnno: AnnotationSeq,
       renameOpt: Option[RenameMap]): AnnotationSeq = {
     val newAnnotations = {
-      val inSet = inAnno.toSet
-      val resSet = resAnno.toSet
+      val inSet = new mutable.LinkedHashSet[Annotation]
+      inSet ++= inAnno
+      val resSet = new mutable.LinkedHashSet[Annotation]
+      resSet ++= resAnno
       val deleted = (inSet -- resSet).map {
         case DeletedAnnotation(xFormName, delAnno) => DeletedAnnotation(s"$xFormName+$name", delAnno)
         case anno => DeletedAnnotation(name, anno)

--- a/src/test/scala/firrtlTests/AnnotationTests.scala
+++ b/src/test/scala/firrtlTests/AnnotationTests.scala
@@ -625,4 +625,22 @@ class JsonAnnotationTests extends AnnotationTests with BackendCompilationUtiliti
         if msg.contains("JObject") =>
     }
   }
+
+  object DoNothingTransform extends Transform {
+    override def inputForm: CircuitForm = UnknownForm
+    override def outputForm: CircuitForm = UnknownForm
+
+    protected def execute(state: CircuitState): CircuitState = state
+  }
+
+  "annotation order" should "should be preserved" in {
+    val annos = Seq(anno("a"), anno("b"), anno("c"), anno("d"), anno("e"))
+    val input: String =
+      """circuit Top :
+         |  module Top :
+         |    input a : UInt<1>
+         |    node b = c""".stripMargin
+    val cr = DoNothingTransform.runTransform(CircuitState(parse(input), ChirrtlForm, annos))
+    cr.annotations.toSeq shouldEqual annos
+  }
 }


### PR DESCRIPTION
- use `LinkedHashSet` in `propagateAnnotations` to preserve order of annotations
- add a test case to test for annotation order preservation