### PR TITLE
Allow the #delay before random initialization to be overridden

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -672,11 +672,16 @@ class VerilogEmitter extends SeqTransform with Emitter {
         emit(Seq("    `ifdef INIT_RANDOM"))
         emit(Seq("      `INIT_RANDOM"))
         emit(Seq("    `endif"))
-        // This enables test benches to set the random values at time 0.001,
-        //   then start the simulation later
+        // This enables testbenches to seed the random values at some time
+        // before `RANDOMIZE_DELAY (or the legacy value 0.002 if
+        // `RANDOMIZE_DELAY is not defined).
         // Verilator does not support delay statements, so they are omitted.
         emit(Seq("    `ifndef VERILATOR"))
-        emit(Seq("      #0.002 begin end"))
+        emit(Seq("      `ifdef RANDOMIZE_DELAY"))
+        emit(Seq("        #`RANDOMIZE_DELAY begin end"))
+        emit(Seq("      `else"))
+        emit(Seq("        #0.002 begin end"))
+        emit(Seq("      `endif"))
         emit(Seq("    `endif"))
         for (x <- initials) emit(Seq(tab, x))
         emit(Seq("  end"))


### PR DESCRIPTION
The default of 0.002 can be less than the Verilog time precision, which
effectively causes it to be rounded down to 0.  So, allow the user to
`define RANDOMIZE_DELAY to some other value.

If the macro is not defined, the old behavior is preserved.