### PR TITLE
Stop reporting exceptions in custom transformations as internal errors

### DIFF
--- a/src/main/scala/firrtl/Driver.scala
+++ b/src/main/scala/firrtl/Driver.scala
@@ -248,6 +248,8 @@ object Driver {
         case p: PassException    => throw p
         case p: PassExceptions   => throw p
         case p: FIRRTLException  => throw p
+        // Propagate exceptions from custom transforms
+        case CustomTransformException(cause) => throw cause
         // Treat remaining exceptions as internal errors.
         case e: Exception => throwInternalError(exception = Some(e))
       }

--- a/src/test/scala/firrtlTests/InferReadWriteSpec.scala
+++ b/src/test/scala/firrtlTests/InferReadWriteSpec.scala
@@ -135,8 +135,11 @@ circuit sram6t :
 """.stripMargin
 
     val annos = Seq(memlib.InferReadWriteAnnotation)
-    intercept[InferReadWriteCheckException] {
+    intercept[Exception] {
       compileAndEmit(CircuitState(parse(input), ChirrtlForm, annos))
+    } match {
+      case CustomTransformException(_: InferReadWriteCheckException) => // success
+      case _ => fail()
     }
   }
 

--- a/src/test/scala/firrtlTests/annotationTests/EliminateTargetPathsSpec.scala
+++ b/src/test/scala/firrtlTests/annotationTests/EliminateTargetPathsSpec.scala
@@ -260,16 +260,19 @@ class EliminateTargetPathsSpec extends FirrtlPropSpec with FirrtlMatchers {
         |    m2.i <= m1.o
         |    o <= m2.o
       """.stripMargin
-    intercept[NoSuchTargetException] {
+    val e1 = the [CustomTransformException] thrownBy {
       val Top_m1 = Top.instOf("m1", "MiddleX")
       val inputState = CircuitState(parse(input), ChirrtlForm, Seq(DummyAnnotation(Top_m1)))
       new LowFirrtlCompiler().compile(inputState, customTransforms)
     }
-    intercept[NoSuchTargetException] {
+    e1.cause shouldBe a [NoSuchTargetException]
+
+    val e2 = the [CustomTransformException] thrownBy {
       val Top_m2 = Top.instOf("x2", "Middle")
       val inputState = CircuitState(parse(input), ChirrtlForm, Seq(DummyAnnotation(Top_m2)))
       new LowFirrtlCompiler().compile(inputState, customTransforms)
     }
+    e2.cause shouldBe a [NoSuchTargetException]
   }
 
   property("No name conflicts between two new modules") {


### PR DESCRIPTION
Instead, just forward the exception