### PR TITLE
add BlackBoxPathAnno

### DIFF
--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -82,8 +82,8 @@ class BlackBoxSourceHelper extends firrtl.Transform {
         val fromFile = new File(path)
         val toFile = new File(targetDir, fileName)
 
-        val inputStream = new FileInputStream(toFile).getChannel
-        val outputStream = new FileOutputStream(fromFile).getChannel
+        val inputStream = new FileInputStream(fromFile).getChannel
+        val outputStream = new FileOutputStream(toFile).getChannel
         outputStream.transferFrom(inputStream, 0, Long.MaxValue)
 
         toFile

--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -2,7 +2,7 @@
 
 package firrtl.transforms
 
-import java.io.{File, FileNotFoundException, FileOutputStream, PrintWriter}
+import java.io.{File, FileNotFoundException, FileInputStream, FileOutputStream, PrintWriter}
 
 import firrtl._
 import firrtl.Utils.throwInternalError
@@ -27,6 +27,12 @@ case class BlackBoxInlineAnno(target: ModuleName, name: String, text: String) ex
     with SingleTargetAnnotation[ModuleName] {
   def duplicate(n: ModuleName) = this.copy(target = n)
   override def serialize: String = s"inline\n$name\n$text"
+}
+
+case class BlackBoxPathAnno(target: ModuleName, path: String) extends BlackBoxHelperAnno
+    with SingleTargetAnnotation[ModuleName] {
+  def duplicate(n: ModuleName) = this.copy(target = n)
+  override def serialize: String = s"path\n$path"
 }
 
 /** Handle source for Verilog ExtModules (BlackBoxes)
@@ -71,6 +77,16 @@ class BlackBoxSourceHelper extends firrtl.Transform {
     val resourceFiles: ListSet[File] = annos.collect {
       case BlackBoxResourceAnno(_, resourceId) =>
         BlackBoxSourceHelper.writeResourceToDirectory(resourceId, targetDir)
+      case BlackBoxPathAnno(_, path) =>
+        val fileName = path.split("/").last
+        val fromFile = new File(path)
+        val toFile = new File(targetDir, fileName)
+
+        val inputStream = new FileInputStream(toFile).getChannel
+        val outputStream = new FileOutputStream(fromFile).getChannel
+        outputStream.transferFrom(inputStream, 0, Long.MaxValue)
+
+        toFile
     }
 
     val inlineFiles: ListSet[File] = annos.collect {

--- a/src/test/scala/firrtlTests/transforms/BlacklBoxSourceHelperSpec.scala
+++ b/src/test/scala/firrtlTests/transforms/BlacklBoxSourceHelperSpec.scala
@@ -59,8 +59,14 @@ class BlacklBoxSourceHelperTransformSpec extends LowTransformSpec {
 
     execute(input, output, annos)
 
-    new java.io.File("test_run_dir/AdderExtModule.v").exists should be (true)
-    new java.io.File(s"test_run_dir/${BlackBoxSourceHelper.fileListName}").exists should be (true)
+    val module = new java.io.File("test_run_dir/AdderExtModule.v")
+    val fileList = new java.io.File(s"test_run_dir/${BlackBoxSourceHelper.fileListName}")
+
+    module.exists should be (true)
+    fileList.exists should be (true)
+
+    module.delete()
+    fileList.delete()
   }
 
   "annotated external modules with relative path" should "appear in output directory" in {
@@ -72,8 +78,14 @@ class BlacklBoxSourceHelperTransformSpec extends LowTransformSpec {
 
     execute(input, output, annos)
 
-    new java.io.File("test_run_dir/AdderExtModule.v").exists should be (true)
-    new java.io.File(s"test_run_dir/${BlackBoxSourceHelper.fileListName}").exists should be (true)
+    val module = new java.io.File("test_run_dir/AdderExtModule.v")
+    val fileList = new java.io.File(s"test_run_dir/${BlackBoxSourceHelper.fileListName}")
+
+    module.exists should be (true)
+    fileList.exists should be (true)
+
+    module.delete()
+    fileList.delete()
   }
 
   "annotated external modules" should "appear in output directory" in {

--- a/src/test/scala/firrtlTests/transforms/BlacklBoxSourceHelperSpec.scala
+++ b/src/test/scala/firrtlTests/transforms/BlacklBoxSourceHelperSpec.scala
@@ -49,6 +49,33 @@ class BlacklBoxSourceHelperTransformSpec extends LowTransformSpec {
                         |   a1.foo <= x
                       """.stripMargin
 
+  "annotated external modules with absolute path" should "appear in output directory" in {
+
+    val absPath = new java.io.File("src/test/resources/blackboxes/AdderExtModule.v").getCanonicalPath
+    val annos = Seq(
+      BlackBoxTargetDirAnno("test_run_dir"),
+      BlackBoxPathAnno(moduleName, absPath)
+    )
+
+    execute(input, output, annos)
+
+    new java.io.File("test_run_dir/AdderExtModule.v").exists should be (true)
+    new java.io.File(s"test_run_dir/${BlackBoxSourceHelper.fileListName}").exists should be (true)
+  }
+
+  "annotated external modules with relative path" should "appear in output directory" in {
+
+    val annos = Seq(
+      BlackBoxTargetDirAnno("test_run_dir"),
+      BlackBoxPathAnno(moduleName, "src/test/resources/blackboxes/AdderExtModule.v")
+    )
+
+    execute(input, output, annos)
+
+    new java.io.File("test_run_dir/AdderExtModule.v").exists should be (true)
+    new java.io.File(s"test_run_dir/${BlackBoxSourceHelper.fileListName}").exists should be (true)
+  }
+
   "annotated external modules" should "appear in output directory" in {
 
     val annos = Seq(


### PR DESCRIPTION
- add `BlackBoxPathAnno` to allow specifying locations of Verilog source files with relative or absolute paths
- add tests for checking that `BlackBoxSourceHelper` copies files