### PR TITLE
Bug Fixes in TopWiring

### DIFF
--- a/src/main/scala/firrtl/transforms/TopWiring.scala
+++ b/src/main/scala/firrtl/transforms/TopWiring.scala
@@ -1,5 +1,5 @@
 // See LICENSE for license details.
-package firrtl.transform
+package firrtl.transforms
 package TopWiring
 
 import firrtl._
@@ -198,7 +198,7 @@ class TopWiringTransform extends Transform {
                 }
                 path.size match {
                    case 1 => {
-                       val leafRef = WRef(path.head.mkString("_"))
+                       val leafRef = WRef(path.head.mkString(""))
                        Connect(NoInfo, modRef, leafRef)
                    }
                    case _ =>  {
@@ -251,19 +251,21 @@ class TopWiringTransform extends Transform {
                           (String,Seq[((ComponentName, Type, Boolean, InstPath, String), Int)],
                                         CircuitState) => CircuitState)] = state.annotations.collect {
          case TopWiringOutputFilesAnnotation(td,of) => (td, of) }
-
     // Do actual work of this transform
     val sources = getSourcesMap(state)
-    val portnamesmap : mutable.Map[String,String] = mutable.Map()
-    val instgraph = new firrtl.analyses.InstanceGraph(state.circuit)
-    val namespacemap = state.circuit.modules.map{ case m => (m.name -> Namespace(m)) }.toMap
-    val modulesx = state.circuit.modules map onModule(sources, portnamesmap, instgraph, namespacemap)
-    val newCircuit = state.circuit.copy(modules = modulesx)
-    val fixedCircuit = fixupCircuit(newCircuit)
-    val mappings = sources(state.circuit.main).zipWithIndex
-    //Generate output files based on the mapping.
-    outputTuples.map { case (dir, outputfunction) => outputfunction(dir, mappings, state) }
-    // fin.
-    state.copy(circuit = fixedCircuit)
+    if (!(sources.isEmpty)) {
+      val portnamesmap : mutable.Map[String,String] = mutable.Map()
+      val instgraph = new firrtl.analyses.InstanceGraph(state.circuit)
+      val namespacemap = state.circuit.modules.map{ case m => (m.name -> Namespace(m)) }.toMap
+      val modulesx = state.circuit.modules map onModule(sources, portnamesmap, instgraph, namespacemap)
+      val newCircuit = state.circuit.copy(modules = modulesx)
+      val fixedCircuit = fixupCircuit(newCircuit)
+      val mappings = sources(state.circuit.main).zipWithIndex
+      //Generate output files based on the mapping.
+      outputTuples.map { case (dir, outputfunction) => outputfunction(dir, mappings, state) }
+      // fin.
+      state.copy(circuit = fixedCircuit)
+    }
+    else { state }
   }
 }

--- a/src/test/scala/firrtlTests/transforms/TopWiringTest.scala
+++ b/src/test/scala/firrtlTests/transforms/TopWiringTest.scala
@@ -1,7 +1,7 @@
 // See LICENSE for license details.
 
 package firrtlTests
-package transform
+package transforms
 
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
@@ -20,7 +20,8 @@ import firrtl.annotations.{
    ComponentName,
    Annotation
 }
