### PR TITLE
Make RemoveWires properly include registers in dependency graph

### DIFF
--- a/src/main/scala/firrtl/WIR.scala
+++ b/src/main/scala/firrtl/WIR.scala
@@ -35,6 +35,8 @@ object WRef {
   def apply(wire: DefWire): WRef = new WRef(wire.name, wire.tpe, WireKind, UNKNOWNGENDER)
   /** Creates a WRef from a Register */
   def apply(reg: DefRegister): WRef = new WRef(reg.name, reg.tpe, RegKind, UNKNOWNGENDER)
+  /** Creates a WRef from a Node */
+  def apply(node: DefNode): WRef = new WRef(node.name, node.value.tpe, NodeKind, MALE)
   def apply(n: String, t: Type = UnknownType, k: Kind = ExpKind): WRef = new WRef(n, t, k, UNKNOWNGENDER)
 }
 case class WSubField(expr: Expression, name: String, tpe: Type, gender: Gender) extends Expression {

--- a/src/test/scala/firrtlTests/RemoveWiresSpec.scala
+++ b/src/test/scala/firrtlTests/RemoveWiresSpec.scala
@@ -150,4 +150,19 @@ class RemoveWiresSpec extends FirrtlFlatSpec {
     val names = orderedNames(result.circuit)
     names should be (Seq("a", "clock2", "b"))
   }
+
+  it should "order registers correctly" in {
+    val result = compileBody(s"""
+      |input clock : Clock
+      |input a : UInt<8>
+      |output c : UInt<8>
+      |wire w : UInt<8>
+      |node n = tail(add(w, UInt(1)), 1)
+      |reg r : UInt<8>, clock
+      |w <= tail(add(r, a), 1)
+      |c <= n""".stripMargin
+    )
+    // Check declaration before use is maintained
+    passes.CheckHighForm.execute(result)
+  }
 }


### PR DESCRIPTION
Fixes a bug where registers could be instantiated after nodes that
referred to them

Also add WRef.apply utility for nodes