### PR TITLE
Firesim - Another TopWiring Bug Fix (Multi-Level Annotations)

### DIFF
--- a/src/main/scala/firrtl/transforms/TopWiring.scala
+++ b/src/main/scala/firrtl/transforms/TopWiring.scala
@@ -150,7 +150,7 @@ class TopWiringTransform extends Transform {
           sourcemods.get(module).map( _.map { case (a,b,c,path,p) => (a,b,c, inst +: path, p)})
       }.flatten
       if (seqChildren.nonEmpty) {
-        sourcemods(mod.name) = seqChildren
+        sourcemods(mod.name) = sourcemods.getOrElse(mod.name, Seq()) ++ seqChildren
       }
     }
 

--- a/src/test/scala/firrtlTests/transforms/TopWiringTest.scala
+++ b/src/test/scala/firrtlTests/transforms/TopWiringTest.scala
@@ -516,6 +516,84 @@ class TopWiringTests extends LowTransformSpec {
       execute(input, check, topwiringannos)
    }
 
+
+   "The signal fullword in module C inst c1 and c2 and signal fullword in module B" should
+   s"be connected to Top port with topwiring prefix" in {
+      val input =
+         """circuit Top :
+           |  module Top :
+           |    inst a1 of A
+           |    inst a2 of A_
+           |  module A :
+           |    output fullword: UInt<1>
+           |    fullword <= UInt(1)
+           |    inst b1 of B
+           |  module A_ :
+           |    output fullword: UInt<1>
+           |    wire y : UInt<1>
+           |    y <= UInt(1)
+           |    fullword <= UInt(1)
+           |  module B :
+           |    output fullword: UInt<1>
+           |    fullword <= UInt(1)
+           |    inst c1 of C
+           |    inst c2 of C
+           |  module C:
+           |    output fullword: UInt<1>
+           |    fullword <= UInt(0)
+           """.stripMargin
+     val topwiringannos = Seq(TopWiringAnnotation(ComponentName(s"fullword",
+                                                                 ModuleName(s"C", CircuitName(s"Top"))),
+                                                   s"topwiring_"),
+                               TopWiringAnnotation(ComponentName(s"fullword",
+                                                                 ModuleName(s"B", CircuitName(s"Top"))),
+                                                   s"topwiring_"))
+     val check =
+         """circuit Top :
+           |  module Top :
+           |    output topwiring_a1_b1_fullword: UInt<1>
+           |    output topwiring_a1_b1_c1_fullword: UInt<1>
+           |    output topwiring_a1_b1_c2_fullword: UInt<1>
+           |    inst a1 of A
+           |    inst a2 of A_
+           |    topwiring_a1_b1_fullword <= a1.topwiring_b1_fullword
+           |    topwiring_a1_b1_c1_fullword <= a1.topwiring_b1_c1_fullword
+           |    topwiring_a1_b1_c2_fullword <= a1.topwiring_b1_c2_fullword
+           |  module A :
+           |    output fullword: UInt<1>
+           |    output topwiring_b1_fullword: UInt<1>
+           |    output topwiring_b1_c1_fullword: UInt<1>
+           |    output topwiring_b1_c2_fullword: UInt<1>
+           |    inst b1 of B
+           |    fullword <= UInt(1)
+           |    topwiring_b1_fullword <= b1.topwiring_fullword
+           |    topwiring_b1_c1_fullword <= b1.topwiring_c1_fullword
+           |    topwiring_b1_c2_fullword <= b1.topwiring_c2_fullword
+           |  module A_ :
+           |    output fullword: UInt<1>
+           |    node y = UInt<1>("h1")
+           |    fullword <= UInt(1)
+           |  module B :
+           |    output fullword: UInt<1>
+           |    output topwiring_fullword: UInt<1>
+           |    output topwiring_c1_fullword: UInt<1>
+           |    output topwiring_c2_fullword: UInt<1>
+           |    inst c1 of C
+           |    inst c2 of C
+           |    fullword <= UInt(1)
+           |    topwiring_fullword <= fullword
+           |    topwiring_c1_fullword <= c1.topwiring_fullword
+           |    topwiring_c2_fullword <= c2.topwiring_fullword
+           |  module C:
+           |    output fullword: UInt<1>
+           |    output topwiring_fullword: UInt<1>
+           |    fullword <= UInt(0)
+           |    topwiring_fullword <= fullword
+           """.stripMargin
+      execute(input, check, topwiringannos)
+   }
+
+
    "TopWiringTransform" should "do nothing if run without TopWiring* annotations" in {
      val input = """|circuit Top :
                     |  module Top :

--- a/src/test/scala/firrtlTests/transforms/TopWiringTest.scala
+++ b/src/test/scala/firrtlTests/transforms/TopWiringTest.scala
@@ -1,7 +1,7 @@
 // See LICENSE for license details.
 
 package firrtlTests
-package transform
+package transforms
 
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
@@ -20,7 +20,8 @@ import firrtl.annotations.{
    ComponentName,
    Annotation
 }
-import firrtl.transform.TopWiring._
+import firrtl.transforms.TopWiring._
+
 
 
 /**
@@ -438,5 +439,104 @@ class TopWiringTests extends LowTransformSpec {
            |    topwiring_x <= x
            """.stripMargin
       execute(input, check, topwiringannos)
+   }
+
+   "The signal fullword in module C inst c1 and c2 and signal y in module A_" should 
+   s"be connected to Top port with topwiring and top2wiring prefix and outfile in $testDirName" in {
+      val input =
+         """circuit Top :
+           |  module Top :
+           |    inst a1 of A
+           |    inst a2 of A_
+           |  module A :
+           |    output fullword: UInt<1>
+           |    fullword <= UInt(1)
+           |    inst b1 of B
+           |  module A_ :
+           |    output fullword: UInt<1>
+           |    wire y : UInt<1>
+           |    y <= UInt(1)
+           |    fullword <= UInt(1)
+           |  module B :
+           |    output fullword: UInt<1>
+           |    fullword <= UInt(1)
+           |    inst c1 of C
+           |    inst c2 of C
+           |  module C:
+           |    output fullword: UInt<1>
+           |    fullword <= UInt(0)
+           """.stripMargin
+      val topwiringannos = Seq(TopWiringAnnotation(ComponentName(s"fullword", 
+                                                                 ModuleName(s"C", CircuitName(s"Top"))), 
+                                                   s"topwiring_"),
+                               TopWiringAnnotation(ComponentName(s"y", 
+                                                                 ModuleName(s"A_", CircuitName(s"Top"))), 
+                                                   s"top2wiring_"),
+                         TopWiringOutputFilesAnnotation(testDirName, topWiringTestOutputFilesFunction))
+      val check =
+         """circuit Top :
+           |  module Top :
+           |    output topwiring_a1_b1_c1_fullword: UInt<1>
+           |    output topwiring_a1_b1_c2_fullword: UInt<1>
+           |    output top2wiring_a2_y: UInt<1>
+           |    inst a1 of A
+           |    inst a2 of A_
+           |    topwiring_a1_b1_c1_fullword <= a1.topwiring_b1_c1_fullword
+           |    topwiring_a1_b1_c2_fullword <= a1.topwiring_b1_c2_fullword
+           |    top2wiring_a2_y <= a2.top2wiring_y
+           |  module A :
+           |    output fullword: UInt<1>
+           |    output topwiring_b1_c1_fullword: UInt<1>
+           |    output topwiring_b1_c2_fullword: UInt<1>
+           |    inst b1 of B
+           |    fullword <= UInt(1)
+           |    topwiring_b1_c1_fullword <= b1.topwiring_c1_fullword
+           |    topwiring_b1_c2_fullword <= b1.topwiring_c2_fullword
+           |  module A_ :
+           |    output fullword: UInt<1>
+           |    output top2wiring_y: UInt<1>
+           |    node y = UInt<1>("h1")
+           |    fullword <= UInt(1)
+           |    top2wiring_y <= y
+           |  module B :
+           |    output fullword: UInt<1>
+           |    output topwiring_c1_fullword: UInt<1>
+           |    output topwiring_c2_fullword: UInt<1>
+           |    inst c1 of C
+           |    inst c2 of C
+           |    fullword <= UInt(1)
+           |    topwiring_c1_fullword <= c1.topwiring_fullword
+           |    topwiring_c2_fullword <= c2.topwiring_fullword
+           |  module C:
+           |    output fullword: UInt<1>
+           |    output topwiring_fullword: UInt<1>
+           |    fullword <= UInt(0)
+           |    topwiring_fullword <= fullword
+           """.stripMargin
+      execute(input, check, topwiringannos)
+   }
+
+   "TopWiringTransform" should "do nothing if run without TopWiring* annotations" in {
+     val input = """|circuit Top :
+                    |  module Top :
+                    |    input foo : UInt<1>""".stripMargin
+     val inputFile = {
+       val fileName = s"${testDir.getAbsolutePath}/input-no-sources.fir"
+       val w = new PrintWriter(fileName)
+       w.write(input)
+       w.close()
+       fileName
+     }
+     val args = Array(
+       "--custom-transforms", "firrtl.transforms.TopWiring.TopWiringTransform",
+       "--input-file", inputFile,
+       "--top-name", "Top",
+       "--compiler", "low",
+       "--info-mode", "ignore"
+     )
+     firrtl.Driver.execute(args) match {
+       case FirrtlExecutionSuccess(_, emitted) => parse(emitted) should be (parse(input))
+       case _ => fail
+     }
    }
 }


### PR DESCRIPTION
Backport to the firesim branch, same as https://github.com/freechipsproject/firrtl/pull/889
Another bug discovered in TopWiring as part Midas testing.
When different levels of the circuit were annotated, the TopWiring signals of the lower levels would "run-over" the TopWiring signals of the higher levels.
One line bug fix, and I added a test that exposes the bug.
