### PR TITLE
Do not remove ExtMods with no ports by default

### DIFF
--- a/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
+++ b/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
@@ -178,7 +178,8 @@ class DeadCodeElimination extends Transform {
                              deadNodes: collection.Set[LogicNode],
                              moduleMap: collection.Map[String, DefModule],
                              renames: RenameMap,
-                             topName: String)
+                             topName: String,
+                             doTouchExtMods: Set[String])
                             (mod: DefModule): Option[DefModule] = {
     // For log-level debug
     def deleteMsg(decl: IsDeclaration): String = {
@@ -257,7 +258,7 @@ class DeadCodeElimination extends Transform {
           Some(Module(info, name, portsx, bodyx))
         }
       case ext: ExtModule =>
-        if (portsx.isEmpty) {
+        if (portsx.isEmpty && doTouchExtMods.contains(ext.name)) {
           logger.debug(deleteMsg(mod))
           None
         }
@@ -308,7 +309,7 @@ class DeadCodeElimination extends Transform {
     // current status of the modulesxMap is used to either delete instances or update their types
     val modulesxMap = mutable.HashMap.empty[String, DefModule]
     topoSortedModules.foreach { case mod =>
-      deleteDeadCode(moduleDeps(mod.name), deadNodes, modulesxMap, renames, c.main)(mod) match {
+      deleteDeadCode(moduleDeps(mod.name), deadNodes, modulesxMap, renames, c.main, doTouchExtMods)(mod) match {
         case Some(m) => modulesxMap += m.name -> m
         case None => renames.delete(ModuleName(mod.name, CircuitName(c.main)))
       }

--- a/src/test/scala/firrtlTests/DCETests.scala
+++ b/src/test/scala/firrtlTests/DCETests.scala
@@ -2,7 +2,7 @@
 
 package firrtlTests
 
-import firrtl.ir._
+import firrtl.ir.Circuit
 import firrtl._
 import firrtl.passes._
 import firrtl.transforms._

--- a/src/test/scala/firrtlTests/DCETests.scala
+++ b/src/test/scala/firrtlTests/DCETests.scala
@@ -2,12 +2,13 @@
 
 package firrtlTests
 
-import firrtl.ir.Circuit
+import firrtl.ir._
 import firrtl._
 import firrtl.passes._
 import firrtl.transforms._
 import firrtl.annotations._
 import firrtl.passes.memlib.SimpleTransform
+import FirrtlCheckers._
 
 import java.io.File
 import java.nio.file.Paths
@@ -319,6 +320,40 @@ class DCETests extends FirrtlFlatSpec {
         |    out <= bb2.out
         """.stripMargin
     exec(input, input)
+  }
+  "extmodules with no ports" should "NOT be deleted by default" in {
+    val input =
+      """circuit Top :
+        |  extmodule BlackBox :
+        |    defname = BlackBox
+        |  module Top :
+        |    input x : UInt<1>
+        |    output y : UInt<1>
+        |    inst blackBox of BlackBox
+        |    y <= x
+        |""".stripMargin
+    exec(input, input)
+  }
+  "extmodules with no ports marked optimizable" should "be deleted" in {
+    val input =
+      """circuit Top :
+        |  extmodule BlackBox :
+        |    defname = BlackBox
+        |  module Top :
+        |    input x : UInt<1>
+        |    output y : UInt<1>
+        |    inst blackBox of BlackBox
+        |    y <= x
+        |""".stripMargin
+    val check =
+      """circuit Top :
+        |  module Top :
+        |    input x : UInt<1>
+        |    output y : UInt<1>
+        |    y <= x
+        |""".stripMargin
+    val doTouchAnno = OptimizableExtModuleAnnotation(ModuleName("BlackBox", CircuitName("Top")))
+    exec(input, check, Seq(doTouchAnno))
   }
   // bar.z is not used and thus is dead code, but foo.z is used so this code isn't eliminated
   "Module deduplication" should "should be preserved despite unused output of ONE instance" in {


### PR DESCRIPTION
Change default behavior so that `ExtModule`s with no ports are not deleted