### PR TITLE
[F764.1] Bump scopt from 3.6.0 -> 3.7.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 
 libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.13.4" % "test"
 
-libraryDependencies += "com.github.scopt" %% "scopt" % "3.6.0"
+libraryDependencies += "com.github.scopt" %% "scopt" % "3.7.0"
 
 libraryDependencies += "net.jcazevedo" %% "moultingyaml" % "0.4.0"
 


### PR DESCRIPTION
This provides support for increased introspection of options inside of
scopt, e.g., getting an options short option (shortOpt).

Patch 1 for #764

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@ibm.com>