### PR TITLE
Another TopWiring Bug Fix (Multi-Level Annotations)

### DIFF
--- a/src/main/scala/firrtl/transforms/TopWiring.scala
+++ b/src/main/scala/firrtl/transforms/TopWiring.scala
@@ -150,7 +150,7 @@ class TopWiringTransform extends Transform {
           sourcemods.get(module).map( _.map { case (a,b,c,path,p) => (a,b,c, inst +: path, p)})
       }.flatten
       if (seqChildren.nonEmpty) {
-        sourcemods(mod.name) = seqChildren
+        sourcemods(mod.name) = sourcemods.getOrElse(mod.name, Seq()) ++ seqChildren
       }
     }
 


### PR DESCRIPTION
Another bug discovered in TopWiring as part Midas testing.
When different levels of the circuit were annotated, the TopWiring signals of the lower levels would "run-over" the TopWiring signals of the higher levels.
One line bug fix, and I added a test that exposes the bug.