### PR TITLE
Enable "Unserializable" JSON Annotations

### DIFF
--- a/src/main/scala/firrtl/annotations/Annotation.scala
+++ b/src/main/scala/firrtl/annotations/Annotation.scala
@@ -1,10 +1,8 @@
 // See LICENSE for license details.
 
-package firrtl
-package annotations
+package firrtl.annotations
 
-import net.jcazevedo.moultingyaml._
-import firrtl.annotations.AnnotationYamlProtocol._
+import firrtl._
 
 case class AnnotationException(message: String) extends Exception(message)
 
@@ -25,6 +23,39 @@ trait Annotation {
   */
 trait NoTargetAnnotation extends Annotation {
   def update(renames: RenameMap) = Seq(this)
+}
+
+/** Indicates that this annotation ''cannot'' be serialized to JSON
+  *
+  * This is intended to be used if you have an annotation containing something that json4s cannot handle, e.g., an
+  * anonymous function like `() => Module`. You can optionally override [[toJsonSerializable]] to provide a conversion
+  * of this unserializable annotation to a serializable one. For example, a dut generator like `() => Module` can be
+  * serializable to a circuit via elaboration.
+  *
+  * '''Use this sparingly! If you find yourself using this, you are likely using an anti-pattern that can be better
+  * accomplished with a different approach!'''
+  */
+trait Unserializable extends Annotation {
+  /** A stub method that will be used to serialize this unserializable annotation to another [[Annotation]] that ''can''
+    * be serialized to JSON.
+    *
+    * '''This method must return an annotation that does not subclass [[Unserializable]]!'''
+    *
+    * @note This is not type safe. There may be a better way to do this...
+    * @throw AnnotationException if this method is implemented to return an [[Annotation]] that subclasses this trait
+    */
+  def toJsonSerializable: AnnotationSeq
+
+  /** Do the conversion to an [[Annotation]] that can be serialized to JSON. This will check that the conversion does not
+    * have the [[Unserializable]] trait.
+    */
+  final def _toJsonSerializable: AnnotationSeq = this.toJsonSerializable.flatMap(
+    _ match {
+      case _: Unserializable =>
+        throw new AnnotationException(s"The provided 'toJsonSerializable' method did not remove all 'Unserializable' annotations from '${this.getClass.getName}' (did you implement 'toJsonSerializable' incorrectly?)")
+      case a => Seq(a)
+    }
+  )
 }
 
 /** An Annotation that targets a single [[Named]] thing */
@@ -177,4 +208,3 @@ private[firrtl] object LegacyAnnotation {
 case class DeletedAnnotation(xFormName: String, anno: Annotation) extends NoTargetAnnotation {
   override def serialize: String = s"""DELETED by $xFormName\n${anno.serialize}"""
 }
-

--- a/src/main/scala/firrtl/annotations/JsonProtocol.scala
+++ b/src/main/scala/firrtl/annotations/JsonProtocol.scala
@@ -46,9 +46,14 @@ object JsonProtocol {
   def serialize(annos: Seq[Annotation]): String = serializeTry(annos).get
 
   def serializeTry(annos: Seq[Annotation]): Try[String] = {
-    val tags = annos.map(_.getClass).distinct
+    val annosx: Seq[Annotation] = annos.flatMap {
+      case a: Unserializable => a._toJsonSerializable
+      case DeletedAnnotation(_, _: Unserializable) => Seq()
+      case a => Seq(a)
+    }
+    val tags = annosx.map(_.getClass).distinct
     implicit val formats = jsonFormat(tags)
-    Try(writePretty(annos))
+    Try(writePretty(annosx))
   }
 
   def deserialize(in: JsonInput): Seq[Annotation] = deserializeTry(in).get

--- a/src/test/scala/firrtlTests/AnnotationTests.scala
+++ b/src/test/scala/firrtlTests/AnnotationTests.scala
@@ -16,6 +16,9 @@ import net.jcazevedo.moultingyaml._
 import org.scalatest.Matchers
 import logger._
 
+// This cannot be put inside the 'it should' block due to a json4s limitation and odd behavior when performing equality
+case class NonExceptingAnnotation(foo: String) extends NoTargetAnnotation
+
 /**
  * An example methodology for testing Firrtl annotations.
  */
@@ -642,5 +645,28 @@ class JsonAnnotationTests extends AnnotationTests with BackendCompilationUtiliti
          |    node b = c""".stripMargin
     val cr = DoNothingTransform.runTransform(CircuitState(parse(input), ChirrtlForm, annos))
     cr.annotations.toSeq shouldEqual annos
+  }
+
+  behavior of "Unserializable annotations"
+
+  it should "throw an exception for a serializer that subclasses Unserializable" in {
+    case class ExceptingAnnotation(foo: () => String) extends NoTargetAnnotation with Unserializable {
+      def toJsonSerializable: AnnotationSeq = Seq(this)
+    }
+    val annos = Seq(ExceptingAnnotation(() => "foo"))
+
+    (the [AnnotationException] thrownBy { JsonProtocol.serialize(annos) })
+      .getMessage should include ("(did you implement 'toJsonSerializable' incorrectly?)")
+  }
+
+  it should "convert to a serializable annotation" in {
+    case class ExceptingAnnotation(foo: () => String) extends NoTargetAnnotation with Unserializable {
+      def toJsonSerializable: AnnotationSeq = Seq(NonExceptingAnnotation(foo()))
+    }
+    val annos = Seq(ExceptingAnnotation(() => "foo"))
+    val annosx = JsonProtocol.deserialize(JsonProtocol.serialize(annos))
+    val expected = Seq(NonExceptingAnnotation("foo"))
+
+    annosx should be (expected)
   }
 }


### PR DESCRIPTION
__This no longer is needed by the F764 patch series. I'm hesitant on whether or not this is the right approach. I'm leaving this here for the time being.__

This adds a trait `Unserializable` that indicates two things when mixed into an `Annotation`:

1. This indicates that this annotation cannot be serialized to JSON by json4s natively because it contains something "weird" like an anonymous function, e.g., `() => RawModule`.
2. By implementing an abstract method, `toJsonSerializable`, this `Annotation` can be converted to an `AnnotationSeq` _that can be serialized_.
3. When the `JsonProtocol` tries to serialize it, it will first convert it to something that is "good" for JSON, e.g., serializing `() => RawModule` would elaborate the module first.

JSON serialization is modified to ignore any `DeletedAnnotation`s that contain an unserializable annotation.

This includes a test that unserializable things that the user doesn't implement properly except _at run time_ and that an unserializable annotation is converted to what you expect.

Note: I used a type-unsafe approach here for the abstract method `toJsonSerializable`. I need this to return an `Annotation` that does not mixin `Unserializable`. I wasn't aware of an approach that could do that in a method signature. I fell back to having a second, final method `_toJsonSerializable` call `toJsonSerializable` and do run-time type checks. This is what is used for automatic conversion during JSON serialization.