### PR TITLE
Easy conversion of String => LogLevel.value

### DIFF
--- a/src/main/scala/logger/Logger.scala
+++ b/src/main/scala/logger/Logger.scala
@@ -29,6 +29,15 @@ import scala.util.DynamicVariable
   */
 object LogLevel extends Enumeration {
   val Error, Warn, Info, Debug, Trace, None = Value
+
+  def apply(s: String): LogLevel.Value = s.toLowerCase match {
+    case "error" => LogLevel.Error
+    case "warn"  => LogLevel.Warn
+    case "info"  => LogLevel.Info
+    case "debug" => LogLevel.Debug
+    case "trace" => LogLevel.Trace
+    case level => throw new Exception("Unknown LogLevel '$level'")
+  }
 }
 
 /**


### PR DESCRIPTION
This adds an apply method to the LogLevel object for conversion from a
String to a LogLevel.value.

Patch 2 for #764 

This can be reordered before https://github.com/freechipsproject/firrtl/pull/875.