### PR TITLE
[F764.3] Add explicit SystemVerilogCompiler class

### DIFF
--- a/src/main/scala/firrtl/ExecutionOptionsManager.scala
+++ b/src/main/scala/firrtl/ExecutionOptionsManager.scala
@@ -209,7 +209,7 @@ extends ComposableOptions {
       case "low"       => new LowFirrtlCompiler()
       case "middle"    => new MiddleFirrtlCompiler()
       case "verilog"   => new VerilogCompiler()
-      case "sverilog"  => new VerilogCompiler()
+      case "sverilog"  => new SystemVerilogCompiler()
     }
   }
 

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -158,3 +158,8 @@ class MinimumVerilogCompiler extends Compiler {
   def transforms: Seq[Transform] = getLoweringTransforms(ChirrtlForm, LowForm) ++
     Seq(new MinimumLowFirrtlOptimization, new BlackBoxSourceHelper)
 }
+
+/** Currently just an alias for the [[VerilogCompiler]] */
+class SystemVerilogCompiler extends VerilogCompiler {
+  Driver.dramaticWarning("SystemVerilog Compiler behaves the same as the Verilog Compiler!")
+}


### PR DESCRIPTION
This adds an explicit SystemVerilogCompiler class that extends the existing VerilogCompiler class. Upon use, this will print a warning that this is equivalent to using the Verilog compiler. 

Note: the SV compiler differs _in the implementation of FIRRTL's `Driver`_ where it will emit filenames ending in `*.sv`.

Patch 3 for #764 

This does not have to be committed in order with other #764 patches.