-import firrtl.transform.TopWiring._
+import firrtl.transforms.TopWiring._
+
 
 /**
  * Tests TopWiring transformation
@@ -437,6 +438,81 @@ class TopWiringTests extends LowTransformSpec with FirrtlRunners {
            |    output topwiring_x: UInt<1>
            |    x <= UInt(0)
            |    topwiring_x <= x
+           """.stripMargin
+      execute(input, check, topwiringannos)
+   }
+
+   "The signal fullword in module C inst c1 and c2 and signal y in module A_" should 
+   s"be connected to Top port with topwiring and top2wiring prefix and outfile in $testDirName" in {
+      val input =
+         """circuit Top :
+           |  module Top :
+           |    inst a1 of A
+           |    inst a2 of A_
+           |  module A :
+           |    output fullword: UInt<1>
+           |    fullword <= UInt(1)
+           |    inst b1 of B
+           |  module A_ :
+           |    output fullword: UInt<1>
+           |    wire y : UInt<1>
+           |    y <= UInt(1)
+           |    fullword <= UInt(1)
+           |  module B :
+           |    output fullword: UInt<1>
+           |    fullword <= UInt(1)
+           |    inst c1 of C
+           |    inst c2 of C
+           |  module C:
+           |    output fullword: UInt<1>
+           |    fullword <= UInt(0)
+           """.stripMargin
+      val topwiringannos = Seq(TopWiringAnnotation(ComponentName(s"fullword", 
+                                                                 ModuleName(s"C", CircuitName(s"Top"))), 
+                                                   s"topwiring_"),
+                               TopWiringAnnotation(ComponentName(s"y", 
+                                                                 ModuleName(s"A_", CircuitName(s"Top"))), 
+                                                   s"top2wiring_"),
+                         TopWiringOutputFilesAnnotation(testDirName, topWiringTestOutputFilesFunction))
+      val check =
+         """circuit Top :
+           |  module Top :
+           |    output topwiring_a1_b1_c1_fullword: UInt<1>
+           |    output topwiring_a1_b1_c2_fullword: UInt<1>
+           |    output top2wiring_a2_y: UInt<1>
+           |    inst a1 of A
+           |    inst a2 of A_
+           |    topwiring_a1_b1_c1_fullword <= a1.topwiring_b1_c1_fullword
+           |    topwiring_a1_b1_c2_fullword <= a1.topwiring_b1_c2_fullword
+           |    top2wiring_a2_y <= a2.top2wiring_y
+           |  module A :
+           |    output fullword: UInt<1>
+           |    output topwiring_b1_c1_fullword: UInt<1>
+           |    output topwiring_b1_c2_fullword: UInt<1>
+           |    inst b1 of B
+           |    fullword <= UInt(1)
+           |    topwiring_b1_c1_fullword <= b1.topwiring_c1_fullword
+           |    topwiring_b1_c2_fullword <= b1.topwiring_c2_fullword
+           |  module A_ :
+           |    output fullword: UInt<1>
+           |    output top2wiring_y: UInt<1>
+           |    node y = UInt<1>("h1")
+           |    fullword <= UInt(1)
+           |    top2wiring_y <= y
+           |  module B :
+           |    output fullword: UInt<1>
+           |    output topwiring_c1_fullword: UInt<1>
+           |    output topwiring_c2_fullword: UInt<1>
+           |    inst c1 of C
+           |    inst c2 of C
+           |    fullword <= UInt(1)
+           |    topwiring_c1_fullword <= c1.topwiring_fullword
+           |    topwiring_c2_fullword <= c2.topwiring_fullword
+           |  module C:
+           |    output fullword: UInt<1>
+           |    output topwiring_fullword: UInt<1>
+           |    fullword <= UInt(0)
+           |    topwiring_fullword <= fullword
            """.stripMargin
       execute(input, check, topwiringannos)
    }

--- a/src/test/scala/firrtlTests/transforms/TopWiringTest.scala
+++ b/src/test/scala/firrtlTests/transforms/TopWiringTest.scala
@@ -516,4 +516,28 @@ class TopWiringTests extends LowTransformSpec with FirrtlRunners {
            """.stripMargin
       execute(input, check, topwiringannos)
    }
+
+   "TopWiringTransform" should "do nothing if run without TopWiring* annotations" in {
+     val input = """|circuit Top :
+                    |  module Top :
+                    |    input foo : UInt<1>""".stripMargin
+     val inputFile = {
+       val fileName = s"${testDir.getAbsolutePath}/input-no-sources.fir"
+       val w = new PrintWriter(fileName)
+       w.write(input)
+       w.close()
+       fileName
+     }
+     val args = Array(
+       "--custom-transforms", "firrtl.transforms.TopWiring.TopWiringTransform",
+       "--input-file", inputFile,
+       "--top-name", "Top",
+       "--compiler", "low",
+       "--info-mode", "ignore"
+     )
+     firrtl.Driver.execute(args) match {
+       case FirrtlExecutionSuccess(_, emitted) => parse(emitted) should be (parse(input))
+       case _ => fail
+     }
+   }
 }


### PR DESCRIPTION
I found a couple of bugs in the TopWiring transform while using it in an actual scenario (rather than only unit tests). The two bugs were a results of running the transform without any relevant annotations, and the transform renaming leaf components in a bad way (separating letters with underscores. This wasn't discovered in the unit tests because all the leaf signal were single letters).
I fixed them, and added an additional unit tests for one of the bugs.
I also changed to package name from 'transform' to 'transforms' in order to match the rests of the firrtl transforms.