### PR TITLE
Fix NoDedupMem to be cognizant of Module scope

### DIFF
--- a/src/main/scala/firrtl/passes/memlib/ResolveMaskGranularity.scala
+++ b/src/main/scala/firrtl/passes/memlib/ResolveMaskGranularity.scala
@@ -78,9 +78,8 @@ object AnalysisUtils {
 
   /** Checks whether the two memories are equivalent in all respects except name
     */
-  def eqMems(a: DefAnnotatedMemory, b: DefAnnotatedMemory, noDeDupeMems: Seq[String]): Boolean =
-    a == b.copy(info = a.info, name = a.name, memRef = a.memRef) &&
-    !(noDeDupeMems.contains(a.name) || noDeDupeMems.contains(b.name))
+  def eqMems(a: DefAnnotatedMemory, b: DefAnnotatedMemory): Boolean =
+    a == b.copy(info = a.info, name = a.name, memRef = a.memRef)
 }
 
 /** Determines if a write mask is needed (wmode/en and wmask are equivalent).

--- a/src/main/scala/firrtl/passes/memlib/ResolveMaskGranularity.scala
+++ b/src/main/scala/firrtl/passes/memlib/ResolveMaskGranularity.scala
@@ -75,11 +75,6 @@ object AnalysisUtils {
        }
     case _ => e
   }
-
-  /** Checks whether the two memories are equivalent in all respects except name
-    */
-  def eqMems(a: DefAnnotatedMemory, b: DefAnnotatedMemory): Boolean =
-    a == b.copy(info = a.info, name = a.name, memRef = a.memRef)
 }
 
 /** Determines if a write mask is needed (wmode/en and wmask are equivalent).

--- a/src/main/scala/firrtl/passes/memlib/ResolveMemoryReference.scala
+++ b/src/main/scala/firrtl/passes/memlib/ResolveMemoryReference.scala
@@ -30,9 +30,7 @@ class ResolveMemoryReference extends Transform {
       case _ => false
     }
   }
-  private implicit def wrapMem(x: DefAnnotatedMemory) = new WrappedDefAnnoMemory(x)
-
-  import scala.language.implicitConversions
+  private def wrap(mem: DefAnnotatedMemory) = new WrappedDefAnnoMemory(mem)
 
   // Values are Tuple of Module Name and Memory Instance Name
   private type AnnotatedMemories = collection.mutable.HashMap[WrappedDefAnnoMemory, (String, String)]
@@ -50,11 +48,12 @@ class ResolveMemoryReference extends Transform {
     // If not dedupable, no need to add to existing (since nothing can dedup with it)
     // We just return the DefAnnotatedMemory as is in the default case below
     case m: DefAnnotatedMemory if dedupable(noDedupMap, mname, m.name) =>
-      existingMems.get(m) match {
+      val wrapped = wrap(m)
+      existingMems.get(wrapped) match {
         case proto @ Some(_) =>
           m.copy(memRef = proto)
         case None =>
-          existingMems(m) = (mname, m.name)
+          existingMems(wrapped) = (mname, m.name)
           m
       }
     case s => s.map(updateMemStmts(mname, existingMems, noDedupMap))


### PR DESCRIPTION
Previously, mems marked no dedup would prevent mems with the same
instance name in other modules from deduping

This is *technically* changing an API because I changed the implementation of public utility method `eqMems`. I did so because the noDeDupeMems argument doesn't really work as intended. Honestly I doubt anyone is using it.