### PR TITLE
[F764.7] Switch to FIRRTL Stage, Driver is compatibility layer

### DIFF
--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -14,6 +14,7 @@ import firrtl.Utils.{error, throwInternalError}
 import firrtl.annotations.TargetToken
 import firrtl.annotations.TargetToken.{Field, Index}
 import firrtl.annotations.transforms.{EliminateTargetPaths, ResolvePaths}
+import firrtl.options.StageUtils
 
 /** Container of all annotations for a Firrtl compiler */
 class AnnotationSeq private (private[firrtl] val underlying: List[Annotation]) {
@@ -101,6 +102,9 @@ object CircuitState {
 sealed abstract class CircuitForm(private val value: Int) extends Ordered[CircuitForm] {
   // Note that value is used only to allow comparisons
   def compare(that: CircuitForm): Int = this.value - that.value
+
+  /** Defines a suffix to use if this form is written to a file */
+  def outputSuffix: String
 }
 
 // scalastyle:off magic.number
@@ -113,7 +117,10 @@ sealed abstract class CircuitForm(private val value: Int) extends Ordered[Circui
   *
   * See [[CDefMemory]] and [[CDefMPort]]
   */
-final case object ChirrtlForm extends CircuitForm(value = 3)
+final case object ChirrtlForm extends CircuitForm(value = 3) {
+  val outputSuffix: String = ".fir"
+}
+
 /** High Form
   *
   * As detailed in the Firrtl specification
@@ -121,7 +128,10 @@ final case object ChirrtlForm extends CircuitForm(value = 3)
   *
   * Also see [[firrtl.ir]]
   */
-final case object HighForm extends CircuitForm(2)
+final case object HighForm extends CircuitForm(2) {
+  val outputSuffix: String = ".hi.fir"
+}
+
 /** Middle Form
   *
   * A "lower" form than [[HighForm]] with the following restrictions:
@@ -129,14 +139,20 @@ final case object HighForm extends CircuitForm(2)
   *  - All whens must be removed
   *  - There can only be a single connection to any element
   */
-final case object MidForm extends CircuitForm(1)
+final case object MidForm extends CircuitForm(1) {
+  val outputSuffix: String = ".mid.fir"
+}
+
 /** Low Form
   *
   * The "lowest" form. In addition to the restrictions in [[MidForm]]:
   *  - All aggregate types (vector/bundle) must have been removed
   *  - All implicit truncations must be made explicit
   */
-final case object LowForm extends CircuitForm(0)
+final case object LowForm extends CircuitForm(0) {
+  val outputSuffix: String = ".lo.fir"
+}
+
 /** Unknown Form
   *
   * Often passes may modify a circuit (e.g. InferTypes), but return
@@ -150,6 +166,8 @@ final case object LowForm extends CircuitForm(0)
   */
 final case object UnknownForm extends CircuitForm(-1) {
   override def compare(that: CircuitForm): Int = { sys.error("Illegal to compare UnknownForm"); 0 }
+
+  val outputSuffix: String = ".unknown.fir"
 }
 // scalastyle:on magic.number
 
@@ -178,7 +196,7 @@ abstract class Transform extends LazyLogging {
   @deprecated("Just collect the actual Annotation types the transform wants", "1.1")
   final def getMyAnnotations(state: CircuitState): Seq[Annotation] = {
     val msg = "getMyAnnotations is deprecated, use collect and match on concrete types"
-    Driver.dramaticWarning(msg)
+    StageUtils.dramaticWarning(msg)
     state.annotations.collect { case a: LegacyAnnotation if a.transform == this.getClass => a }
   }
 
@@ -293,6 +311,9 @@ trait ResolvedAnnotationPaths {
 trait Emitter extends Transform {
   @deprecated("Use emission annotations instead", "firrtl 1.0")
   def emit(state: CircuitState, writer: Writer): Unit
+
+  /** An output suffix to use if the output of this [[Emitter]] was written to a file */
+  def outputSuffix: String
 }
 
 object CompilerUtils extends LazyLogging {
@@ -449,4 +470,3 @@ trait Compiler extends LazyLogging {
   }
 
 }
-

--- a/src/main/scala/firrtl/Driver.scala
+++ b/src/main/scala/firrtl/Driver.scala
@@ -4,11 +4,10 @@ package firrtl
 
 import scala.collection._
 import scala.io.Source
-import scala.sys.process.{BasicIO, ProcessLogger, stringSeqToProcess}
 import scala.util.{Failure, Success, Try}
 import scala.util.control.ControlThrowable
 import java.io.{File, FileNotFoundException}
-
+import scala.sys.process.{BasicIO, ProcessLogger, stringSeqToProcess}
 import net.jcazevedo.moultingyaml._
 import logger.Logger
 import Parser.{IgnoreInfo, InfoMode}
@@ -17,7 +16,10 @@ import firrtl.annotations.AnnotationYamlProtocol._
 import firrtl.passes.{PassException, PassExceptions}
 import firrtl.transforms._
 import firrtl.Utils.throwInternalError
-import firrtl.stage.TargetDirAnnotation
+import firrtl.stage.{FirrtlExecutionResultView, FirrtlStage}
+import firrtl.stage.phases.DriverCompatibility
+import firrtl.options.{StageUtils, Phase}
+import firrtl.options.Viewer.view
 
 
 /**
@@ -41,30 +43,22 @@ import firrtl.stage.TargetDirAnnotation
   * @see firrtlTests/DriverSpec.scala in the test directory for a lot more examples
   * @see [[CompilerUtils.mergeTransforms]] to see how customTransformations are inserted
   */
-
+@deprecated("Use firrtl.stage.FirrtlStage", "1.2")
 object Driver {
   /** Print a warning message
     *
     * @param message error message
     */
-  //scalastyle:off regex
-  def dramaticWarning(message: String): Unit = {
-    println(Console.YELLOW + "-"*78)
-    println(s"Warning: $message")
-    println("-"*78 + Console.RESET)
-  }
+  @deprecated("Use firrtl.options.StageUtils.dramaticWarning", "1.2")
+  def dramaticWarning(message: String): Unit = StageUtils.dramaticWarning(message)
 
   /**
     * print the message in red
     *
     * @param message error message
     */
-  //scalastyle:off regex
-  def dramaticError(message: String): Unit = {
-    println(Console.RED + "-"*78)
-    println(s"Error: $message")
-    println("-"*78 + Console.RESET)
-  }
+  @deprecated("Use firrtl.options.StageUtils.dramaticWarning", "1.2")
+  def dramaticError(message: String): Unit = StageUtils.dramaticError(message)
 
   /** Load annotation file based on options
     * @param optionsManager use optionsManager config to load annotation file if it exists
@@ -108,7 +102,7 @@ object Driver {
     if (firrtlConfig.annotationFileNameOverride.nonEmpty) {
       val msg = "annotationFileNameOverride is deprecated! " +
                 "Use annotationFileNames"
-      Driver.dramaticWarning(msg)
+      dramaticWarning(msg)
     } else if (usingImplicitAnnoFile) {
       val msg = "Implicit .anno file from top-name is deprecated!\n" +
              (" "*9) + "Use explicit -faf option or annotationFileNames"
@@ -160,7 +154,7 @@ object Driver {
     }
 
   // Useful for handling erros in the options
-  case class OptionsException(msg: String) extends Exception(msg)
+  case class OptionsException(message: String) extends Exception(message)
 
   /** Get the Circuit from the compile options
     *
@@ -217,75 +211,25 @@ object Driver {
     * @return a FirrtlExecutionResult indicating success or failure, provide access to emitted data on success
     *         for downstream tools as desired
     */
-  //scalastyle:off cyclomatic.complexity method.length
   def execute(optionsManager: ExecutionOptionsManager with HasFirrtlOptions): FirrtlExecutionResult = {
-    def firrtlConfig = optionsManager.firrtlOptions
+    StageUtils.dramaticWarning("firrtl.Driver is deprecated since 1.2!\nPlease switch to firrtl.stage.FirrtlStage")
 
-    Logger.makeScope(optionsManager) {
-      // Wrap compilation in a try/catch to present Scala MatchErrors in a more user-friendly format.
-      val finalState = try {
-        val circuit = getCircuit(optionsManager) match {
-          case Success(c) => c
-          case Failure(OptionsException(msg)) =>
-            dramaticError(msg)
-            return FirrtlExecutionFailure(msg)
-          case Failure(e) => throw e
-        }
+    val annos = optionsManager.firrtlOptions.toAnnotations ++ optionsManager.commonOptions.toAnnotations
 
-        val annos = getAnnotations(optionsManager)
+    val phases: Seq[Phase] = Seq(
+      DriverCompatibility.AddImplicitAnnotationFile,
+      DriverCompatibility.AddImplicitFirrtlFile,
+      DriverCompatibility.AddImplicitOutputFile,
+      DriverCompatibility.AddImplicitEmitter,
+      FirrtlStage )
 
-        // Does this need to be before calling compiler?
-        optionsManager.makeTargetDir()
-
-        firrtlConfig.compiler.compile(
-          CircuitState(circuit, ChirrtlForm, annos),
-          firrtlConfig.customTransforms
-        )
-      }
-      catch {
-        // Rethrow the exceptions which are expected or due to the runtime environment (out of memory, stack overflow)
-        case p: ControlThrowable => throw p
-        case p: PassException    => throw p
-        case p: PassExceptions   => throw p
-        case p: FIRRTLException  => throw p
-        // Treat remaining exceptions as internal errors.
-        case e: Exception => throwInternalError(exception = Some(e))
-      }
-
-      // Do emission
-      // Note: Single emission target assumption is baked in here
-      // Note: FirrtlExecutionSuccess emitted is only used if we're emitting the whole Circuit
-      val emittedRes = firrtlConfig.getOutputConfig(optionsManager) match {
-        case SingleFile(filename) =>
-          val emitted = finalState.getEmittedCircuit
-          val outputFile = new java.io.PrintWriter(filename)
-          outputFile.write(emitted.value)
-          outputFile.close()
-          emitted.value
-        case OneFilePerModule(dirName) =>
-          val emittedModules = finalState.emittedComponents collect { case x: EmittedModule => x }
-          if (emittedModules.isEmpty) throwInternalError() // There should be something
-          emittedModules.foreach { module =>
-            val filename = optionsManager.getBuildFileName(firrtlConfig.outputSuffix, s"$dirName/${module.name}")
-            val outputFile = new java.io.PrintWriter(filename)
-            outputFile.write(module.value)
-            outputFile.close()
-          }
-          "" // Should we return something different here?
-      }
-
-      // If set, emit final annotations to a file
-      optionsManager.firrtlOptions.outputAnnotationFileName match {
-        case "" =>
-        case file =>
-          val filename = optionsManager.getBuildFileName("anno.json", file)
-          val outputFile = new java.io.PrintWriter(filename)
-          outputFile.write(JsonProtocol.serialize(finalState.annotations))
-          outputFile.close()
-      }
-
-      FirrtlExecutionSuccess(firrtlConfig.compilerName, emittedRes, finalState)
+    val annosx = try {
+      phases.foldLeft(annos)( (a, p) => p.transform(a) )
+    } catch {
+      case e: firrtl.options.OptionsException => return FirrtlExecutionFailure(e.message)
     }
+
+    view[FirrtlExecutionResult](annosx)
   }
 
   /**
@@ -320,23 +264,16 @@ object Driver {
 }
 
 object FileUtils {
-  /**
-    * recursive create directory and all parents
-    *
+
+  /** Create a directory if it doesn't exist
     * @param directoryName a directory string with one or more levels
-    * @return
+    * @return true if the directory exists or if it was successfully created
     */
   def makeDirectory(directoryName: String): Boolean = {
-    val dirFile = new java.io.File(directoryName)
+    val dirFile = new File(directoryName)
     if(dirFile.exists()) {
-      if(dirFile.isDirectory) {
-        true
-      }
-      else {
-        false
-      }
-    }
-    else {
+      dirFile.isDirectory
+    } else {
       dirFile.mkdirs()
     }
   }
@@ -360,7 +297,7 @@ object FileUtils {
     if(file.getPath.split("/").last.isEmpty ||
       file.getAbsolutePath == "/" ||
       file.getPath.startsWith("/")) {
-      Driver.dramaticError(s"delete directory ${file.getPath} will not delete absolute paths")
+      StageUtils.dramaticError(s"delete directory ${file.getPath} will not delete absolute paths")
       false
     }
     else {

--- a/src/main/scala/firrtl/ExecutionOptionsManager.scala
+++ b/src/main/scala/firrtl/ExecutionOptionsManager.scala
@@ -8,7 +8,13 @@ import firrtl.ir.Circuit
 import firrtl.passes.memlib.{InferReadWriteAnnotation, ReplSeqMemAnnotation}
 import firrtl.passes.clocklist.ClockListAnnotation
 import logger.LogLevel
+import logger.{ClassLogLevelAnnotation, LogClassNamesAnnotation, LogFileAnnotation, LogLevelAnnotation}
 import scopt.OptionParser
+import firrtl.stage.{CompilerAnnotation, FirrtlCircuitAnnotation, FirrtlFileAnnotation, FirrtlSourceAnnotation,
+  InfoModeAnnotation, OutputFileAnnotation, RunFirrtlTransformAnnotation}
+import firrtl.stage.phases.DriverCompatibility.{TopNameAnnotation, EmitOneFilePerModuleAnnotation}
+import firrtl.options.{InputAnnotationFileAnnotation, OutputAnnotationFileAnnotation, ProgramArgsAnnotation, StageUtils}
+import firrtl.transforms.{DontCheckCombLoopsAnnotation, NoDCEAnnotation}
 
 import scala.collection.Seq
 
@@ -18,8 +24,10 @@ import scala.collection.Seq
   * '''NOTE''' In all derived trait/classes, if you intend on maintaining backwards compatibility,
   *  be sure to add new options at the end of the current ones and don't remove any existing ones.
   */
+@deprecated("Use firrtl.options.HasScoptOptions and/or library/transform registration", "1.2")
 trait ComposableOptions
 
+@deprecated("Use firrtl.options.{ExecutionOptionsManager, TerminateOnExit, DuplicateHandling}", "1.2")
 abstract class HasParser(applicationName: String) {
   final val parser = new OptionParser[Unit](applicationName) {
     var terminateOnExit = true
@@ -48,6 +56,7 @@ abstract class HasParser(applicationName: String) {
   * For example, in chisel, by deferring this it is possible for the execute there to first elaborate the
   * circuit and then set the topName from that if it has not already been set.
   */
+@deprecated("Use a FirrtlOptionsView, LoggerOptionsView, or construct your own view of an AnnotationSeq", "1.2")
 case class CommonOptions(
     topName:           String         = "",
     targetDirName:     String         = ".",
@@ -66,8 +75,17 @@ case class CommonOptions(
       optionsManager.getBuildFileName("log")
     }
   }
+
+  def toAnnotations: AnnotationSeq = (if (topName.nonEmpty) Seq(TopNameAnnotation(topName)) else Seq()) ++
+    (if (targetDirName != ".") Some(TargetDirAnnotation(targetDirName)) else None) ++
+    Some(LogLevelAnnotation(globalLogLevel)) ++
+    (if (logToFile) { Some(LogFileAnnotation(None)) } else { None }) ++
+    (if (logClassNames) { Some(LogClassNamesAnnotation) } else { None }) ++
+    classLogLevels.map{ case (c, v) => ClassLogLevelAnnotation(c, v) } ++
+    programArgs.map( a => ProgramArgsAnnotation(a) )
 }
 
+@deprecated("Specify command line arguments in an Annotation mixing in HasScoptOptions", "1.2")
 trait HasCommonOptions {
   self: ExecutionOptionsManager =>
   var commonOptions = CommonOptions()
@@ -168,6 +186,7 @@ final case class OneFilePerModule(targetDir: String) extends OutputConfig
   * @param compilerName           which compiler to use
   * @param annotations            annotations to pass to compiler
   */
+@deprecated("Use a FirrtlOptionsView or construct your own view of an AnnotationSeq", "1.2")
 case class FirrtlExecutionOptions(
     inputFileNameOverride:  String = "",
     outputFileNameOverride: String = "",
@@ -284,8 +303,31 @@ extends ComposableOptions {
   def getAnnotationFileName(optionsManager: ExecutionOptionsManager): String = {
     optionsManager.getBuildFileName("anno", annotationFileNameOverride)
   }
+
+  def toAnnotations: AnnotationSeq = {
+    if (inferRW.nonEmpty) {
+      StageUtils.dramaticWarning("User set FirrtlExecutionOptions.inferRW, but inferRW has no effect!")
+    }
+
+    (if (inputFileNameOverride.nonEmpty) Seq(FirrtlFileAnnotation(inputFileNameOverride)) else Seq()) ++
+      (if (outputFileNameOverride.nonEmpty) { Some(OutputFileAnnotation(outputFileNameOverride)) } else { None }) ++
+      Some(CompilerAnnotation(compilerName)) ++
+      Some(InfoModeAnnotation(infoModeName)) ++
+      firrtlSource.map(FirrtlSourceAnnotation(_)) ++
+      customTransforms.map(t => RunFirrtlTransformAnnotation(t)) ++
+      annotations ++
+      (if (annotationFileNameOverride.nonEmpty) { Some(InputAnnotationFileAnnotation(annotationFileNameOverride)) } else { None }) ++
+      (if (outputAnnotationFileName.nonEmpty) { Some(OutputAnnotationFileAnnotation(outputAnnotationFileName)) } else { None }) ++
+      (if (emitOneFilePerModule) { Some(EmitOneFilePerModuleAnnotation) } else { None }) ++
+      (if (dontCheckCombLoops) { Some(DontCheckCombLoopsAnnotation) } else { None }) ++
+      (if (noDCE) { Some(NoDCEAnnotation) } else { None }) ++
+      annotationFileNames.map(InputAnnotationFileAnnotation(_)) ++
+      firrtlCircuit.map(FirrtlCircuitAnnotation(_))
+  }
 }
 
+
+@deprecated("Specify command line arguments in an Annotation mixing in HasScoptOptions", "1.2")
 trait HasFirrtlOptions {
   self: ExecutionOptionsManager =>
   var firrtlOptions = FirrtlExecutionOptions()
@@ -330,7 +372,7 @@ trait HasFirrtlOptions {
     .foreach { _ =>
       val msg = "force-append-anno-file is deprecated and will soon be removed\n" +
                 (" "*9) + "(It does not do anything anymore)"
-      Driver.dramaticWarning(msg)
+      StageUtils.dramaticWarning(msg)
     }
 
   parser.opt[String]("output-annotation-file")
@@ -474,8 +516,10 @@ trait HasFirrtlOptions {
   parser.note("")
 }
 
+@deprecated("Use FirrtlStage and examine the output AnnotationSeq directly", "since 1.3")
 sealed trait FirrtlExecutionResult
 
+@deprecated("Use FirrtlStage and examine the output AnnotationSeq directly", "since 1.3")
 object FirrtlExecutionSuccess {
   def apply(
     emitType    : String,
@@ -495,6 +539,7 @@ object FirrtlExecutionSuccess {
   * @param emitType  The name of the compiler used, currently "high", "middle", "low", "verilog", or "sverilog"
   * @param emitted   The emitted result of compilation
   */
+@deprecated("Use FirrtlStage and examine the output AnnotationSeq directly", "since 1.3")
 class FirrtlExecutionSuccess(
   val emitType: String,
   val emitted : String,
@@ -506,12 +551,14 @@ class FirrtlExecutionSuccess(
   *
   * @param message  Some kind of hint as to what went wrong.
   */
+@deprecated("Use FirrtlStage and examine the output AnnotationSeq directly", "since 1.3")
 case class FirrtlExecutionFailure(message: String) extends FirrtlExecutionResult
 
 /**
   *
   * @param applicationName  The name shown in the usage
   */
+@deprecated("Use new FirrtlStage infrastructure", "1.2")
 class ExecutionOptionsManager(val applicationName: String) extends HasParser(applicationName) with HasCommonOptions {
 
   def parse(args: Array[String]): Boolean = {

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -3,6 +3,7 @@
 package firrtl
 
 import firrtl.transforms.IdentityTransform
+import firrtl.options.StageUtils
 
 sealed abstract class CoreTransform extends SeqTransform
 
@@ -173,5 +174,6 @@ class MinimumVerilogCompiler extends Compiler {
 
 /** Currently just an alias for the [[VerilogCompiler]] */
 class SystemVerilogCompiler extends VerilogCompiler {
-  Driver.dramaticWarning("SystemVerilog Compiler behaves the same as the Verilog Compiler!")
+  override def emitter = new SystemVerilogEmitter
+  StageUtils.dramaticWarning("SystemVerilog Compiler behaves the same as the Verilog Compiler!")
 }

--- a/src/main/scala/firrtl/annotations/Annotation.scala
+++ b/src/main/scala/firrtl/annotations/Annotation.scala
@@ -6,6 +6,7 @@ package annotations
 import net.jcazevedo.moultingyaml._
 import firrtl.annotations.AnnotationYamlProtocol._
 import firrtl.Utils.throwInternalError
+import firrtl.options.StageUtils
 
 import scala.collection.mutable
 
@@ -190,7 +191,7 @@ private[firrtl] object LegacyAnnotation {
     case other => other
   }
   // scalastyle:on
-  def convertLegacyAnnos(annos: Seq[Annotation]): Seq[Annotation] = {
+  def convertLegacyAnnos(annos: AnnotationSeq): AnnotationSeq = {
     var warned: Boolean = false
     annos.map {
       case legacy: LegacyAnnotation =>
@@ -198,7 +199,7 @@ private[firrtl] object LegacyAnnotation {
         if (!warned && (annox ne legacy)) {
           val msg = s"A LegacyAnnotation was automatically converted.\n" + (" "*9) +
             "This functionality will soon be removed. Please migrate to new annotations."
-          Driver.dramaticWarning(msg)
+          StageUtils.dramaticWarning(msg)
           warned = true
         }
         annox
@@ -210,4 +211,3 @@ private[firrtl] object LegacyAnnotation {
 case class DeletedAnnotation(xFormName: String, anno: Annotation) extends NoTargetAnnotation {
   override def serialize: String = s"""DELETED by $xFormName\n${anno.serialize}"""
 }
-

--- a/src/main/scala/firrtl/options/Exceptions.scala
+++ b/src/main/scala/firrtl/options/Exceptions.scala
@@ -1,0 +1,20 @@
+// See LICENSE for license details.
+
+package firrtl.options
+
+/** Indicate a generic error in a [[Phase]]
+  * @param message exception message
+  * @param cause an underlying Exception that this wraps
+  */
+class PhaseException(val message: String, cause: Throwable = null) extends RuntimeException(message, cause)
+
+/** Indicate an error related to a bad [[firrtl.annotations.Annotation Annotation]] or it's command line option
+  * equivalent. This exception is always caught and converted to an error message by a [[Stage]]. Do not use this for
+  * communicating generic exception information.
+  */
+class OptionsException(val message: String, cause: Throwable = null) extends IllegalArgumentException(message, cause)
+
+/** Indicates that a [[Phase]] is missing some mandatory information. This likely occurs either if a user ran something
+  * out of order or if the compiler did not run things in the correct order.
+  */
+class PhasePrerequisiteException(message: String, cause: Throwable = null) extends PhaseException(message, cause)

--- a/src/main/scala/firrtl/options/OptionParser.scala
+++ b/src/main/scala/firrtl/options/OptionParser.scala
@@ -2,14 +2,26 @@
 
 package firrtl.options
 
-import firrtl.{FIRRTLException, AnnotationSeq}
+import firrtl.AnnotationSeq
 
 import scopt.OptionParser
 
-/** Causes an OptionParser to not call exit (call `sys.exit`) if the `--help` option is passed
-  */
+case object OptionsHelpException extends Exception("Usage help invoked")
+
+/** OptionParser mixin that causes the OptionParser to not call exit (call `sys.exit`) if the `--help` option is
+  * passed */
 trait DoNotTerminateOnExit { this: OptionParser[_] =>
   override def terminate(exitState: Either[String, Unit]): Unit = Unit
+}
+
+/** OptionParser mixin that converts to [[OptionsException]]
+  *
+  * Scopt, by default, will print errors to stderr, e.g., invalid arguments will do this. However, a [[Stage]] uses
+  * [[StageUtils.dramaticError]]. By converting this to an [[OptionsException]], a [[Stage]] can then catch the error an
+  * convert it to an [[OptionsException]] that a [[Stage]] can get at.
+  */
+trait ExceptOnError { this: OptionParser[_] =>
+  override def reportError(msg: String): Unit = throw new OptionsException(msg)
 }
 
 /** A modified OptionParser with mutable termination and additional checks

--- a/src/main/scala/firrtl/options/OptionsView.scala
+++ b/src/main/scala/firrtl/options/OptionsView.scala
@@ -4,25 +4,25 @@ package firrtl.options
 
 import firrtl.AnnotationSeq
 
-/** Type class defining a "view" of an [[AnnotationSeq]]
-  * @tparam T the type to which this viewer converts an [[AnnotationSeq]] to
+/** Type class defining a "view" of an [[firrtl.AnnotationSeq AnnotationSeq]]
+  * @tparam T the type to which this viewer converts an [[firrtl.AnnotationSeq AnnotationSeq]] to
   */
 trait OptionsView[T] {
 
-  /** Convert an [[AnnotationSeq]] to some other type
+  /** Convert an [[firrtl.AnnotationSeq AnnotationSeq]] to some other type
     * @param options some annotations
     */
   def view(options: AnnotationSeq): T
 
 }
 
-/** A shim to manage multiple "views" of an [[AnnotationSeq]] */
+/** A shim to manage multiple "views" of an [[firrtl.AnnotationSeq AnnotationSeq]] */
 object Viewer {
 
   /** Convert annotations to options using an implicitly provided [[OptionsView]]
     * @param options some annotations
     * @param optionsView a converter of options to the requested type
-    * @tparam T the type to which the input [[AnnotationSeq]] should be viewed as
+    * @tparam T the type to which the input [[firrtl.AnnotationSeq AnnotationSeq]] should be viewed as
     */
   def view[T](options: AnnotationSeq)(implicit optionsView: OptionsView[T]): T = optionsView.view(options)
 

--- a/src/main/scala/firrtl/options/Phase.scala
+++ b/src/main/scala/firrtl/options/Phase.scala
@@ -4,17 +4,70 @@ package firrtl.options
 
 import firrtl.AnnotationSeq
 
-/** A transformation of an [[AnnotationSeq]]
-  *
-  * A [[Phase]] forms one block in the Chisel/FIRRTL Hardware Compiler Framework (HCF). Note that a [[Phase]] may
-  * consist of multiple phases internally.
-  */
-abstract class Phase {
+import logger.LazyLogging
 
-  /** A transformation of an [[AnnotationSeq]]
-    * @param annotations some annotations
-    * @return transformed annotations
+/** A polymorphic mathematical transform
+  * @tparam A the transformed type
+  */
+trait TransformLike[A] extends LazyLogging {
+
+  /** An identifier of this [[TransformLike]] that can be used for logging and informational printing */
+  def name: String
+
+  /** A mathematical transform on some type
+    * @param a an input object
+    * @return an output object of the same type
     */
-  def transform(annotations: AnnotationSeq): AnnotationSeq
+  def transform(a: A): A
+
+}
+
+/** A mathematical transformation of an [[AnnotationSeq]].
+  *
+  * A [[Phase]] forms one unit in the Chisel/FIRRTL Hardware Compiler Framework (HCF). The HCF is built from a sequence
+  * of [[Phase]]s applied to an [[AnnotationSeq]]. Note that a [[Phase]] may consist of multiple phases internally.
+  */
+abstract class Phase extends TransformLike[AnnotationSeq] {
+
+  /** The name of this [[Phase]]. This will be used to generate debug/error messages or when deleting annotations. This
+    * will default to the `simpleName` of the class.
+    * @return this phase's name
+    * @note Override this with your own implementation for different naming behavior.
+    */
+  lazy val name: String = this.getClass.getName
+
+}
+
+/** A [[TransformLike]] that internally ''translates'' the input type to some other type, transforms the internal type,
+  * and converts back to the original type.
+  *
+  * This is intended to be used to insert a [[TransformLike]] parameterized by type `B` into a sequence of
+  * [[TransformLike]]s parameterized by type `A`.
+  * @tparam A the type of the [[TransformLike]]
+  * @tparam B the internal type
+  */
+trait Translator[A, B] { this: TransformLike[A] =>
+
+  /** A method converting type `A` into type `B`
+    * @param an object of type `A`
+    * @return an object of type `B`
+    */
+  protected implicit def aToB(a: A): B
+
+  /** A method converting type `B` back into type `A`
+    * @param an object of type `B`
+    * @return an object of type `A`
+    */
+  protected implicit def bToA(b: B): A
+
+  /** A transform on an internal type
+    * @param b an object of type `B`
+    * @return an object of type `B`
+    */
+  protected def internalTransform(b: B): B
+
+  /** Convert the input object to the internal type, transform the internal type, and convert back to the original type
+    */
+  final def transform(a: A): A = internalTransform(a)
 
 }

--- a/src/main/scala/firrtl/options/Registration.scala
+++ b/src/main/scala/firrtl/options/Registration.scala
@@ -10,7 +10,14 @@ import scopt.OptionParser
   */
 trait HasScoptOptions {
 
-  /** This method will be called to add options to an OptionParser
+  /** This method will be called to add options to an OptionParser ('''OPTIONS SHOULD BE PREPENDED''')
+    *
+    *
+    * '''The ordering of [[firrtl.annotations.Annotation Annotation]] is important and has meaning for parallel
+    * compilations. For deterministic behavior, you should always prepend any annotations to the [[firrtl.AnnotationSeq
+    * AnnotationSeq]]. The [[firrtl.AnnotationSeq AnnotationSeq]] will be automatically reversed after a [[Stage]]
+    * parses it.'''
+    *
     * @param p an option parser
     */
   def addOptions(p: OptionParser[AnnotationSeq]): Unit

--- a/src/main/scala/firrtl/options/Shell.scala
+++ b/src/main/scala/firrtl/options/Shell.scala
@@ -38,7 +38,7 @@ class Shell(val applicationName: String) {
   lazy val registeredTransforms: Seq[RegisteredTransform] = {
     val transforms = scala.collection.mutable.ArrayBuffer[RegisteredTransform]()
     val iter = ServiceLoader.load(classOf[RegisteredTransform]).iterator()
-    parser.note("FIRRTL Transform Options")
+    if (iter.hasNext) { parser.note("FIRRTL Transform Options") }
     while (iter.hasNext) {
       val tx = iter.next()
       transforms += tx
@@ -53,8 +53,12 @@ class Shell(val applicationName: String) {
     * line options via methods of [[Shell.parser]]
     */
   def parse(args: Array[String], initAnnos: AnnotationSeq = Seq.empty): AnnotationSeq = {
-    registeredTransforms
-    registeredLibraries
+    val rtString = registeredTransforms.map(r => s"\n  - ${r.getClass.getName}").mkString
+    val rlString = registeredLibraries.map(l => s"\n  - ${l.getClass.getName}").mkString
+    parser.note(s"""|
+                    |The following FIRRTL transforms registered command line options:$rtString
+                    |The following libraries registered command line options:$rlString""".stripMargin)
+
     parser
       .parse(args, initAnnos)
       .getOrElse(throw new OptionsException("Failed to parse command line options", new IllegalArgumentException))

--- a/src/main/scala/firrtl/options/Shell.scala
+++ b/src/main/scala/firrtl/options/Shell.scala
@@ -8,18 +8,13 @@ import scopt.OptionParser
 
 import java.util.ServiceLoader
 
-/** Indicate an error in [[firrtl.options]]
-  * @param msg a message to print
-  */
-case class OptionsException(msg: String, cause: Throwable = null) extends Exception(msg, cause)
-
 /** A utility for working with command line options
   * @param applicationName the application associated with these command line options
   */
 class Shell(val applicationName: String) {
 
   /** Command line argument parser (OptionParser) with modifications */
-  final val parser = new OptionParser[AnnotationSeq](applicationName) with DuplicateHandling
+  final val parser = new OptionParser[AnnotationSeq](applicationName) with DuplicateHandling with ExceptOnError
 
   /** Contains all discovered [[RegisteredLibrary]] */
   lazy val registeredLibraries: Seq[RegisteredLibrary] = {
@@ -31,6 +26,7 @@ class Shell(val applicationName: String) {
       parser.note(lib.name)
       lib.addOptions(parser)
     }
+
     libraries
   }
 
@@ -44,6 +40,7 @@ class Shell(val applicationName: String) {
       transforms += tx
       tx.addOptions(parser)
     }
+
     transforms
   }
 
@@ -53,19 +50,30 @@ class Shell(val applicationName: String) {
     * line options via methods of [[Shell.parser]]
     */
   def parse(args: Array[String], initAnnos: AnnotationSeq = Seq.empty): AnnotationSeq = {
-    val rtString = registeredTransforms.map(r => s"\n  - ${r.getClass.getName}").mkString
-    val rlString = registeredLibraries.map(l => s"\n  - ${l.getClass.getName}").mkString
-    parser.note(s"""|
-                    |The following FIRRTL transforms registered command line options:$rtString
-                    |The following libraries registered command line options:$rlString""".stripMargin)
-
+    registeredTransforms
+    registeredLibraries
     parser
       .parse(args, initAnnos)
       .getOrElse(throw new OptionsException("Failed to parse command line options", new IllegalArgumentException))
   }
 
   parser.note("Shell Options")
-  Seq( InputAnnotationFileAnnotation(),
-       TargetDirAnnotation() )
+  Seq( TargetDirAnnotation,
+       ProgramArgsAnnotation,
+       InputAnnotationFileAnnotation,
+       OutputAnnotationFileAnnotation )
     .map(_.addOptions(parser))
+
+  parser.opt[Unit]("show-registrations")
+    .action{ (_, c) =>
+      val rtString = registeredTransforms.map(r => s"\n  - ${r.getClass.getName}").mkString
+      val rlString = registeredLibraries.map(l => s"\n  - ${l.getClass.getName}").mkString
+
+      println(s"""|The following FIRRTL transforms registered command line options:$rtString
+                  |The following libraries registered command line options:$rlString""".stripMargin)
+      c }
+    .unbounded()
+    .text("print discovered registered libraries and transforms")
+
+  parser.help("help").text("prints this usage text")
 }

--- a/src/main/scala/firrtl/options/Shell.scala
+++ b/src/main/scala/firrtl/options/Shell.scala
@@ -53,8 +53,9 @@ class Shell(val applicationName: String) {
     registeredTransforms
     registeredLibraries
     parser
-      .parse(args, initAnnos)
+      .parse(args, initAnnos.reverse)
       .getOrElse(throw new OptionsException("Failed to parse command line options", new IllegalArgumentException))
+      .reverse
   }
 
   parser.note("Shell Options")

--- a/src/main/scala/firrtl/options/Stage.scala
+++ b/src/main/scala/firrtl/options/Stage.scala
@@ -4,8 +4,6 @@ package firrtl.options
 
 import firrtl.AnnotationSeq
 
-case class StageException(val str: String, cause: Throwable = null) extends RuntimeException(str, cause)
-
 /** A [[Stage]] represents one stage in the FIRRTL hardware compiler framework. A [[Stage]] is, conceptually, a
   * [[Phase]] that includes a command line interface.
   *
@@ -19,37 +17,43 @@ abstract class Stage extends Phase {
   /** A utility that helps convert command line options to annotations */
   val shell: Shell
 
-  /** Run this [[Stage]] on some input annotations
+  /** Run this stage on some input annotations
     * @param annotations input annotations
     * @return output annotations
     */
   def run(annotations: AnnotationSeq): AnnotationSeq
 
-  /** Execute this [[Stage]] on some input annotations. Annotations will be read from any input annotation files.
+  /** Execute this stage on some input annotations. Annotations will be read from any input annotation files.
     * @param annotations input annotations
     * @return output annotations
+    * @throws OptionsException if command line or annotation validation fails
     */
-  final def transform(annotations: AnnotationSeq): AnnotationSeq = {
-    val preprocessing: Seq[Phase] = Seq(
-      phases.GetIncludes,
-      phases.ConvertLegacyAnnotations,
-      phases.AddDefaults )
+  final def transform(annotations: AnnotationSeq): AnnotationSeq =
+    Seq( phases.GetIncludes,
+         phases.ConvertLegacyAnnotations,
+         phases.AddDefaults,
+         phases.Checks,
+         new Phase { def transform(a: AnnotationSeq) = run(a) },
+         phases.WriteOutputAnnotations )
+      .foldLeft(annotations)((a, p) => p.transform(a))
 
-    val a = preprocessing.foldLeft(annotations)((a, p) => p.transform(a))
-
-    run(a)
-  }
-
-  /** Run this [[Stage]] on on a mix of arguments and annotations
+  /** Run this stage on on a mix of arguments and annotations
     * @param args command line arguments
     * @param initialAnnotations annotation
     * @return output annotations
+    * @throws OptionsException if command line or annotation validation fails
     */
   final def execute(args: Array[String], annotations: AnnotationSeq): AnnotationSeq =
     transform(shell.parse(args, annotations))
 
-  /** The main function that serves as this [[Stage]]'s command line interface
+  /** The main function that serves as this stage's command line interface.
     * @param args command line arguments
     */
-  final def main(args: Array[String]): Unit = execute(args, Seq.empty)
+  final def main(args: Array[String]): Unit = try {
+    execute(args, Seq.empty)
+  } catch {
+    case a: OptionsException =>
+      StageUtils.dramaticUsageError(a.message)
+      System.exit(1)
+  }
 }

--- a/src/main/scala/firrtl/options/StageAnnotations.scala
+++ b/src/main/scala/firrtl/options/StageAnnotations.scala
@@ -3,18 +3,55 @@
 package firrtl.options
 
 import firrtl.AnnotationSeq
-import firrtl.annotations.NoTargetAnnotation
+import firrtl.annotations.{Annotation, NoTargetAnnotation}
 
 import scopt.OptionParser
 
-sealed trait StageOption extends HasScoptOptions
+sealed trait StageOption { this: Annotation => }
+
+/** An annotation that should not be serialized automatically [[phases.WriteOutputAnnotations WriteOutputAnnotations]].
+  * This usually means that this is an annotation that is used only internally to a [[Stage]].
+  */
+trait Unserializable { this: Annotation => }
+
+/** Holds the name of the target directory
+  *  - set with `-td/--target-dir`
+  *  - if unset, a [[TargetDirAnnotation]] will be generated with the
+  * @param value target directory name
+  */
+case class TargetDirAnnotation(directory: String = ".") extends NoTargetAnnotation with StageOption
+
+object TargetDirAnnotation extends HasScoptOptions {
+  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("target-dir")
+    .abbr("td")
+    .valueName("<target-directory>")
+    .action( (x, c) => c ++ Seq(TargetDirAnnotation(x)) )
+    .unbounded() // See [Note 1]
+    .text(s"Work directory for intermediate files/blackboxes, default is '.' (current directory)")
+}
+
+/** Additional arguments
+  *  - set with any trailing option on the command line
+  * @param value one [[scala.String]] argument
+  */
+case class ProgramArgsAnnotation(arg: String) extends NoTargetAnnotation with StageOption
+
+object ProgramArgsAnnotation extends HasScoptOptions {
+  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.arg[String]("<arg>...")
+    .unbounded()
+    .optional()
+    .action( (x, c) => c :+ ProgramArgsAnnotation(x) )
+    .text("optional unbounded args")
+}
 
 /** Holds a filename containing one or more [[annotations.Annotation]] to be read
   *  - this is not stored in [[FirrtlExecutionOptions]]
   *  - set with `-faf/--annotation-file`
   * @param value input annotation filename
   */
-case class InputAnnotationFileAnnotation(value: String) extends NoTargetAnnotation with StageOption {
+case class InputAnnotationFileAnnotation(file: String) extends NoTargetAnnotation with StageOption
+
+object InputAnnotationFileAnnotation extends HasScoptOptions {
   def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("annotation-file")
     .abbr("faf")
     .unbounded()
@@ -23,20 +60,17 @@ case class InputAnnotationFileAnnotation(value: String) extends NoTargetAnnotati
     .text("Used to specify annotation file")
 }
 
-object InputAnnotationFileAnnotation {
-  private [firrtl] def apply(): InputAnnotationFileAnnotation = InputAnnotationFileAnnotation("")
-}
-
-/** Holds the name of the target directory
-  *  - set with `-td/--target-dir`
-  *  - if unset, a [[TargetDirAnnotation]] will be generated with the
-  * @param value target directory name
+/** An explicit output _annotation_ file to write to
+  *  - set with `-foaf/--output-annotation-file`
+  * @param value output annotation filename
   */
-case class TargetDirAnnotation(dir: String = ".") extends NoTargetAnnotation with StageOption {
-  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("target-dir")
-    .abbr("td")
-    .valueName("<target-directory>")
-    .action( (x, c) => c ++ Seq(TargetDirAnnotation(x)) )
-    .unbounded() // See [Note 1]
-    .text(s"Work directory for intermediate files/blackboxes, default is '.' (current directory)")
+case class OutputAnnotationFileAnnotation(file: String) extends NoTargetAnnotation with StageOption
+
+object OutputAnnotationFileAnnotation extends HasScoptOptions {
+  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("output-annotation-file")
+    .abbr("foaf")
+    .valueName ("<output-anno-file>")
+    .action( (x, c) => c :+ OutputAnnotationFileAnnotation(x) )
+    .unbounded()
+    .text("use this to set the annotation output file")
 }

--- a/src/main/scala/firrtl/options/StageAnnotations.scala
+++ b/src/main/scala/firrtl/options/StageAnnotations.scala
@@ -25,7 +25,7 @@ object TargetDirAnnotation extends HasScoptOptions {
   def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("target-dir")
     .abbr("td")
     .valueName("<target-directory>")
-    .action( (x, c) => c ++ Seq(TargetDirAnnotation(x)) )
+    .action( (x, c) => TargetDirAnnotation(x) +: c )
     .unbounded() // See [Note 1]
     .text(s"Work directory for intermediate files/blackboxes, default is '.' (current directory)")
 }
@@ -40,7 +40,7 @@ object ProgramArgsAnnotation extends HasScoptOptions {
   def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.arg[String]("<arg>...")
     .unbounded()
     .optional()
-    .action( (x, c) => c :+ ProgramArgsAnnotation(x) )
+    .action( (x, c) => ProgramArgsAnnotation(x) +: c )
     .text("optional unbounded args")
 }
 
@@ -56,7 +56,7 @@ object InputAnnotationFileAnnotation extends HasScoptOptions {
     .abbr("faf")
     .unbounded()
     .valueName("<input-anno-file>")
-    .action( (x, c) => c :+ InputAnnotationFileAnnotation(x) )
+    .action( (x, c) => InputAnnotationFileAnnotation(x) +: c )
     .text("Used to specify annotation file")
 }
 
@@ -70,7 +70,7 @@ object OutputAnnotationFileAnnotation extends HasScoptOptions {
   def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("output-annotation-file")
     .abbr("foaf")
     .valueName ("<output-anno-file>")
-    .action( (x, c) => c :+ OutputAnnotationFileAnnotation(x) )
+    .action( (x, c) => OutputAnnotationFileAnnotation(x) +: c )
     .unbounded()
     .text("use this to set the annotation output file")
 }

--- a/src/main/scala/firrtl/options/StageOptions.scala
+++ b/src/main/scala/firrtl/options/StageOptions.scala
@@ -7,10 +7,28 @@ import java.io.File
 /** Options that every stage shares
   * @param targetDirName a target (build) directory
   * @param an input annotation file
+  * @param programArgs explicit program arguments
+  * @param outputAnnotationFileName an output annotation filename
   */
-final case class StageOptions(
-  targetDir:       String      = TargetDirAnnotation().dir,
-  annotationFiles: Seq[String] = Seq.empty ) {
+class StageOptions private [firrtl] (
+  val targetDir:         String         = TargetDirAnnotation().directory,
+  val annotationFilesIn: Seq[String]    = Seq.empty,
+  val annotationFileOut: Option[String] = None,
+  val programArgs:       Seq[String]    = Seq.empty ) {
+
+  private [options] def copy(
+    targetDir:         String         = targetDir,
+    annotationFilesIn: Seq[String]    = annotationFilesIn,
+    annotationFileOut: Option[String] = annotationFileOut,
+    programArgs:       Seq[String]    = programArgs ): StageOptions = {
+
+    new StageOptions(
+      targetDir = targetDir,
+      annotationFilesIn = annotationFilesIn,
+      annotationFileOut = annotationFileOut,
+      programArgs = programArgs )
+
+  }
 
   /** Generate a filename (with an optional suffix) and create any parent directories. Suffix is only added if it is not
     * already there.
@@ -18,7 +36,6 @@ final case class StageOptions(
     * @param suffix an optional suffix that the file must end in
     * @return the name of the file
     * @note the filename may include a path
-    * @throws IllegalArgumentException if the filename is empty or if the suffix doesn't start with a '.'
     */
   def getBuildFileName(filename: String, suffix: Option[String] = None): String = {
     require(filename.nonEmpty, "requested filename must not be empty")

--- a/src/main/scala/firrtl/options/StageUtils.scala
+++ b/src/main/scala/firrtl/options/StageUtils.scala
@@ -27,7 +27,11 @@ object StageUtils {
     println("-"*78 + Console.RESET)
   }
 
-  // def canonicalFileName(suffix: String, directory: String = TargetDirAnnotation().targetDirName) {
-  // }
+  /** Generate a message suggesting that the user look at the usage text.
+    * @param message the error message
+    */
+  def dramaticUsageError(message: String): Unit =
+    dramaticError(s"""|$message
+                      |Try --help for more information.""".stripMargin)
 
 }

--- a/src/main/scala/firrtl/options/package.scala
+++ b/src/main/scala/firrtl/options/package.scala
@@ -7,10 +7,14 @@ package object options {
   implicit object StageOptionsView extends OptionsView[StageOptions] {
     def view(options: AnnotationSeq): StageOptions = options
       .collect { case a: StageOption => a }
-      .foldLeft(StageOptions())((c, x) =>
+      .foldLeft(new StageOptions())((c, x) =>
         x match {
           case TargetDirAnnotation(a) => c.copy(targetDir = a)
-          case InputAnnotationFileAnnotation(a) => c.copy(annotationFiles = a +: c.annotationFiles)
+          /* Insert input files at the head of the Seq for speed and because order shouldn't matter */
+          case InputAnnotationFileAnnotation(a) => c.copy(annotationFilesIn = a +: c.annotationFilesIn)
+          case OutputAnnotationFileAnnotation(a) => c.copy(annotationFileOut = Some(a))
+          /* Do NOT reorder program args. The order may matter. */
+          case ProgramArgsAnnotation(a) => c.copy(programArgs = c.programArgs :+ a)
         }
       )
   }

--- a/src/main/scala/firrtl/options/phases/AddDefaults.scala
+++ b/src/main/scala/firrtl/options/phases/AddDefaults.scala
@@ -13,11 +13,7 @@ import firrtl.options.{Phase, StageOption, TargetDirAnnotation}
 object AddDefaults extends Phase {
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = {
-    var td = true
-    annotations.collect { case a: StageOption => a }.map {
-      case _: TargetDirAnnotation => td = false
-      case _ =>
-    }
+    val td = annotations.collectFirst{ case a: TargetDirAnnotation => a}.isEmpty
 
     (if (td) Seq(TargetDirAnnotation()) else Seq()) ++
       annotations

--- a/src/main/scala/firrtl/options/phases/Checks.scala
+++ b/src/main/scala/firrtl/options/phases/Checks.scala
@@ -1,0 +1,43 @@
+// See LICENSE for license details.
+
+package firrtl.options.phases
+
+import firrtl.AnnotationSeq
+import firrtl.annotations.Annotation
+import firrtl.options.{OptionsException, OutputAnnotationFileAnnotation, Phase, TargetDirAnnotation}
+
+/** [[firrtl.options.Phase Phase]] that validates an [[AnnotationSeq]]. If successful, views of this [[AnnotationSeq]]
+  * as [[StageOptions]] are guaranteed to succeed.
+  */
+object Checks extends Phase {
+
+  /** Validate an [[AnnotationSeq]] for [[StageOptions]]
+    * @throws OptionsException if annotations are invalid
+    */
+  def transform(annotations: AnnotationSeq): AnnotationSeq = {
+
+    val td, outA = collection.mutable.ListBuffer[Annotation]()
+    annotations.foreach {
+      case a: TargetDirAnnotation => td += a
+      case a: OutputAnnotationFileAnnotation => outA += a
+      case _ =>
+    }
+
+    if (td.size != 1) {
+      val d = td.map{ case TargetDirAnnotation(x) => x }
+      throw new OptionsException(
+        s"""|Exactly one target directory must be specified, but found `${d.mkString(", ")}` specified via:
+            |    - explicit target directory: -td, --target-dir, TargetDirAnnotation
+            |    - fallback default value""".stripMargin )}
+
+    if (outA.size > 1) {
+      val x = outA.map{ case OutputAnnotationFileAnnotation(x) => x }
+      throw new OptionsException(
+        s"""|At most one output annotation file can be specified, but found '${x.mkString(", ")}' specified via:
+            |    - an option or annotation: -foaf, --output-annotation-file, OutputAnnotationFileAnnotation"""
+          .stripMargin )}
+
+    annotations
+  }
+
+}

--- a/src/main/scala/firrtl/options/phases/ConvertLegacyAnnotations.scala
+++ b/src/main/scala/firrtl/options/phases/ConvertLegacyAnnotations.scala
@@ -6,7 +6,7 @@ import firrtl.AnnotationSeq
 import firrtl.annotations.LegacyAnnotation
 import firrtl.options.Phase
 
-/** Convert any [[LegacyAnnotation]]s to non-legacy variants */
+/** Convert any [[firrtl.annotations.LegacyAnnotation LegacyAnnotation]]s to non-legacy variants */
 object ConvertLegacyAnnotations extends Phase {
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = LegacyAnnotation.convertLegacyAnnos(annotations)

--- a/src/main/scala/firrtl/options/phases/GetIncludes.scala
+++ b/src/main/scala/firrtl/options/phases/GetIncludes.scala
@@ -46,15 +46,14 @@ object GetIncludes extends Phase {
     */
   private def getIncludes(includeGuard: mutable.Set[String] = mutable.Set())
                          (annos: AnnotationSeq): AnnotationSeq = {
-    val phaseName = this.getClass.getName
     annos.flatMap {
       case a @ InputAnnotationFileAnnotation(value) =>
         if (includeGuard.contains(value)) {
-          StageUtils.dramaticWarning("Tried to import the same annotation file twice! (Did you include it twice?)")
-          Seq(DeletedAnnotation(phaseName, a))
+          StageUtils.dramaticWarning(s"Annotation file ($value) already included! (Did you include it more than once?)")
+          Seq(DeletedAnnotation(name, a))
         } else {
           includeGuard += value
-          DeletedAnnotation(phaseName, a) +: getIncludes(includeGuard)(readAnnotationsFromFile(value))
+          DeletedAnnotation(name, a) +: getIncludes(includeGuard)(readAnnotationsFromFile(value))
         }
       case x => Seq(x)
     }

--- a/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
+++ b/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
@@ -1,0 +1,35 @@
+// See LICENSE for license details.
+
+package firrtl.options.phases
+
+import firrtl.AnnotationSeq
+import firrtl.annotations.{DeletedAnnotation, JsonProtocol}
+import firrtl.options.{Phase, StageOptions, Unserializable, Viewer}
+
+import java.io.PrintWriter
+
+/** [[firrtl.options.Phase Phase]] that writes an [[AnnotationSeq]] to a file. A file is written if and only if a
+  * [[StageOptions]] view has a non-empty [[StageOptions.annotationFileOut annotationFileOut]].
+  */
+object WriteOutputAnnotations extends Phase {
+
+  /** Write the input [[AnnotationSeq]] to a fie. */
+  def transform(annotations: AnnotationSeq): AnnotationSeq = {
+    val sopts = Viewer.view[StageOptions](annotations)
+    val serializable = annotations.filter{
+      case _: Unserializable | _: DeletedAnnotation => false
+      case _                                        => true
+    }
+
+    sopts.annotationFileOut match {
+      case None =>
+      case Some(file) =>
+        val pw = new PrintWriter(sopts.getBuildFileName(file, Some(".anno.json")))
+        pw.write(JsonProtocol.serialize(serializable))
+        pw.close()
+    }
+
+    annotations
+  }
+
+}

--- a/src/main/scala/firrtl/package.scala
+++ b/src/main/scala/firrtl/package.scala
@@ -8,9 +8,9 @@ package object firrtl {
   implicit def annoSeqToSeq(as: AnnotationSeq): Seq[Annotation] = as.underlying
 
   /* Options as annotations compatibility items */
-  @deprecated("Use firrtl.stage.TargetDirAnnotation", "3.2")
-  type TargetDirAnnotation = firrtl.stage.TargetDirAnnotation
+  @deprecated("Use firrtl.stage.TargetDirAnnotation", "1.2")
+  type TargetDirAnnotation = firrtl.options.TargetDirAnnotation
 
-  @deprecated("Use firrtl.stage.TargetDirAnnotation", "3.2")
-  val TargetDirAnnotation = firrtl.stage.TargetDirAnnotation
+  @deprecated("Use firrtl.stage.TargetDirAnnotation", "1.2")
+  val TargetDirAnnotation = firrtl.options.TargetDirAnnotation
 }

--- a/src/main/scala/firrtl/passes/memlib/InferReadWrite.scala
+++ b/src/main/scala/firrtl/passes/memlib/InferReadWrite.scala
@@ -155,7 +155,7 @@ class InferReadWrite extends Transform with SeqTransformBased with HasScoptOptio
     .opt[Unit]("infer-rw")
     .abbr("firw")
     .valueName ("<circuit>")
-    .action( (_, c) => c ++ Seq(InferReadWriteAnnotation, RunFirrtlTransformAnnotation(new InferReadWrite)) )
+    .action( (_, c) => Seq(InferReadWriteAnnotation, RunFirrtlTransformAnnotation(new InferReadWrite)) ++ c )
     .maxOccurs(1)
     .text("Enable readwrite port inference for the target circuit")
 

--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
@@ -114,8 +114,8 @@ class ReplSeqMem extends Transform with HasScoptOptions {
     .opt[String]("repl-seq-mem")
     .abbr("frsq")
     .valueName ("-c:<circuit>:-i:<filename>:-o:<filename>")
-    .action( (x, c) => c ++ Seq(passes.memlib.ReplSeqMemAnnotation.parse(x),
-                                RunFirrtlTransformAnnotation(new ReplSeqMem)) )
+    .action( (x, c) => Seq(passes.memlib.ReplSeqMemAnnotation.parse(x),
+                           RunFirrtlTransformAnnotation(new ReplSeqMem)) ++ c )
     .maxOccurs(1)
     .text("Replace sequential memories with blackboxes + configuration file")
 

--- a/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
+++ b/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
@@ -53,7 +53,7 @@ object FirrtlFileAnnotation extends HasScoptOptions {
   def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("input-file")
     .abbr("i")
     .valueName ("<firrtl-source>")
-    .action( (x, c) => c :+ FirrtlFileAnnotation(x) )
+    .action( (x, c) => FirrtlFileAnnotation(x) +: c )
     .unbounded()
     .text("use this to override the default input file name, default is empty")
 }
@@ -68,7 +68,7 @@ object OutputFileAnnotation extends HasScoptOptions {
   def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("output-file")
     .abbr("o")
     .valueName("<output>")
-    .action( (x, c) => c :+ OutputFileAnnotation(x) )
+    .action( (x, c) => OutputFileAnnotation(x) +: c )
     .unbounded()
     .text("use this to override the default output file name, default is empty")
 }
@@ -100,7 +100,7 @@ case class InfoModeAnnotation(modeName: String = "use") extends NoTargetAnnotati
 object InfoModeAnnotation extends HasScoptOptions {
   def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("info-mode")
     .valueName ("<ignore|use|gen|append>")
-    .action( (x, c) => c :+ InfoModeAnnotation(x) )
+    .action( (x, c) => InfoModeAnnotation(x) +: c )
     .unbounded()
     .text(s"specifies the source info handling, default is ${apply().modeName}")
 }
@@ -119,7 +119,7 @@ case class FirrtlSourceAnnotation(source: String) extends NoTargetAnnotation wit
 object FirrtlSourceAnnotation extends HasScoptOptions {
   def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("firrtl-source")
     .valueName ("A FIRRTL string")
-    .action( (x, c) => c :+ FirrtlSourceAnnotation(x) )
+    .action( (x, c) => FirrtlSourceAnnotation(x) +: c )
     .unbounded()
     .text(s"A FIRRTL circuit as a string")
 }
@@ -176,8 +176,9 @@ object RunFirrtlTransformAnnotation extends HasScoptOptions {
                     case e: Throwable => throw new OptionsException(
                       s"Unknown error when instantiating class $txName", e) } )
                 p.success } )
-    .action( (x, c) => c ++ x.map(txName =>
-              RunFirrtlTransformAnnotation(Class.forName(txName).asInstanceOf[Class[_ <: Transform]].newInstance())) )
+    .action( (x, c) =>
+      x.map(txName =>
+        RunFirrtlTransformAnnotation(Class.forName(txName).asInstanceOf[Class[_ <: Transform]].newInstance())) ++ c )
     .unbounded()
     .text("runs these custom transforms during compilation.")
 }

--- a/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
+++ b/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
@@ -4,154 +4,67 @@ package firrtl.stage
 
 import firrtl._
 import firrtl.ir.Circuit
-import firrtl.annotations.NoTargetAnnotation
-import firrtl.transforms.BlackBoxTargetDirAnno
-import firrtl.options.HasScoptOptions
-
-import logger.LogLevel
+import firrtl.annotations.{Annotation, NoTargetAnnotation}
+import firrtl.options.{HasScoptOptions, OptionsException}
 
 import scopt.OptionParser
 
-/** Indicates that a subclass is an [[firrtl.annotations Annotation]] that includes a command line option
-  *
-  * This must be mixed into a subclass of [[annotations.Annotation]]
+import java.io.FileNotFoundException
+import java.nio.file.NoSuchFileException
+
+/** Indicates that this is an [[firrtl.annotations.Annotation Annotation]] directly used in the construction of a
+  * [[FirrtlOptions]] view.
   */
-sealed trait FirrtlOption extends HasScoptOptions
+sealed trait FirrtlOption { this: Annotation => }
 
-/** Holds the name of the top module
-  *  - set on the command line with `-tn/--top-name`
-  * @param value top module name
+/** Indicates that this [[firrtl.annotations.Annotation Annotation]] contains information that is directly convertable
+  * to a FIRRTL [[firrtl.ir.Circuit Circuit]].
   */
-case class TopNameAnnotation(topName: String) extends NoTargetAnnotation with FirrtlOption {
-  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("top-name")
-    .abbr("tn")
-    .valueName("<top-level-circuit-name>")
-    .action( (x, c) => c :+ TopNameAnnotation(x) )
-    .unbounded() // See [Note 1]
-    .text("This options defines the top level circuit, defaults to dut when possible")
-}
+sealed trait CircuitOption extends { this: Annotation =>
 
-object TopNameAnnotation {
-  private [firrtl] def apply(): TopNameAnnotation = TopNameAnnotation(topName = "")
-}
+  /** Convert this [[firrtl.annotations.Annotation Annotation]] to a [[FirrtlCircuitAnnotation]]
+    */
+  def toCircuit(info: Parser.InfoMode): FirrtlCircuitAnnotation
 
-/** Holds the name of the target directory
-  *  - set with `-td/--target-dir`
-  *  - if unset, a [[TargetDirAnnotation]] will be generated with the
-  * @param value target directory name
-  */
-case class TargetDirAnnotation(targetDirName: String = ".") extends NoTargetAnnotation with FirrtlOption {
-  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("target-dir")
-    .abbr("td")
-    .valueName("<target-directory>")
-    .action( (x, c) => c ++ Seq(TargetDirAnnotation(x)) )
-    .unbounded() // See [Note 1]
-    .text(s"Work directory for intermediate files/blackboxes, default is ${CommonOptions().targetDirName}")
-}
-
-/** Describes the verbosity of information to log
-  *  - set with `-ll/--log-level`
-  *  - if unset, a [[LogLevelAnnotation]] with the default log level will be emitted
-  * @param level the level of logging
-  */
-case class LogLevelAnnotation(globalLogLevel: LogLevel.Value = LogLevel.None) extends NoTargetAnnotation with FirrtlOption {
-  val value = globalLogLevel.toString
-
-  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("log-level")
-    .abbr("ll")
-    .valueName("<Error|Warn|Info|Debug|Trace>")
-    .action( (x, c) => c :+ LogLevelAnnotation(LogLevel(x)) )
-    .validate{ x =>
-      lazy val msg = s"$x bad value must be one of error|warn|info|debug|trace"
-      if (Array("error", "warn", "info", "debug", "trace").contains(x.toLowerCase)) { p.success      }
-      else                                                                          { p.failure(msg) }}
-    .unbounded() // See [Note 1]
-    .text(s"Sets the verbosity level of logging, default is ${CommonOptions().globalLogLevel}")
-}
-
-/** Describes a mapping of a class to a specific log level
-  *  - set with `-cll/--class-log-level`
-  * @param name the class name to log
-  * @param level the verbosity level
-  */
-case class ClassLogLevelAnnotation(className: String, level: LogLevel.Value) extends NoTargetAnnotation
-    with FirrtlOption {
-  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[Seq[String]]("class-log-level")
-    .abbr("cll")
-    .valueName("<FullClassName:[Error|Warn|Info|Debug|Trace]>[,...]")
-    .action( (x, c) => c ++ (x.map { y =>
-                               val className :: levelName :: _ = y.split(":").toList
-                               val level = LogLevel(levelName)
-                               ClassLogLevelAnnotation(className, level) }) )
-    .unbounded() // This can actually occur any number of times safely
-    .text(s"This defines per-class verbosity of logging")
-}
-
-object ClassLogLevelAnnotation {
-  private [firrtl] def apply(): ClassLogLevelAnnotation = ClassLogLevelAnnotation("", LogLevel.None)
-}
-
-/** Enables logging to a file (as opposed to STDOUT)
-  *  - enabled with `-ltf/--log-to-file`
-  */
-case object LogToFileAnnotation extends NoTargetAnnotation with FirrtlOption {
-  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[Unit]("log-to-file")
-    .abbr("ltf")
-    .action( (x, c) => c :+ LogToFileAnnotation )
-    .unbounded()
-    .text(s"default logs to stdout, this flags writes to topName.log or firrtl.log if no topName")
-}
-
-/** Enables class names in log output
-  *  - enabled with `-lcn/--log-class-names`
-  */
-case object LogClassNamesAnnotation extends NoTargetAnnotation with FirrtlOption {
-  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[Unit]("log-class-names")
-    .abbr("lcn")
-    .action( (x, c) => c :+ LogClassNamesAnnotation )
-    .unbounded()
-    .text(s"shows class names and log level in logging output, useful for target --class-log-level")
-}
-
-/** Additional arguments
-  *  - set with any trailing option on the command line
-  * @param value one [[scala.String]] argument
-  */
-case class ProgramArgsAnnotation(value: String) extends NoTargetAnnotation with FirrtlOption {
-  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.arg[String]("<arg>...")
-    .unbounded()
-    .optional()
-    .action( (x, c) => c :+ ProgramArgsAnnotation(x) )
-    .text("optional unbounded args")
-}
-
-object ProgramArgsAnnotation {
-  private [firrtl] def apply(): ProgramArgsAnnotation = ProgramArgsAnnotation("")
 }
 
 /** An explicit input FIRRTL file to read
   *  - set with `-i/--input-file`
-  *  - If unset, an [[InputFileAnnotation]] with the default input file __will not be generated__
-  * @param value input filename
+  *  - If unset, an [[FirrtlFileAnnotation]] with the default input file __will not be generated__
+  * @param file input filename
   */
-case class InputFileAnnotation(value: String) extends NoTargetAnnotation with FirrtlOption {
+case class FirrtlFileAnnotation(file: String) extends NoTargetAnnotation with CircuitOption {
+
+  def toCircuit(info: Parser.InfoMode): FirrtlCircuitAnnotation = {
+    val circuit = try {
+      FirrtlStageUtils.getFileExtension(file) match {
+        case ProtoBufFile => proto.FromProto.fromFile(file)
+        case FirrtlFile => Parser.parseFile(file, info) }
+    } catch {
+      case a @ (_: FileNotFoundException | _: NoSuchFileException) =>
+        throw new OptionsException(s"Input file '$file' not found! (Did you misspell it?)", a)
+    }
+    FirrtlCircuitAnnotation(circuit)
+  }
+
+}
+
+object FirrtlFileAnnotation extends HasScoptOptions {
   def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("input-file")
     .abbr("i")
     .valueName ("<firrtl-source>")
-    .action( (x, c) => c :+ InputFileAnnotation(x) )
-    .unbounded() // See [Note 1]
+    .action( (x, c) => c :+ FirrtlFileAnnotation(x) )
+    .unbounded()
     .text("use this to override the default input file name, default is empty")
-}
-
-object InputFileAnnotation {
-  private [firrtl] def apply(): InputFileAnnotation = InputFileAnnotation("")
 }
 
 /** An explicit output file the emitter will write to
   *   - set with `-o/--output-file`
-  *  @param value output filename
+  *  @param file output filename
   */
-case class OutputFileAnnotation(value: String) extends NoTargetAnnotation with FirrtlOption {
+case class OutputFileAnnotation(file: String) extends NoTargetAnnotation with FirrtlOption
+
+object OutputFileAnnotation extends HasScoptOptions {
   def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("output-file")
     .abbr("o")
     .valueName("<output>")
@@ -160,104 +73,95 @@ case class OutputFileAnnotation(value: String) extends NoTargetAnnotation with F
     .text("use this to override the default output file name, default is empty")
 }
 
-object OutputFileAnnotation {
-  private [firrtl] def apply(): OutputFileAnnotation = OutputFileAnnotation("")
-}
-
-/** An explicit output _annotation_ file to write to
-  *  - set with `-foaf/--output-annotation-file`
-  * @param value output annotation filename
-  */
-case class OutputAnnotationFileAnnotation(value: String) extends NoTargetAnnotation with FirrtlOption {
-  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("output-annotation-file")
-    .abbr("foaf")
-    .valueName ("<output-anno-file>")
-    .action( (x, c) => c :+ OutputAnnotationFileAnnotation(x) )
-    .unbounded() // See [Note 1]
-    .text("use this to set the annotation output file")
-}
-
-object OutputAnnotationFileAnnotation {
-  private [firrtl] def apply(): OutputAnnotationFileAnnotation = OutputAnnotationFileAnnotation("")
-}
-
 /** Sets the info mode style
   *  - set with `--info-mode`
-  * @param value info mode name
+  * @param mode info mode name
+  * @note This cannote be directly converted to [[Parser.InfoMode]] as that depends on an optional [[FirrtlFileAnnotation]]
   */
-case class InfoModeAnnotation(value: String = "append") extends NoTargetAnnotation with FirrtlOption {
-  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("info-mode")
-    .valueName ("<ignore|use|gen|append>")
-    .action( (x, c) => c :+ InfoModeAnnotation(x.toLowerCase) )
-    .unbounded() // See [Note 1]
-    .text(s"specifies the source info handling, default is ${FirrtlExecutionOptions().infoModeName}")
+case class InfoModeAnnotation(modeName: String = "use") extends NoTargetAnnotation with FirrtlOption {
+  require(modeName match { case "use" | "ignore" | "gen" | "append" => true; case _ => false },
+          s"Unknown info mode '$modeName'! (Did you misspell it?)")
+
+  /** Return the [[Parser.InfoMode]] equivalent for this [[firrtl.annotations.Annotation Annotation]]
+    * @param infoSource the name of a file to use for "gen" or "append" info modes
+    */
+  def toInfoMode(infoSource: Option[String] = None): Parser.InfoMode = modeName match {
+    case "use"    => Parser.UseInfo
+    case "ignore" => Parser.IgnoreInfo
+    case _        =>
+      val a = infoSource.getOrElse("unknown source")
+      modeName match {
+        case "gen"    => Parser.GenInfo(a)
+        case "append" => Parser.AppendInfo(a)
+      }
+  }
 }
 
-/** Holds a [[scala.String]] containing FIRRTL source to read as input
+object InfoModeAnnotation extends HasScoptOptions {
+  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("info-mode")
+    .valueName ("<ignore|use|gen|append>")
+    .action( (x, c) => c :+ InfoModeAnnotation(x) )
+    .unbounded()
+    .text(s"specifies the source info handling, default is ${apply().modeName}")
+}
+
+/** Holds a String containing FIRRTL source to read as input
   *  - set with `--firrtl-source`
-  * @param value FIRRTL source as a [[scala.String]]
+  * @param source FIRRTL source as a string
   */
-case class FirrtlSourceAnnotation(value: String) extends NoTargetAnnotation with FirrtlOption {
+case class FirrtlSourceAnnotation(source: String) extends NoTargetAnnotation with CircuitOption {
+
+  def toCircuit(info: Parser.InfoMode): FirrtlCircuitAnnotation =
+    FirrtlCircuitAnnotation(Parser.parseString(source, info))
+
+}
+
+object FirrtlSourceAnnotation extends HasScoptOptions {
   def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("firrtl-source")
     .valueName ("A FIRRTL string")
     .action( (x, c) => c :+ FirrtlSourceAnnotation(x) )
-    .unbounded() // See [Note 1]
+    .unbounded()
     .text(s"A FIRRTL circuit as a string")
 }
 
-object FirrtlSourceAnnotation {
-  private [firrtl] def apply(): FirrtlSourceAnnotation = FirrtlSourceAnnotation("")
-}
-
-/**  Indicates that an emitted circuit (FIRRTL, Verilog, etc.) will be one file per module
-  *   - set with `--split-modules`
+/** Holds a [[Compiler]] that should be run
+  *  - set stringly with `-X/--compiler`
+  *  - If unset, a [[CompilerAnnotation]] with the default [[VerilogCompiler]]
+  * @param compiler compiler name
   */
-case object EmitOneFilePerModuleAnnotation extends NoTargetAnnotation with FirrtlOption {
-  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[Unit]("split-modules")
-    .abbr("fsm")
-    .action( (x, c) => c :+ EmitOneFilePerModuleAnnotation )
-    .unbounded()
-    .text ("Emit each module to its own file in the target directory.")
-}
+case class CompilerAnnotation(compiler: Compiler = new VerilogCompiler()) extends NoTargetAnnotation with FirrtlOption
 
-/** Holds a filename containing one or more [[annotations.Annotation]] to be read
-  *  - this is not stored in [[FirrtlExecutionOptions]]
-  *  - set with `-faf/--annotation-file`
-  * @param value input annotation filename
-  */
-case class InputAnnotationFileAnnotation(value: String) extends NoTargetAnnotation with FirrtlOption {
-  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("annotation-file")
-    .abbr("faf")
-    .unbounded()
-    .valueName("<input-anno-file>")
-    .action( (x, c) => c :+ InputAnnotationFileAnnotation(x) )
-    .text("Used to specify annotation file")
-}
+object CompilerAnnotation extends HasScoptOptions {
 
-object InputAnnotationFileAnnotation {
-  private [firrtl] def apply(): InputAnnotationFileAnnotation = InputAnnotationFileAnnotation("")
-}
+  private [firrtl] def apply(compilerName: String): CompilerAnnotation = {
+    val c = compilerName match {
+      case "none"      => new NoneCompiler()
+      case "high"      => new HighFirrtlCompiler()
+      case "low"       => new LowFirrtlCompiler()
+      case "middle"    => new MiddleFirrtlCompiler()
+      case "verilog"   => new VerilogCompiler()
+      case "sverilog"  => new SystemVerilogCompiler()
+      case _           => throw new OptionsException(s"Unknown compiler name '$compilerName'! (Did you misspell it?)")
+    }
+    CompilerAnnotation(c)
+  }
 
-/** Holds the name of the compiler to run
-  *  - set with `-X/--compiler`
-  *  - If unset, a [[CompilerNameAnnotation]] with the default compiler ("verilog") __will be generated__
-  * @param value compiler name
-  */
-case class CompilerNameAnnotation(value: String = "verilog") extends NoTargetAnnotation with FirrtlOption {
   def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("compiler")
     .abbr("X")
-    .valueName ("<high|middle|low|verilog|sverilog>")
-    .action( (x, c) => c :+ CompilerNameAnnotation(x) )
-    .unbounded() // See [Note 1]
+    .valueName ("<none|high|middle|low|verilog|sverilog>")
+    .action{ (x, c) => CompilerAnnotation(x) +: c }
+    .unbounded()
     .text(s"compiler to use, default is 'verilog'")
 }
 
 /** Holds the unambiguous class name of a [[Transform]] to run
   *  - will be append to [[FirrtlExecutionOptions.customTransforms]]
   *  - set with `-fct/--custom-transforms`
-  * @param value the full class name of the transform
+  * @param transform the full class name of the transform
   */
-case class RunFirrtlTransformAnnotation(transform: Transform) extends NoTargetAnnotation with FirrtlOption {
+case class RunFirrtlTransformAnnotation(transform: Transform) extends NoTargetAnnotation
+
+object RunFirrtlTransformAnnotation extends HasScoptOptions {
   def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[Seq[String]]("custom-transforms")
     .abbr("fct")
     .valueName ("<package>.<class>")
@@ -265,11 +169,11 @@ case class RunFirrtlTransformAnnotation(transform: Transform) extends NoTargetAn
                 x.map(txName =>
                   try { Class.forName(txName).asInstanceOf[Class[_ <: Transform]].newInstance() }
                   catch {
-                    case e: ClassNotFoundException => throw new FIRRTLException(
+                    case e: ClassNotFoundException => throw new OptionsException(
                       s"Unable to locate custom transform $txName (did you misspell it?)", e)
-                    case e: InstantiationException => throw new FIRRTLException(
+                    case e: InstantiationException => throw new OptionsException(
                       s"Unable to create instance of Transform $txName (is this an anonymous class?)", e)
-                    case e: Throwable => throw new FIRRTLException(
+                    case e: Throwable => throw new OptionsException(
                       s"Unknown error when instantiating class $txName", e) } )
                 p.success } )
     .action( (x, c) => c ++ x.map(txName =>
@@ -278,13 +182,31 @@ case class RunFirrtlTransformAnnotation(transform: Transform) extends NoTargetAn
     .text("runs these custom transforms during compilation.")
 }
 
-object RunFirrtlTransformAnnotation {
-  private [firrtl] def apply(): RunFirrtlTransformAnnotation = RunFirrtlTransformAnnotation(new firrtl.transforms.VerilogRename)
+/** Holds a FIRRTL [[firrtl.ir.Circuit Circuit]]
+  * @param circuit a circuit
+  */
+case class FirrtlCircuitAnnotation(circuit: Circuit) extends NoTargetAnnotation with FirrtlOption {
+  /* Caching the hashCode for a large circuit is necessary due to repeated queries, e.g., in
+   * [[Compiler.propagateAnnotations]]. Not caching the hashCode will cause severe performance degredations for large
+   * [[Annotations]].
+   */
+  override lazy val hashCode: Int = circuit.hashCode
+
 }
 
-/** Holds a FIRRTL [[Circuit]]
-  * @param value a circuit
+private [stage] case class FirrtlCircuitStateAnnotation(
+  circuit: Circuit, form: CircuitForm, annotations: AnnotationSeq, renames: Option[RenameMap])
+
+/** This disables stripping unnecessary, uneeded, and deleted annotations from the [[AnnotationSeq]] in [FirrtlStage]]
+  * preprocessing and before emission. This disables [[firrtl.stage.phases.Strip Strip]].
+  *  - set with `--dont-strip`
   */
-case class FirrtlCircuitAnnotation(value: Circuit) extends NoTargetAnnotation with FirrtlOption {
-  def addOptions(p: OptionParser[AnnotationSeq]): Unit = Unit
+case object DontStripAnnotation extends NoTargetAnnotation with HasScoptOptions {
+  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p
+    .opt[Unit]("dont-strip")
+    .action( (x, c) => DontStripAnnotation +: c )
+    .unbounded()
+    .text ("Do not remove unneeded/unnecessary/deleted annotations")
 }
+
+private [firrtl] case class AnnotationGroupAnnotation(annotations: AnnotationSeq)

--- a/src/main/scala/firrtl/stage/FirrtlCli.scala
+++ b/src/main/scala/firrtl/stage/FirrtlCli.scala
@@ -1,0 +1,23 @@
+// See LICENSE for license details.
+
+package firrtl.stage
+
+import firrtl.options.Shell
+
+/** [[firrtl.options.Shell Shell]] mixin that provides command line options for FIRRTL. This does not include any
+  * [[firrtl.options.RegisteredLibrary RegisteredLibrary]] or [[firrtl.options.RegisteredTransform RegisteredTransform]]
+  * as those are automatically loaded by the [[firrtl.options.Stage Stage]] using this [[firrtl.options.Shell Shell]].
+  */
+trait FirrtlCli { this: Shell =>
+  parser.note("FIRRTL Compiler Options")
+  Seq( FirrtlFileAnnotation,
+       OutputFileAnnotation,
+       InfoModeAnnotation,
+       FirrtlSourceAnnotation,
+       CompilerAnnotation,
+       RunFirrtlTransformAnnotation,
+       DontStripAnnotation,
+       firrtl.EmitCircuitAnnotation,
+       firrtl.EmitAllModulesAnnotation )
+    .map(_.addOptions(parser))
+}

--- a/src/main/scala/firrtl/stage/FirrtlOptions.scala
+++ b/src/main/scala/firrtl/stage/FirrtlOptions.scala
@@ -1,0 +1,32 @@
+// See LICENSE for license details.
+
+package firrtl.stage
+
+import firrtl.{Compiler, Transform}
+import firrtl.ir.Circuit
+
+/** Internal options used to control the FIRRTL compiler stage.
+  * @param outputFileName output file, default: `targetDir/topName.SUFFIX` with `SUFFIX` as determined by the compiler
+  * @param compiler which compiler to use (default: [[VerilogCompiler]])
+  * @param infoModeName the policy for generating [[firrtl.ir Info]] when processing FIRRTL (default: "append")
+  * @param firrtlCircuit a [[firrtl.ir Circuit]]
+  */
+class FirrtlOptions private [stage] (
+  val outputFileName:       Option[String]  = None,
+  val compiler:             Compiler        = CompilerAnnotation().compiler,
+  val infoModeName:         String          = InfoModeAnnotation().modeName,
+  val firrtlCircuit:        Option[Circuit] = None) {
+
+  private [stage] def copy(
+    outputFileName:       Option[String]  = outputFileName,
+    compiler:             Compiler        = compiler,
+    infoModeName:         String          = infoModeName,
+    firrtlCircuit:        Option[Circuit] = firrtlCircuit ): FirrtlOptions = {
+
+    new FirrtlOptions(
+      outputFileName       = outputFileName,
+      compiler             = compiler,
+      infoModeName         = infoModeName,
+      firrtlCircuit        = firrtlCircuit )
+  }
+}

--- a/src/main/scala/firrtl/stage/FirrtlStage.scala
+++ b/src/main/scala/firrtl/stage/FirrtlStage.scala
@@ -1,0 +1,42 @@
+// See LICENSE for license details.
+
+package firrtl.stage
+
+import firrtl.{AnnotationSeq, FIRRTLException, Utils}
+import firrtl.options.{Stage, Phase, PhaseException, Shell, OptionsException}
+import firrtl.passes.{PassException, PassExceptions}
+
+import logger.{Logger, LoggerCli}
+
+import scala.util.control.ControlThrowable
+
+import java.io.PrintWriter
+
+object FirrtlStage extends Stage {
+  val shell: Shell = new Shell("firrtl") with FirrtlCli with LoggerCli
+
+  private val phases: Seq[Phase] = Seq(
+    firrtl.stage.phases.AddDefaults,
+    firrtl.stage.phases.Checks,
+    firrtl.stage.phases.AddCircuit,
+    firrtl.stage.phases.AddImplicitOutputFile,
+    /* TODO: Replace Compiler with a Dependency API compliant compiler. The implementation of the Dependency API is being
+     * discussed on FIRRTL issue #948:
+     *   - https://github.com/freechipsproject/firrtl/issues/948
+     */
+    firrtl.stage.phases.Compiler,
+    firrtl.stage.phases.WriteEmitted
+  )
+
+  def run(annotations: AnnotationSeq): AnnotationSeq = Logger.makeScope(annotations) {
+    try {
+      phases.foldLeft(annotations)((a, f) => f.transform(a))
+    } catch {
+      /* Rethrow the exceptions which are expected or due to the runtime environment (out of memory, stack overflow, etc.).
+       * Any UNEXPECTED exceptions should be treated as internal errors. */
+      case p @ (_: ControlThrowable | _: PassException | _: PassExceptions | _: FIRRTLException | _: OptionsException
+                  | _: PhaseException) => throw p
+      case e: Exception => Utils.throwInternalError(exception = Some(e))
+    }
+  }
+}

--- a/src/main/scala/firrtl/stage/FirrtlStageUtils.scala
+++ b/src/main/scala/firrtl/stage/FirrtlStageUtils.scala
@@ -1,0 +1,17 @@
+// See LICENSE for license details.
+
+package firrtl.stage
+
+private [stage] sealed trait FileExtension
+private [stage] case object FirrtlFile extends FileExtension
+private [stage] case object ProtoBufFile extends FileExtension
+
+/** Utilities that help with processing FIRRTL options */
+object FirrtlStageUtils {
+
+  private [stage] def getFileExtension(file: String): FileExtension = file.drop(file.lastIndexOf('.')) match {
+    case ".pb" => ProtoBufFile
+    case _     => FirrtlFile
+  }
+
+}

--- a/src/main/scala/firrtl/stage/package.scala
+++ b/src/main/scala/firrtl/stage/package.scala
@@ -1,0 +1,58 @@
+// See LICENSE for license details.
+
+package firrtl
+
+import firrtl.options.{OptionsView, PhasePrerequisiteException, Viewer}
+
+/** The [[stage]] package provides an implementation of the FIRRTL compiler using the [[firrtl.options]] package. This
+  * primarily consists of:
+  *   - [[FirrtlStage]], the internal and external (command line) interface to the FIRRTL compiler
+  *   - A number of [[options.Phase Phase]]s that support and compartmentalize the individual operations of
+  *     [[FirrtlStage]]
+  *   - [[FirrtlOptions]], a class representing options that are necessary to drive the [[FirrtlStage]] and its
+  *     [[firrtl.options.Phase Phase]]s
+  *   - [[FirrtlOptionsView]], a utility that constructs an [[options.OptionsView OptionsView]] of [[FirrtlOptions]]
+  *     from an [[AnnotationSeq]]
+  *   - [[FirrtlCli]], the command line options that the [[FirrtlStage]] supports
+  *   - [[FirrtlStageUtils]] containing miscellaneous utilities for [[stage]]
+  */
+package object stage {
+  implicit object FirrtlOptionsView extends OptionsView[FirrtlOptions] {
+
+    /**
+      * @todo custom transforms are appended as discovered, can this be prepended safely?
+      */
+    def view(options: AnnotationSeq): FirrtlOptions = options
+      .collect { case a: FirrtlOption => a }
+      .foldLeft(new FirrtlOptions()){ (c, x) =>
+        x match {
+          case OutputFileAnnotation(f)           => c.copy(outputFileName = Some(f))
+          case InfoModeAnnotation(i)             => c.copy(infoModeName = i)
+          case CompilerAnnotation(cx)            => c.copy(compiler = cx)
+          case FirrtlCircuitAnnotation(cir)      => c.copy(firrtlCircuit = Some(cir))
+        }
+      }
+  }
+
+  private [firrtl] implicit object FirrtlExecutionResultView extends OptionsView[FirrtlExecutionResult] {
+
+    def view(options: AnnotationSeq): FirrtlExecutionResult = {
+      val fopts = Viewer.view[FirrtlOptions](options)
+      val emittedRes = options.collect{ case a: EmittedAnnotation[_] => a.value.value }.mkString("\n")
+
+      options.collectFirst{ case a: FirrtlCircuitAnnotation => a.circuit } match {
+        case None => FirrtlExecutionFailure("No circuit found in AnnotationSeq!")
+        case Some(a) => FirrtlExecutionSuccess(
+          emitType = fopts.compiler.getClass.getSimpleName,
+          emitted = emittedRes,
+          circuitState = CircuitState(
+            circuit = a,
+            form = fopts.compiler.outputForm,
+            annotations = firrtl.stage.phases.Strip.transform(options),
+            renames = None
+          ))
+      }
+    }
+  }
+
+}

--- a/src/main/scala/firrtl/stage/phases/AddCircuit.scala
+++ b/src/main/scala/firrtl/stage/phases/AddCircuit.scala
@@ -1,0 +1,60 @@
+// See LICENSE for license details.
+
+package firrtl.stage.phases
+
+import firrtl.stage._
+
+import firrtl.{AnnotationSeq, Parser, proto}
+import firrtl.annotations.DeletedAnnotation
+import firrtl.options.{OptionsException, Phase, PhasePrerequisiteException}
+
+/** [[firrtl.options.Phase Phase]] that expands [[FirrtlFileAnnotation]]/[[FirrtlSourceAnnotation]] into
+  * [[FirrtlCircuitAnnotation]]s and deletes the originals. This is part of the preprocessing done on an input
+  * [[AnnotationSeq]] by [[FirrtlStage]].
+  *
+  * The types of possible annotations are handled in the following ways:
+  *  - [[FirrtlFileAnnotation]]s are read as Protocol Buffers if the file extension ends in `.pb`. Otherwise, these are
+  *    assumed to be raw FIRRTL text and is sent to the [[Parser]]. The original [[FirrtlFileAnnotation]] is deleted.
+  *  - [[FirrtlSourceAnnotation]]s are run through the [[Parser]]. The original [[FirrtlSourceAnnotation]] is deleted.
+  *  - [[FirrtlCircuitAnnotation]]s are left untouched (along with all other annotations).
+  *
+  * If a [[Parser]] is used, its [[Parser.InfoMode InfoMode]] is read from a ''mandatory'' [[InfoModeAnnotation]]. If
+  * using an [[Parser.InfoMode InfoMode]] that expects a filename, the filename is used for [[FirrtlFileAnnotation]]s
+  * and `[anonymous source]` is used for [[FirrtlSourceAnnotation]]s.
+  *
+  * @note '''This must be run after [[AddDefaults]] as this [[firrtl.options.Phase Phase]] depends on the existence of
+  * an [[InfoModeAnnotation]].'''.
+  * @define infoModeException firrtl.options.PhasePrerequisiteException if no [[InfoModeAnnotation]] is present
+  */
+object AddCircuit extends Phase {
+
+  /** Extract the info mode from an [[AnnotationSeq]] or use the default info mode if no annotation exists
+    * @param annotations some annotations
+    * @return the info mode
+    * @throws $infoModeException
+    */
+  private def infoMode(annotations: AnnotationSeq): Parser.InfoMode = {
+    val infoModeAnnotation = annotations
+      .collectFirst{ case a: InfoModeAnnotation => a }
+      .getOrElse { throw new PhasePrerequisiteException(
+                    "An InfoModeAnnotation must be present (did you forget to run AddDefaults?)") }
+    val infoSource = annotations.collectFirst{
+      case FirrtlFileAnnotation(f) => f
+      case _: FirrtlSourceAnnotation => "anonymous source"
+    }.getOrElse("not defined")
+
+    infoModeAnnotation.toInfoMode(Some(infoSource))
+  }
+
+  /** Convert [[FirrtlFileAnnotation]]/[[FirrtlSourceAnnotation]] into [[FirrtlCircuitAnnotation]] and delete originals
+    * @throws $infoModeException
+    */
+  def transform(annotations: AnnotationSeq): AnnotationSeq = {
+    lazy val info = infoMode(annotations)
+    annotations.flatMap {
+      case a: CircuitOption => Seq(DeletedAnnotation(name, a), a.toCircuit(info))
+      case a                => Seq(a)
+    }
+  }
+
+}

--- a/src/main/scala/firrtl/stage/phases/AddDefaults.scala
+++ b/src/main/scala/firrtl/stage/phases/AddDefaults.scala
@@ -1,0 +1,36 @@
+// See LICENSE for license details.
+
+package firrtl.stage.phases
+
+import firrtl.AnnotationSeq
+import firrtl.options.{Phase, TargetDirAnnotation}
+import firrtl.transforms.BlackBoxTargetDirAnno
+import firrtl.stage.{CompilerAnnotation, InfoModeAnnotation, FirrtlOptions}
+
+/** [[firrtl.options.Phase Phase]] that adds default [[FirrtlOption]] [[firrtl.annotations.Annotation Annotation]]s.
+  * This is a part of the preprocessing done by [[FirrtlStage]].
+  */
+object AddDefaults extends Phase {
+
+  /** Append any missing default annotations to an annotation sequence */
+  def transform(annotations: AnnotationSeq): AnnotationSeq = {
+    var bb, c, im = true
+    annotations.foreach {
+      case _: BlackBoxTargetDirAnno => bb = false
+      case _: CompilerAnnotation => c  = false
+      case _: InfoModeAnnotation => im = false
+      case a =>
+    }
+
+    val default = new FirrtlOptions()
+    val targetDir = annotations
+      .collectFirst { case d: TargetDirAnnotation => d }
+      .getOrElse(TargetDirAnnotation()).directory
+
+    (if (bb) Seq(BlackBoxTargetDirAnno(targetDir)) else Seq() ) ++
+      (if (c) Seq(CompilerAnnotation(default.compiler)) else Seq() ) ++
+      (if (im) Seq(InfoModeAnnotation()) else Seq() ) ++
+      annotations
+  }
+
+}

--- a/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
+++ b/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
@@ -1,0 +1,35 @@
+// See LICENSE for license details.
+
+package firrtl.stage.phases
+
+import firrtl.{AnnotationSeq, EmitAllModulesAnnotation}
+import firrtl.options.{Phase, Viewer}
+import firrtl.stage.{FirrtlCircuitAnnotation, FirrtlOptions, OutputFileAnnotation}
+
+/** [[firrtl.options.Phase Phase]] that adds an [[OutputFileAnnotation]] if one does not already exist.
+  *
+  * To determine the [[OutputFileAnnotation]], the following precedence is used. Whichever happens first succeeds:
+  *  - Do nothing if an [[OutputFileAnnotation]] or [[EmitAllModulesAnnotation]] exist
+  *  - Use the main in the first discovered [[FirrtlCircuitAnnotation]] (see note below)
+  *  - Use "a"
+  *
+  * The file suffix may or may not be specified, but this may be arbitrarily changed by the [[Emitter]].
+  *
+  * @note This [[firrtl.options.Phase Phase]] has a dependency on [[AddCircuit]]. Only a [[FirrtlCircuitAnnotation]]
+  * will be used to implicitly set the [[OutputFileAnnotation]] (not other [[CircuitOption]] subclasses).
+  */
+object AddImplicitOutputFile extends Phase {
+
+  /** Add an [[OutputFileAnnotation]] to an [[AnnotationSeq]] */
+  def transform(annotations: AnnotationSeq): AnnotationSeq =
+    annotations
+      .collectFirst { case _: OutputFileAnnotation | _: EmitAllModulesAnnotation => annotations }
+      .getOrElse {
+        val topName = Viewer
+          .view[FirrtlOptions](annotations)
+          .firrtlCircuit
+          .map(_.main)
+          .getOrElse("a")
+        OutputFileAnnotation(topName) +: annotations
+      }
+}

--- a/src/main/scala/firrtl/stage/phases/Checks.scala
+++ b/src/main/scala/firrtl/stage/phases/Checks.scala
@@ -1,0 +1,92 @@
+// See LICENSE for license details.
+
+package firrtl.stage.phases
+
+import firrtl.stage._
+
+import firrtl.{AnnotationSeq, EmitAllModulesAnnotation}
+import firrtl.annotations.Annotation
+import firrtl.options.{OptionsException, Phase}
+
+/** [[firrtl.options.Phase Phase]] that strictly validates an [[AnnotationSeq]]. The checks applied are intended to be
+  * extremeley strict. Nothing is inferred or assumed to take a default value (for default value resolution see
+  * [[AddDefaults]]).
+  *
+  * The intent of this approach is that after running this [[firrtl.options.Phase Phase]], a user can be absolutely
+  * certain that other [[firrtl.options.Phase Phase]]s or views will succeed. See [[FirrtlStage]] for a list of
+  * [[firrtl.options.Phase Phase]] that commonly run before this.
+  */
+object Checks extends Phase {
+
+  /** Determine if an annotations are sane
+    *
+    * @param annos a sequence of [[annotation.Annotation]]
+    * @return true if all checks pass
+    * @throws firrtl.options.OptionsException if any checks fail
+    */
+  def transform(annos: AnnotationSeq): AnnotationSeq = {
+    val inF, inS, eam, outF, td, i, foaf, comp, im, inC = collection.mutable.ListBuffer[Annotation]()
+    annos.foreach(
+      _ match {
+        case a: FirrtlFileAnnotation     => a +=: inF
+        case a: FirrtlSourceAnnotation   => a +=: inS
+        case a: EmitAllModulesAnnotation => a +=: eam
+        case a: OutputFileAnnotation     => a +=: outF
+        case a: CompilerAnnotation       => a +=: comp
+        case a: InfoModeAnnotation       => a +=: im
+        case a: FirrtlCircuitAnnotation  => a +=: inC
+        case _                           =>           })
+
+    /* At this point, only a FIRRTL Circuit should exist */
+    if (inF.isEmpty && inS.isEmpty && inC.isEmpty) {
+      throw new OptionsException(
+        s"""|Unable to determine FIRRTL source to read. None of the following were found:
+            |    - an input file:  -i, --input-file,    FirrtlFileAnnotation
+            |    - FIRRTL source:      --firrtl-source, FirrtlSourceAnnotation
+            |    - FIRRTL circuit:                      FirrtlCircuitAnnotation""".stripMargin )}
+
+    /* Only one FIRRTL input can exist */
+    if (inF.size + inS.size + inC.size > 1) {
+      throw new OptionsException(
+        s"""|Multiply defined input FIRRTL sources. More than one of the following was found:
+            |    - an input file (${inF.size} times):  -i, --input-file,    FirrtlFileAnnotation
+            |    - FIRRTL source (${inS.size} times):      --firrtl-source, FirrtlSourceAnnotation
+            |    - FIRRTL circuit (${inC.size} times):                      FirrtlCircuitAnnotation""".stripMargin )}
+
+    /* Specifying an output file and one-file-per module conflict */
+    if (eam.nonEmpty && outF.nonEmpty) {
+      throw new OptionsException(
+        s"""|Output file is incompatible with emit all modules annotation, but multiples were found:
+            |    - explicit output file (${outF.size} times): -o, --output-file, OutputFileAnnotation
+            |    - one file per module (${eam.size} times):  -e, --emit-modules, EmitAllModulesAnnotation"""
+          .stripMargin )}
+
+    /* Only one output file can be specified */
+    if (outF.size > 1) {
+      val x = outF.map{ case OutputFileAnnotation(x) => x }
+      throw new OptionsException(
+        s"""|No more than one output file can be specified, but found '${x.mkString(", ")}' specified via:
+            |    - option or annotation: -o, --output-file, OutputFileAnnotation""".stripMargin) }
+
+    /* One mandatory compiler must be specified */
+    if (comp.size != 1) {
+      val x = comp.map{ case CompilerAnnotation(x) => x }
+      val (msg, suggest) = if (comp.size == 0) { ("none found",                       "forget one of")   }
+      else                                     { (s"""found '${x.mkString(", ")}'""", "use multiple of") }
+      throw new OptionsException(
+        s"""|Exactly one compiler must be specified, but $msg. Did you $suggest the following?
+            |    - an option or annotation: -X, --compiler, CompilerAnnotation""".stripMargin )}
+
+    /* One mandatory info mode must be specified */
+    if (im.size != 1) {
+      val x = im.map{ case InfoModeAnnotation(x) => x }
+      val (msg, suggest) = if (im.size == 0) { ("none found",                       "forget one of")   }
+      else                                     { (s"""found '${x.mkString(", ")}'""", "use multiple of") }
+      throw new OptionsException(
+        s"""|Exactly one info mode must be specified, but $msg. Did you $suggest the following?
+            |    - an option or annotation: --info-mode, InfoModeAnnotation""".stripMargin )}
+
+    annos
+  }
+
+}

--- a/src/main/scala/firrtl/stage/phases/Compiler.scala
+++ b/src/main/scala/firrtl/stage/phases/Compiler.scala
@@ -83,7 +83,7 @@ object Compiler extends Phase with Translator[AnnotationSeq, Seq[CompilerRun]] {
       Seq( FirrtlCircuitAnnotation(bb.stateOut.get.circuit),
            DeletedAnnotation(name, FirrtlCircuitAnnotation(bb.stateIn.circuit)),
            DeletedAnnotation(name, CompilerAnnotation(bb.compiler.get)) ) ++
-        bb.transforms.map(t => DeletedAnnotation(name, RunFirrtlTransformAnnotation(t))) ++
+        bb.transforms.reverse.map(t => DeletedAnnotation(name, RunFirrtlTransformAnnotation(t))) ++
         bb.stateOut.get.annotations }
 
   /** Run the FIRRTL compiler some number of times. If more than one run is specified, a parallel collection will be
@@ -94,7 +94,7 @@ object Compiler extends Phase with Translator[AnnotationSeq, Seq[CompilerRun]] {
       val statex = c
         .compiler
         .getOrElse { throw new PhasePrerequisiteException("No compiler specified!") }
-        .compile(c.stateIn, c.transforms)
+        .compile(c.stateIn, c.transforms.reverse)
       c.copy(stateOut = Some(statex))
     }
 

--- a/src/main/scala/firrtl/stage/phases/Compiler.scala
+++ b/src/main/scala/firrtl/stage/phases/Compiler.scala
@@ -1,0 +1,105 @@
+// See LICENSE for license details.
+
+package firrtl.stage.phases
+
+import firrtl.{AnnotationSeq, ChirrtlForm, CircuitState, Compiler, Transform, seqToAnnoSeq}
+import firrtl.annotations.DeletedAnnotation
+import firrtl.options.{Phase, PhasePrerequisiteException, Translator}
+import firrtl.stage.{CircuitOption, CompilerAnnotation, FirrtlOptions, FirrtlCircuitAnnotation,
+  RunFirrtlTransformAnnotation}
+
+import scala.collection.mutable
+
+/** An encoding of the information necessary to run the FIRRTL compiler once */
+private [stage] case class CompilerRun(
+  stateIn: CircuitState,
+  stateOut: Option[CircuitState],
+  transforms: Seq[Transform],
+  compiler: Option[Compiler] )
+
+/** An encoding of possible defaults for a [[CompilerRun]] */
+private [stage] case class Defaults(
+  annotations: AnnotationSeq = Seq.empty,
+  transforms: Seq[Transform] = Seq.empty,
+  compiler: Option[Compiler] = None)
+
+/** Runs the FIRRTL compilers on an [[AnnotationSeq]]. If the input [[AnnotationSeq]] contains more than one circuit
+  * (i.e., more than one [[FirrtlCircuitAnnotation]]), then annotations will be broken up and each run will be executed
+  * in parallel.
+  *
+  * The [[AnnotationSeq]] will be chunked up into compiler runs using the following algorithm. All annotations that
+  * occur before the first [[FirrtlCircuitAnnotation]] are treated as global annotations that apply to all circuits.
+  * Annotations after a circuit are only associated with their closest preceeding circuit. E.g., for the following
+  * annotations (where A, B, and C are some annotations):
+  *
+  *    A(a), FirrtlCircuitAnnotation(x), B, FirrtlCircuitAnnotation(y), A(b), C, FirrtlCircuitAnnotation(z)
+  *
+  * Then this will result in two compiler runs:
+  *   - FirrtlCircuitAnnotation(x): A(a), B
+  *   - FirrtlCircuitAnnotation(y): A(a), A(b), C
+  *   - FirrtlCircuitAnnotation(z): A(a)
+  *
+  * A(a) is a default, global annotation. B binds to FirrtlCircuitAnnotation(x). A(a), A(b), and C bind to
+  * FirrtlCircuitAnnotation(y). Note: A(b) ''may'' overwrite A(a) if this is a CompilerAnnotation.
+  * FirrtlCircuitAnnotation(z) has no annotations, so it only gets the default A(a).
+  */
+object Compiler extends Phase with Translator[AnnotationSeq, Seq[CompilerRun]] {
+
+  /** Convert an [[AnnotationSeq]] into a sequence of compiler runs. */
+  protected def aToB(a: AnnotationSeq): Seq[CompilerRun] = {
+    var foundFirstCircuit = false
+    val c = mutable.ArrayBuffer.empty[CompilerRun]
+    a.foldLeft(Defaults()){
+      case (d, FirrtlCircuitAnnotation(circuit)) =>
+        foundFirstCircuit = true
+        CompilerRun(CircuitState(circuit, ChirrtlForm, d.annotations, None), None, d.transforms, d.compiler) +=: c
+        d
+      case (d, a) if foundFirstCircuit => a match {
+        case RunFirrtlTransformAnnotation(transform) =>
+          c(0) = c(0).copy(transforms = transform +: c(0).transforms)
+          d
+        case CompilerAnnotation(compiler) =>
+          c(0) = c(0).copy(compiler = Some(compiler))
+          d
+        case annotation =>
+          val state = c(0).stateIn
+          c(0) = c(0).copy(stateIn = state.copy(annotations = annotation +: state.annotations))
+          d
+      }
+      case (d, a) if !foundFirstCircuit => a match {
+        case RunFirrtlTransformAnnotation(transform) => d.copy(transforms = transform +: d.transforms)
+        case CompilerAnnotation(compiler) => d.copy(compiler = Some(compiler))
+        case annotation => d.copy(annotations = annotation +: d.annotations)
+      }
+    }
+    c
+  }
+
+  /** Expand compiler output back into an [[AnnotationSeq]]. Annotations used in the construction of the compiler run are
+    * deleted ([[CompilerAnnotation]]s and [[RunFirrtlTransformAnnotation]]s).
+    */
+  protected def bToA(b: Seq[CompilerRun]): AnnotationSeq =
+    b.flatMap { bb =>
+      Seq( FirrtlCircuitAnnotation(bb.stateOut.get.circuit),
+           DeletedAnnotation(name, FirrtlCircuitAnnotation(bb.stateIn.circuit)),
+           DeletedAnnotation(name, CompilerAnnotation(bb.compiler.get)) ) ++
+        bb.transforms.map(t => DeletedAnnotation(name, RunFirrtlTransformAnnotation(t))) ++
+        bb.stateOut.get.annotations }
+
+  /** Run the FIRRTL compiler some number of times. If more than one run is specified, a parallel collection will be
+    * used.
+    */
+  protected def internalTransform(b: Seq[CompilerRun]): Seq[CompilerRun] = {
+    def f(c: CompilerRun): CompilerRun = {
+      val statex = c
+        .compiler
+        .getOrElse { throw new PhasePrerequisiteException("No compiler specified!") }
+        .compile(c.stateIn, c.transforms)
+      c.copy(stateOut = Some(statex))
+    }
+
+    if (b.size <= 1) { b.map(f)         }
+    else             { b.par.map(f).seq }
+  }
+
+}

--- a/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
+++ b/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
@@ -1,0 +1,203 @@
+// See LICENSE for license details.
+
+package firrtl.stage.phases
+
+import firrtl.stage._
+
+import firrtl.{AnnotationSeq, EmitAllModulesAnnotation, EmitCircuitAnnotation, Parser}
+import firrtl.annotations.NoTargetAnnotation
+import firrtl.proto.FromProto
+import firrtl.options.{InputAnnotationFileAnnotation, Phase, StageOptions, StageUtils}
+import firrtl.options.Viewer
+
+import java.io.File
+
+/** Provides compatibility methods to replicate deprecated [[Driver]] semantics.
+  *
+  * At a high level, the [[Driver]] tries extremely hard to figure out what the user meant and to enable them to not be
+  * explicit with command line options. As an example, the `--top-name` option is not used for any FIRRTL top module
+  * determination, but to find a FIRRTL file by that name and/or an annotation file by that name. This mode of file
+  * discovery is only used if no explicit FIRRTL file/source/circuit and/or annotation file is given. Going further, the
+  * `--top-name` argument is implicitly specified by the `main` of an input circuit if not explicit and can be used to
+  * derive an annotation file. Summarily, the [[firrtl.options.Phase Phase]]s provided by this enable this type of
+  * resolution.
+  *
+  * '''Only use these methods if you are intending to replicate old [[Driver]] semantics for a good reason.'''
+  * Otherwise, opt for more explicit specification by the user.
+  */
+object DriverCompatibility {
+  /** Holds the name of the top (main) module in an input circuit
+    * @param value top module name
+    */
+  case class TopNameAnnotation(topName: String) extends NoTargetAnnotation
+
+  /** Indicates that the implicit emitter, derived from a [[CompilerAnnotation]] should be an [[EmitAllModulesAnnotation]]
+    * as opposed to an [[EmitCircuitAnnotation]].
+    */
+  private [firrtl] case object EmitOneFilePerModuleAnnotation extends NoTargetAnnotation
+
+  /** Indicates that FIRRTL was called using the [[Driver]] compatibility mode
+    *
+    * If we're in compatibility mode, error handling and reporting may change (e.g., usage messages for the
+    * [[FirrtlStage]] should not be reported). This enables communication to downstream annotation consumers that this was
+    * created using the [[Driver]] compatibility layer.
+    * @todo This is an interesting API and could be expanded into some kind of "stack trace" annotation or "stage history"
+    * annotation. There may be some utility in tracking the path that a set of annotations took through the compiler.
+    */
+  private [phases] case object DriverCompatibilityAnnotation extends NoTargetAnnotation
+
+  /** Determine the top name using the following precedence (highest to lowest):
+    *  - Explicitly from a [[TopNameAnnotation]]
+    *  - Implicitly from the top module ([[firrtl.ir.Circuit.main main]]) of a [[FirrtlCircuitAnnotation]]
+    *  - Implicitly from the top module ([[firrtl.ir.Circuit.main main]]) of a [[FirrtlSourceAnnotation]]
+    *  - Implicitly from the top module ([[firrtl.ir.Circuit.main main]]) of a [[FirrtlFileAnnotation]]
+    *
+    * @param annotations annotations to extract topName from
+    * @return the top module ''if it can be determined''
+    */
+  private def topName(annotations: AnnotationSeq): Option[String] =
+    annotations.collectFirst{ case TopNameAnnotation(n) => n }.orElse(
+      annotations.collectFirst{ case FirrtlCircuitAnnotation(c) => c.main }.orElse(
+        annotations.collectFirst{ case FirrtlSourceAnnotation(s) => Parser.parse(s).main }.orElse(
+          annotations.collectFirst{ case FirrtlFileAnnotation(f) =>
+            FirrtlStageUtils.getFileExtension(f) match {
+              case ProtoBufFile => FromProto.fromFile(f).main
+              case FirrtlFile   => Parser.parse(io.Source.fromFile(f).getLines().mkString("\n")).main } } )))
+
+  /** Determine the target directory with the following precedence (highest to lowest):
+    *  - Explicitly from the user-specified [[firrtl.options.TargetDirAnnotation TargetDirAnnotation]]
+    *  - Implicitly from the default of [[firrtl.options.StageOptions.targetDir StageOptions.targetDir]]
+    *
+    * @param annotations input annotations to extract targetDir from
+    * @return the target directory
+    */
+  private def targetDir(annotations: AnnotationSeq): String = Viewer.view[StageOptions](annotations).targetDir
+
+  /** Add an implicit annotation file derived from the determined top name of the circuit if no
+    * [[firrtl.options.InputAnnotationFileAnnotation InputAnnotationFileAnnotation]] is present.
+    *
+    * The implicit annotation file is determined through the following complicated semantics:
+    *   - If an [[InputAnnotationFileAnnotation]] already exists, then nothing is modified
+    *   - If the derived topName (the `main` in a [[firrtl.ir.Circuit Circuit]]) is ''discernable'' (see below) and a
+    *     file called `topName.anno` (exactly, not `topName.anno.json`) exists, then this will add an
+    *     [[InputAnnotationFileAnnotation]] using that `topName.anno`
+    *   - If any of this doesn't work, then the the [[AnnotationSeq]] is unmodified
+    *
+    * The precedence for determining the `topName` is the following (first one wins):
+    *   - The `topName` in a [[TopNameAnnotation]]
+    *   - The `main` [[FirrtlCircuitAnnotation]]
+    *   - The `main` in a parsed [[FirrtlSourceAnnotation]]
+    *   - The `main` in the first [[FirrtlFileAnnotation]] using either ProtoBuf or parsing as determined by file
+    *     extension
+    *
+    * @param annos input annotations
+    * @return output annotations
+    */
+  private [firrtl] object AddImplicitAnnotationFile extends Phase {
+
+    /** Try to add an [[InputAnnotationFileAnnotation]] implicitly specified by an [[AnnotationSeq]]. */
+    def transform(annotations: AnnotationSeq): AnnotationSeq = {
+      val annotationsx: AnnotationSeq = annotations
+        .collectFirst{ case a: InputAnnotationFileAnnotation => a } match {
+          case Some(_) => annotations
+          case None => topName(annotations) match {
+            case Some(n) =>
+              val filename = targetDir(annotations) + "/" + n + ".anno"
+              if (new File(filename).exists) {
+                StageUtils.dramaticWarning(
+                  s"Implicit reading of the annotation file is deprecated! Use an explict --annotation-file argument.")
+                annotations :+ InputAnnotationFileAnnotation(filename)
+              } else {
+                annotations
+              }
+            case None => annotations
+          } }
+
+      DriverCompatibilityAnnotation +: annotationsx
+    }
+
+  }
+
+  /** Add a [[FirrtlFileAnnotation]] if no annotation that explictly defines a circuit exists.
+    *
+    * This takes the option with the following precedence:
+    *  - If an annotation subclassing [[CircuitOption]] exists, do nothing
+    *  - If a [[TopNameAnnotation]] exists, use that to derive a [[FirrtlFileAnnotation]] and append it
+    *  - Do nothing
+    *
+    * In the case of (3) above, this [[AnnotationSeq]] is likely insufficient for FIRRTL to work with (no circuit was
+    * passed). However, instead of catching this here, we rely on [[Checks]] to validate the annotations.
+    *
+    * @param annotations input annotations
+    * @return
+    */
+  private [firrtl] object AddImplicitFirrtlFile extends Phase {
+
+    /** Try to add a [[FirrtlFileAnnotation]] implicitly specified by an [[AnnotationSeq]]. */
+    def transform(annotations: AnnotationSeq): AnnotationSeq = {
+      val circuit = annotations.collectFirst { case a @ (_: CircuitOption | _: FirrtlCircuitAnnotation) => a }
+      val main = annotations.collectFirst { case a: TopNameAnnotation => a.topName }
+
+      val annotationsx: AnnotationSeq = if (circuit.nonEmpty) {
+        annotations
+      } else if (main.nonEmpty) {
+        StageUtils.dramaticWarning(
+          s"Implicit reading of the input file is deprecated! Use an explict --input-file argument.")
+        FirrtlFileAnnotation(Viewer.view[StageOptions](annotations).getBuildFileName(s"${main.get}.fir")) +: annotations
+      } else {
+        annotations
+      }
+
+      DriverCompatibilityAnnotation +: annotationsx
+    }
+  }
+
+  /** Adds an [[EmitAnnotation]] for each [[CompilerAnnotation]].
+    *
+    * If an [[EmitOneFilePerModuleAnnotation]] exists, then this will add an [[EmitAllModulesAnnotation]]. Otherwise,
+    * this adds an [[EmitCircuitAnnotation]]. This replicates old behavior where specifying a compiler automatically
+    * meant that an emitter would also run.
+    */
+  object AddImplicitEmitter extends Phase {
+
+    /** Add one [[EmitAnnotation]] foreach [[CompilerAnnotation]]. */
+    def transform(annotations: AnnotationSeq): AnnotationSeq = {
+      val splitModules = annotations.collectFirst{ case a: EmitOneFilePerModuleAnnotation.type => a }.isDefined
+
+      val annotationsx = annotations.flatMap {
+        case a @ CompilerAnnotation(c) =>
+          if (splitModules) { Seq(a, EmitAllModulesAnnotation(c.emitter.getClass)) }
+          else              { Seq(a, EmitCircuitAnnotation   (c.emitter.getClass)) }
+        case a => Seq(a)
+      }
+
+      DriverCompatibilityAnnotation +: annotationsx
+    }
+
+  }
+
+  /** Adds an [[OutputFileAnnotation]] derived from a [[TopNameAnnotation]] if no [[OutputFileAnnotation]] already
+    * exists. If no [[TopNameAnnotation]] exists, then no [[OutputFileAnnotation]] is added.
+    */
+  object AddImplicitOutputFile extends Phase {
+
+    /** Add an [[OutputFileAnnotation]] derived from a [[TopNameAnnotation]] if needed. */
+    def transform(annotations: AnnotationSeq): AnnotationSeq = {
+      val hasOutputFile = annotations
+        .collectFirst{ case a @(_: EmitOneFilePerModuleAnnotation.type | _: OutputFileAnnotation) => a }
+        .isDefined
+      val top = topName(annotations)
+
+      val annotationsx: AnnotationSeq =
+        if (!hasOutputFile && top.isDefined) {
+          OutputFileAnnotation(top.get) +: annotations
+        } else {
+          annotations
+        }
+
+      DriverCompatibilityAnnotation +: annotationsx
+    }
+
+  }
+
+}

--- a/src/main/scala/firrtl/stage/phases/Strip.scala
+++ b/src/main/scala/firrtl/stage/phases/Strip.scala
@@ -1,0 +1,39 @@
+// See LICENSE for license details.
+
+package firrtl.stage.phases
+
+import firrtl.{AnnotationSeq, EmittedAnnotation}
+import firrtl.annotations.DeletedAnnotation
+import firrtl.options.Phase
+import firrtl.stage.{CircuitOption, DontStripAnnotation, FirrtlOption}
+
+/** Remove [[firrtl.annotations.Annotation Annotation]]s that are of no use byeond [[FirrtlStage]]. Disable this with a
+  * [[DontStripAnnotation]].
+  *
+  * All of the following [[firrtl.annotations.Annotation Annotation]] types will be stripped:
+  *   - Annotations that mixin [[FirrtlOption]] (indicating that they are options specific to FIRRTL)
+  *   - Annotations that mixin [[CircuitOption]] (indicating that they provide a circuit)
+  *   - Any [[firrtl.annotations.DeletedAnnotation DeletedAnnotation]]s
+  *   - Any [[EmittedAnnotation]]s if '''not''' running in [[Driver]] compatibility mode. (In [[Driver]] compatibility
+  *     mode, the emitted circuit has to be used to construct the return type that the [[Driver]] expected.)
+  */
+object Strip extends Phase {
+
+  /** Remove unneeded/unecessary [[firrtl.annotations.Annotation Annotation]]s from an [[AnnotationSeq]] */
+  def transform(annotations: AnnotationSeq): AnnotationSeq = {
+    lazy val compat = annotations
+      .collectFirst { case a: DriverCompatibility.DriverCompatibilityAnnotation.type => a }
+      .isDefined
+
+    annotations
+      .collectFirst { case a: DontStripAnnotation.type => a } match {
+        case Some(_) => annotations
+        case None => annotations.filterNot {
+          case _: FirrtlOption | _: CircuitOption | _: DeletedAnnotation => true
+          case _: EmittedAnnotation[_] if (!compat)                      => true
+          case _                                                         => false
+        }
+      }
+  }
+
+}

--- a/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
+++ b/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
@@ -1,0 +1,47 @@
+// See LICENSE for license details.
+
+package firrtl.stage.phases
+
+import firrtl.{AnnotationSeq, EmittedModuleAnnotation, EmittedCircuitAnnotation}
+import firrtl.options.{Phase, StageOptions, Viewer}
+import firrtl.stage.FirrtlOptions
+
+import java.io.PrintWriter
+
+/** [[firrtl.options.Phase Phase]] that writes any [[EmittedAnnotation]]s in an input [[AnnotationSeq]] to one or more
+  * files. The input [[AnnotationSeq]] is viewed as both [[FirrtlOptions]] and [[firrtl.options.StageOptions
+  * StageOptions]] to determine the output filenames in the following way:
+  *   - [[EmittedModuleAnnotation]]s are written to a file in [[firrtl.options.StageOptions.targetDir
+  *     StageOptions.targetDir]] with the same name as the module and the [[EmittedComponent.outputSuffix outputSuffix]]
+  *     that the [[EmittedComponent]] specified
+  *   - [[EmittedCircuitAnnotation]]s are written to a file in [[firrtl.options.StageOptions.targetDir
+  *     StageOptions.targetDir]] using the [[FirrtlOptions.outputFileName]] viewed from the [[AnnotationSeq]]. If no
+  *     [[FirrtlOptions.outputFileName]] exists, then the top module/main name will be used. The
+  *     [[EmittedComponent.outputSuffix outputSuffix]] will be appended as needed.
+  *
+  * This does no sanity checking of the input [[AnnotationSeq]]. This simply writes any modules or circuits it sees to
+  * files. If you need additional checking, then you should stack an appropriate checking phase before this.
+  */
+object WriteEmitted extends Phase {
+
+  /** Write any [[EmittedAnnotation]]s in an [[AnnotationSeq]] to files. */
+  def transform(annotations: AnnotationSeq): AnnotationSeq = {
+    val fopts = Viewer.view[FirrtlOptions](annotations)
+    val sopts = Viewer.view[StageOptions](annotations)
+
+    annotations.foreach {
+      case a: EmittedModuleAnnotation[_] =>
+        val pw = new PrintWriter(sopts.getBuildFileName(a.value.name, Some(a.value.outputSuffix)))
+        pw.write(a.value.value)
+        pw.close()
+      case a: EmittedCircuitAnnotation[_] =>
+        val pw = new PrintWriter(
+          sopts.getBuildFileName(fopts.outputFileName.getOrElse(a.value.name), Some(a.value.outputSuffix)))
+        pw.write(a.value.value)
+        pw.close()
+      case _ =>
+    }
+
+    annotations
+  }
+}

--- a/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
+++ b/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
@@ -10,7 +10,7 @@ import java.util.Calendar
 import firrtl.FirrtlExecutionOptions
 
 import scala.sys.process.{ProcessBuilder, ProcessLogger, _}
- 
+
 trait BackendCompilationUtilities {
   /** Parent directory for tests */
   lazy val TestDirectory = new File("test_run_dir")

--- a/src/main/scala/logger/Logger.scala
+++ b/src/main/scala/logger/Logger.scala
@@ -4,7 +4,12 @@ package logger
 
 import java.io.{ByteArrayOutputStream, File, FileOutputStream, PrintStream}
 
-import firrtl.ExecutionOptionsManager
+import firrtl.{ExecutionOptionsManager, HasFirrtlOptions, AnnotationSeq}
+import firrtl.stage.FirrtlOptions
+import firrtl.options.StageOptions
+import firrtl.options.Viewer.view
+import firrtl.stage.FirrtlOptionsView
+import logger.phases.{AddDefaults, Checks}
 
 import scala.util.DynamicVariable
 
@@ -120,7 +125,36 @@ object Logger {
     * @tparam A       The return type of codeBlock
     * @return         Whatever block returns
     */
-  def makeScope[A](manager: ExecutionOptionsManager)(codeBlock: => A): A = {
+  @deprecated("Use makeScope(opts: FirrtlOptions)", "1.2")
+  def makeScope[A](manager: ExecutionOptionsManager)(codeBlock: => A): A =
+    makeScope(manager.commonOptions.toAnnotations)(codeBlock)
+
+  /**
+    * See makeScope using manager.  This creates a manager from a command line arguments style
+    * list of strings
+    * @param args List of strings
+    * @param codeBlock  the block to call
+    * @tparam A   return type of codeBlock
+    * @return
+    */
+  @deprecated("Use makescope(opts: FirrtlOptions)", "1.2")
+  def makeScope[A](args: Array[String] = Array.empty)(codeBlock: => A): A = {
+    val executionOptionsManager = new ExecutionOptionsManager("logger")
+    if(executionOptionsManager.parse(args)) {
+      makeScope(executionOptionsManager)(codeBlock)
+    }
+    else {
+      throw new Exception(s"logger invoke failed to parse args ${args.mkString(", ")}")
+    }
+  }
+
+  /** Set a scope for this logger based on available annotations
+    * @param options a sequence annotations
+    * @param codeBlock some Scala code over which to define this scope
+    * @tparam A return type of the code block
+    * @return the original return of the code block
+    */
+  def makeScope[A](options: AnnotationSeq)(codeBlock: => A): A = {
     val runState: LoggerState = {
       val newRunState = updatableLoggerState.value.getOrElse(new LoggerState)
       if(newRunState.fromInvoke) {
@@ -132,31 +166,11 @@ object Logger {
         forcedNewRunState
       }
     }
-
     updatableLoggerState.withValue(Some(runState)) {
-      setOptions(manager)
+      setOptions(options)
       codeBlock
     }
   }
-
-  /**
-    * See makeScope using manager.  This creates a manager from a command line arguments style
-    * list of strings
-    * @param args List of strings
-    * @param codeBlock  the block to call
-    * @tparam A   return type of codeBlock
-    * @return
-    */
-  def makeScope[A](args: Array[String] = Array.empty)(codeBlock: => A): A = {
-    val executionOptionsManager = new ExecutionOptionsManager("logger")
-    if(executionOptionsManager.parse(args)) {
-      makeScope(executionOptionsManager)(codeBlock)
-    }
-    else {
-      throw new Exception(s"logger invoke failed to parse args ${args.mkString(", ")}")
-    }
-  }
-
 
   /**
     * Used to test whether a given log statement should generate some logging output.
@@ -341,20 +355,33 @@ object Logger {
     * from the command line via an options manager
     * @param optionsManager manager
     */
-  def setOptions(optionsManager: ExecutionOptionsManager): Unit = {
-    val commonOptions = optionsManager.commonOptions
-    state.globalLevel = (state.globalLevel, commonOptions.globalLogLevel) match {
+  @deprecated("Use setOptions(annotations: AnnotationSeq)", "1.2")
+  def setOptions(optionsManager: ExecutionOptionsManager): Unit =
+    setOptions(optionsManager.commonOptions.toAnnotations)
+
+  /** Set logger options based on the content of an [[firrtl.AnnotationSeq AnnotationSeq]]
+    * @param inputAnnotations annotation sequence containing logger options
+    */
+  def setOptions(inputAnnotations: AnnotationSeq): Unit = {
+    val annotations = Seq( AddDefaults,
+                           Checks )
+      .foldLeft(inputAnnotations)((a, p) => p.transform(a))
+
+    val lopts = view[LoggerOptions](annotations)
+    state.globalLevel = (state.globalLevel, lopts.globalLogLevel) match {
       case (LogLevel.None, LogLevel.None) => LogLevel.None
       case (x, LogLevel.None) => x
       case (LogLevel.None, x) => x
       case (_, x) => x
       case _ => LogLevel.Error
     }
-    setClassLogLevels(commonOptions.classLogLevels)
-    if(commonOptions.logToFile) {
-      setOutput(commonOptions.getLogFileName(optionsManager))
+    setClassLogLevels(lopts.classLogLevels)
+
+    if (lopts.logFileName.nonEmpty) {
+      setOutput(lopts.logFileName.get)
     }
-    state.logClassNames = commonOptions.logClassNames
+
+    state.logClassNames = lopts.logClassNames
   }
 }
 
@@ -399,3 +426,9 @@ class Logger(containerClass: String) {
     Logger.showMessage(LogLevel.Trace, containerClass, message)
   }
 }
+
+/** An exception originating from the Logger
+  * @param str an exception message
+  * @param cause a reason for the exception
+  */
+class LoggerException(val str: String, cause: Throwable = null) extends RuntimeException(str, cause)

--- a/src/main/scala/logger/LoggerAnnotations.scala
+++ b/src/main/scala/logger/LoggerAnnotations.scala
@@ -1,0 +1,85 @@
+// See LICENSE for license details.
+
+package logger
+
+import firrtl.AnnotationSeq
+import firrtl.annotations.{Annotation, NoTargetAnnotation}
+import firrtl.options.{HasScoptOptions, StageUtils}
+
+import scopt.OptionParser
+
+/** An annotation associated with a Logger command line option */
+sealed trait LoggerOption { this: Annotation => }
+
+/** Describes the verbosity of information to log
+  *  - set with `-ll/--log-level`
+  *  - if unset, a [[LogLevelAnnotation]] with the default log level will be emitted
+  * @param level the level of logging
+  */
+case class LogLevelAnnotation(globalLogLevel: LogLevel.Value = LogLevel.None) extends NoTargetAnnotation with LoggerOption
+
+object LogLevelAnnotation extends HasScoptOptions {
+  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("log-level")
+    .abbr("ll")
+    .valueName("<Error|Warn|Info|Debug|Trace>")
+    .action( (x, c) => c :+ LogLevelAnnotation(LogLevel(x)) )
+    .validate{ x =>
+      lazy val msg = s"$x bad value must be one of error|warn|info|debug|trace"
+      if (Array("error", "warn", "info", "debug", "trace").contains(x.toLowerCase)) { p.success      }
+      else                                                                          { p.failure(msg) }}
+    .unbounded()
+    .text(s"Sets the verbosity level of logging, default is ${new LoggerOptions().globalLogLevel}")
+}
+
+/** Describes a mapping of a class to a specific log level
+  *  - set with `-cll/--class-log-level`
+  * @param name the class name to log
+  * @param level the verbosity level
+  */
+case class ClassLogLevelAnnotation(className: String, level: LogLevel.Value) extends NoTargetAnnotation with LoggerOption
+
+object ClassLogLevelAnnotation extends HasScoptOptions {
+  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[Seq[String]]("class-log-level")
+    .abbr("cll")
+    .valueName("<FullClassName:[Error|Warn|Info|Debug|Trace]>[,...]")
+    .action( (x, c) => c ++ (x.map { y =>
+                               val className :: levelName :: _ = y.split(":").toList
+                               val level = LogLevel(levelName)
+                               ClassLogLevelAnnotation(className, level) }) )
+    .unbounded()
+    .text(s"This defines per-class verbosity of logging")
+}
+
+/** Enables logging to a file (as opposed to STDOUT)
+  *  - maps to [[LoggerOptions.logFileName]]
+  *  - enabled with `--log-file`
+  *  - a deprecated, default name can be generated with `-ltf/--log-to-file`
+  */
+case class LogFileAnnotation(file: Option[String]) extends NoTargetAnnotation with LoggerOption
+
+object LogFileAnnotation extends HasScoptOptions {
+  def addOptions(p: OptionParser[AnnotationSeq]): Unit = {
+    p.opt[Unit]("log-to-file")
+      .abbr("ltf")
+      .action{ (_, c) =>
+        StageUtils.dramaticWarning("-ltf/--log-to-file is deprecated, use an explicit --log-file")
+        c :+ LogFileAnnotation(None) }
+      .unbounded()
+      .text(s"DEPRECATED: flags writes to topName.log or firrtl.log if no topName")
+    p.opt[String]("log-file")
+      .action( (x, c) => c :+ LogFileAnnotation(Some(x)) )
+      .unbounded()
+      .text(s"log to the specified file")
+  }
+}
+
+/** Enables class names in log output
+  *  - enabled with `-lcn/--log-class-names`
+  */
+case object LogClassNamesAnnotation extends NoTargetAnnotation with LoggerOption with HasScoptOptions {
+  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[Unit]("log-class-names")
+    .abbr("lcn")
+    .action( (x, c) => c :+ LogClassNamesAnnotation )
+    .unbounded()
+    .text(s"shows class names and log level in logging output, useful for target --class-log-level")
+}

--- a/src/main/scala/logger/LoggerAnnotations.scala
+++ b/src/main/scala/logger/LoggerAnnotations.scala
@@ -22,7 +22,7 @@ object LogLevelAnnotation extends HasScoptOptions {
   def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("log-level")
     .abbr("ll")
     .valueName("<Error|Warn|Info|Debug|Trace>")
-    .action( (x, c) => c :+ LogLevelAnnotation(LogLevel(x)) )
+    .action( (x, c) => LogLevelAnnotation(LogLevel(x)) +: c )
     .validate{ x =>
       lazy val msg = s"$x bad value must be one of error|warn|info|debug|trace"
       if (Array("error", "warn", "info", "debug", "trace").contains(x.toLowerCase)) { p.success      }
@@ -42,10 +42,10 @@ object ClassLogLevelAnnotation extends HasScoptOptions {
   def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[Seq[String]]("class-log-level")
     .abbr("cll")
     .valueName("<FullClassName:[Error|Warn|Info|Debug|Trace]>[,...]")
-    .action( (x, c) => c ++ (x.map { y =>
-                               val className :: levelName :: _ = y.split(":").toList
-                               val level = LogLevel(levelName)
-                               ClassLogLevelAnnotation(className, level) }) )
+    .action( (x, c) => (x.map { y =>
+                          val className :: levelName :: _ = y.split(":").toList
+                          val level = LogLevel(levelName)
+                          ClassLogLevelAnnotation(className, level) }) ++ c )
     .unbounded()
     .text(s"This defines per-class verbosity of logging")
 }
@@ -63,11 +63,11 @@ object LogFileAnnotation extends HasScoptOptions {
       .abbr("ltf")
       .action{ (_, c) =>
         StageUtils.dramaticWarning("-ltf/--log-to-file is deprecated, use an explicit --log-file")
-        c :+ LogFileAnnotation(None) }
+        LogFileAnnotation(None) +: c }
       .unbounded()
       .text(s"DEPRECATED: flags writes to topName.log or firrtl.log if no topName")
     p.opt[String]("log-file")
-      .action( (x, c) => c :+ LogFileAnnotation(Some(x)) )
+      .action( (x, c) => LogFileAnnotation(Some(x)) +: c )
       .unbounded()
       .text(s"log to the specified file")
   }
@@ -79,7 +79,7 @@ object LogFileAnnotation extends HasScoptOptions {
 case object LogClassNamesAnnotation extends NoTargetAnnotation with LoggerOption with HasScoptOptions {
   def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[Unit]("log-class-names")
     .abbr("lcn")
-    .action( (x, c) => c :+ LogClassNamesAnnotation )
+    .action( (x, c) => LogClassNamesAnnotation +: c )
     .unbounded()
     .text(s"shows class names and log level in logging output, useful for target --class-log-level")
 }

--- a/src/main/scala/logger/LoggerCli.scala
+++ b/src/main/scala/logger/LoggerCli.scala
@@ -1,0 +1,16 @@
+// See LICENSE for license details.
+
+package logger
+
+import firrtl.options.Shell
+
+/** Include Logger command line options in an options manager */
+trait LoggerCli { this: Shell =>
+  parser.note("Logger Options")
+
+  Seq( LogLevelAnnotation,
+       ClassLogLevelAnnotation,
+       LogFileAnnotation,
+       LogClassNamesAnnotation )
+    .map(_.addOptions(parser))
+}

--- a/src/main/scala/logger/LoggerOptions.scala
+++ b/src/main/scala/logger/LoggerOptions.scala
@@ -1,0 +1,38 @@
+// See LICENSE for license details.
+
+package logger
+
+/** Internal options used to control the logging in programs that are part of the Chisel stack
+  *
+  * @param globalLogLevel the verbosity of logging (default: [[logger.LogLevel.None]])
+  * @param classLogLevels the individual verbosity of logging for specific classes
+  * @param logToFile      if true, log to a file
+  * @param logClassNames  indicates logging verbosity on a class-by-class basis
+  */
+class LoggerOptions private [logger] (
+  val globalLogLevel: LogLevel.Value              = LogLevelAnnotation().globalLogLevel,
+  val classLogLevels: Map[String, LogLevel.Value] = Map.empty,
+  val logClassNames:  Boolean                     = false,
+  val logFileName:    Option[String]              = None) {
+
+  private [logger] def copy(
+    globalLogLevel: LogLevel.Value              = globalLogLevel,
+    classLogLevels: Map[String, LogLevel.Value] = classLogLevels,
+    logClassNames:  Boolean                     = logClassNames,
+    logFileName:    Option[String]              = logFileName): LoggerOptions = {
+
+    new LoggerOptions(
+      globalLogLevel = globalLogLevel,
+      classLogLevels = classLogLevels,
+      logClassNames = logClassNames,
+      logFileName = logFileName)
+
+  }
+
+  /** Return the name of the log file, defaults to `a.log` if unspecified */
+  def getLogFileName(): Option[String] = if (!logToFile) None else logFileName.orElse(Some("a.log"))
+
+  /** True if a [[Logger]] should be writing to a file */
+  @deprecated("logToFile was removed, use logFileName.nonEmpty", "1.2")
+  def logToFile(): Boolean = logFileName.nonEmpty
+}

--- a/src/main/scala/logger/package.scala
+++ b/src/main/scala/logger/package.scala
@@ -1,0 +1,21 @@
+// See LICENSE for license details.
+
+import firrtl.AnnotationSeq
+import firrtl.options.OptionsView
+
+package object logger {
+
+  implicit object LoggerOptionsView extends OptionsView[LoggerOptions] {
+    def view(options: AnnotationSeq): LoggerOptions = options
+      .foldLeft(new LoggerOptions()) { (c, x) =>
+        x match {
+          case LogLevelAnnotation(logLevel)         => c.copy(globalLogLevel = logLevel)
+          case ClassLogLevelAnnotation(name, level) => c.copy(classLogLevels = c.classLogLevels + (name -> level))
+          case LogFileAnnotation(f)                 => c.copy(logFileName = f)
+          case LogClassNamesAnnotation              => c.copy(logClassNames = true)
+          case _                                    => c
+        }
+      }
+  }
+
+}

--- a/src/main/scala/logger/phases/AddDefaults.scala
+++ b/src/main/scala/logger/phases/AddDefaults.scala
@@ -1,0 +1,27 @@
+// See LICENSE for license details.
+
+package logger.phases
+
+import firrtl.AnnotationSeq
+import firrtl.options.Phase
+
+import logger.{LoggerOption, LogLevelAnnotation}
+
+/** Add default logger [[Annotation]]s */
+private [logger] object AddDefaults extends Phase {
+
+  /** Add missing default [[Logger]] [[Annotation]]s to an [[AnnotationSeq]]
+    * @param annotations input annotations
+    * @return output annotations with defaults
+    */
+  def transform(annotations: AnnotationSeq): AnnotationSeq = {
+    var ll = true
+    annotations.collect{ case a: LoggerOption => a }.map{
+      case _: LogLevelAnnotation => ll = false
+      case _                     =>
+    }
+    annotations ++
+      (if (ll) Seq(LogLevelAnnotation()) else Seq() )
+  }
+
+}

--- a/src/main/scala/logger/phases/Checks.scala
+++ b/src/main/scala/logger/phases/Checks.scala
@@ -1,0 +1,42 @@
+// See LICENSE for license details.
+
+package logger.phases
+
+import firrtl.AnnotationSeq
+import firrtl.annotations.Annotation
+import firrtl.options.Phase
+
+import logger.{LogLevelAnnotation, LogFileAnnotation, LoggerException}
+
+import scala.collection.mutable
+
+/** Check that an [[firrtl.AnnotationSeq AnnotationSeq]] has all necessary [[firrtl.annotations.Annotation Annotation]]s
+  * for a [[Logger]] */
+object Checks extends Phase {
+
+  /** Ensure that an [[firrtl.AnnotationSeq AnnotationSeq]] has necessary [[Logger]] [[firrtl.annotations.Annotation
+    * Annotation]]s
+    * @param annotations input annotations
+    * @return input annotations unmodified
+    * @throws logger.LoggerException
+    */
+  def transform(annotations: AnnotationSeq): AnnotationSeq = {
+    val ll, lf = mutable.ListBuffer[Annotation]()
+    annotations.foreach(
+      _ match {
+        case a: LogLevelAnnotation => ll += a
+        case a: LogFileAnnotation  => lf += a
+        case _                     =>         })
+    if (ll.size > 1) {
+      val l = ll.map{ case LogLevelAnnotation(x) => x }
+      throw new LoggerException(
+        s"""|At most one log level can be specified, but found '${l.mkString(", ")}' specified via:
+            |    - an option or annotation: -ll, --log-level, LogLevelAnnotation""".stripMargin )}
+    if (lf.size > 1) {
+      throw new LoggerException(
+        s"""|At most one log file can be specified, but found ${lf.size} combinations of:
+            |    - an options or annotation: -ltf, --log-to-file, --log-file, LogFileAnnotation""".stripMargin )}
+    annotations
+  }
+
+}

--- a/src/test/scala/firrtl/stage/phases/tests/DriverCompatibilitySpec.scala
+++ b/src/test/scala/firrtl/stage/phases/tests/DriverCompatibilitySpec.scala
@@ -1,0 +1,210 @@
+// See LICENSE for license details.
+
+package firrtl.stage.phases.tests
+
+import org.scalatest.{FlatSpec, Matchers, PrivateMethodTester}
+
+import scala.io.Source
+
+import java.io.File
+
+import firrtl._
+import firrtl.stage._
+import firrtl.stage.phases.DriverCompatibility._
+
+import firrtl.options.{InputAnnotationFileAnnotation, TargetDirAnnotation}
+import firrtl.stage.phases.DriverCompatibility
+
+class DriverCompatibilitySpec extends FlatSpec with Matchers with PrivateMethodTester {
+
+  /* This method wraps some magic that lets you use the private method DriverCompatibility.topName */
+  def topName(annotations: AnnotationSeq): Option[String] = {
+    val topName = PrivateMethod[Option[String]]('topName)
+    DriverCompatibility invokePrivate topName(annotations)
+  }
+
+  def simpleCircuit(main: String): String = s"""|circuit $main:
+                                                |  module $main:
+                                                |    node x = UInt<1>("h0")
+                                                |""".stripMargin
+
+  /* This is a tuple holding an annotation that can be used to derive a top name and the expected top name for that
+   * annotation. If these annotations are presented here in the same order that DriverCompatibility.topName uses to
+   * discern a top name. E.g., a TopNameAnnotation is always used, even in the presence of a FirrtlSourceAnnotation.
+   * Note: the last two FirrtlFileAnnotations have equal precedence, but the first one in the AnnotationSeq wins.
+   */
+  val annosWithTops = Seq(
+    (TopNameAnnotation("foo"), "foo"),
+    (FirrtlCircuitAnnotation(Parser.parse(simpleCircuit("bar"))), "bar"),
+    (FirrtlSourceAnnotation(simpleCircuit("baz")), "baz"),
+    (FirrtlFileAnnotation("src/test/resources/integration/PipeTester.fir"), "PipeTester"),
+    (FirrtlFileAnnotation("src/test/resources/integration/GCDTester.pb"), "GCDTester")
+  )
+
+  behavior of s"${DriverCompatibility.getClass.getName}.topName (private method)"
+
+  /* This iterates over the tails of annosWithTops. Using the ordering of annosWithTops, if this AnnotationSeq is fed to
+   * DriverCompatibility.topName, the head annotation will be used to determine the top name. This test ensures that
+   * topName behaves as expected.
+   */
+  for ( t <- annosWithTops.tails ) t match {
+    case Nil =>
+      it should "return None on an empty AnnotationSeq" in {
+        topName(Seq.empty) should be (None)
+      }
+    case x =>
+      val annotations = x.map(_._1)
+      val top = x.head._2
+      it should s"determine a top name ('$top') from a ${annotations.head.getClass.getName}" in {
+        topName(annotations).get should be (top)
+      }
+  }
+
+  def createFile(name: String): Unit = {
+    val file = new File(name)
+    file.getParentFile.getCanonicalFile.mkdirs()
+    file.createNewFile()
+  }
+
+  behavior of AddImplicitAnnotationFile.getClass.getName
+
+  val testDir = "test_run_dir/DriverCompatibilitySpec"
+
+  it should "not modify the annotations if an InputAnnotationFile already exists" in {
+    createFile(testDir + "/foo.anno")
+    val annotations = Seq(
+      InputAnnotationFileAnnotation("bar.anno"),
+      TargetDirAnnotation(testDir),
+      TopNameAnnotation("foo") )
+
+    val expected = DriverCompatibilityAnnotation +: annotations
+
+    AddImplicitAnnotationFile.transform(annotations).toSeq should be (expected)
+  }
+
+  it should "add an InputAnnotationFile based on a derived topName" in {
+    createFile(testDir + "/bar.anno")
+    val annotations = Seq(
+      TargetDirAnnotation(testDir),
+      TopNameAnnotation("bar") )
+
+    val expected = annotations.toSet +
+      InputAnnotationFileAnnotation(testDir + "/bar.anno") +
+      DriverCompatibilityAnnotation
+
+    AddImplicitAnnotationFile.transform(annotations).toSet should be (expected)
+  }
+
+  it should "not add an InputAnnotationFile for .anno.json annotations" in {
+    createFile(testDir + "/baz.anno.json")
+    val annotations = Seq(
+      TargetDirAnnotation(testDir),
+      TopNameAnnotation("baz") )
+
+    val expected = DriverCompatibilityAnnotation +: annotations
+
+    AddImplicitAnnotationFile.transform(annotations).toSeq should be (expected)
+  }
+
+  it should "not add an InputAnnotationFile if it cannot determine the topName" in {
+    val annotations = Seq( TargetDirAnnotation(testDir) )
+    val expected = DriverCompatibilityAnnotation +: annotations
+
+    AddImplicitAnnotationFile.transform(annotations).toSeq should be (expected)
+  }
+
+  behavior of AddImplicitFirrtlFile.getClass.getName
+
+  it should "not modify the annotations if a CircuitOption is present" in {
+    val annotations = Seq( FirrtlFileAnnotation("foo"), TopNameAnnotation("bar") )
+    val expected = DriverCompatibilityAnnotation +: annotations
+
+    AddImplicitFirrtlFile.transform(annotations).toSeq should be (expected)
+  }
+
+  it should "add an FirrtlFileAnnotation if a TopNameAnnotation is present" in {
+    val annotations = Seq( TopNameAnnotation("foo") )
+    val expected = annotations.toSet +
+      FirrtlFileAnnotation(new File("foo.fir").getCanonicalPath) +
+      DriverCompatibilityAnnotation
+
+    AddImplicitFirrtlFile.transform(annotations).toSet should be (expected)
+  }
+
+  it should "do nothing if no TopNameAnnotation is present" in {
+    val annotations = Seq( TargetDirAnnotation("foo") )
+    val expected = DriverCompatibilityAnnotation +: annotations
+
+    AddImplicitFirrtlFile.transform(annotations).toSeq should be (expected)
+  }
+
+  behavior of AddImplicitEmitter.getClass.getName
+
+  val (nc, hfc, mfc, lfc, vc, svc) = ( new NoneCompiler,
+                                       new HighFirrtlCompiler,
+                                       new MiddleFirrtlCompiler,
+                                       new LowFirrtlCompiler,
+                                       new VerilogCompiler,
+                                       new SystemVerilogCompiler )
+
+  it should "convert CompilerAnnotations into EmitCircuitAnnotations without EmitOneFilePerModuleAnnotation" in {
+    val annotations = Seq(
+      CompilerAnnotation(nc),
+      CompilerAnnotation(hfc),
+      CompilerAnnotation(mfc),
+      CompilerAnnotation(lfc),
+      CompilerAnnotation(vc),
+      CompilerAnnotation(svc)
+    )
+    val expected = DriverCompatibilityAnnotation +: annotations
+      .flatMap( a => Seq(a, EmitCircuitAnnotation(a.compiler.emitter.getClass)) )
+
+    AddImplicitEmitter.transform(annotations).toSeq should be (expected)
+  }
+
+  it should "convert CompilerAnnotations into EmitAllodulesAnnotation with EmitOneFilePerModuleAnnotation" in {
+    val annotations = Seq(
+      EmitOneFilePerModuleAnnotation,
+      CompilerAnnotation(nc),
+      CompilerAnnotation(hfc),
+      CompilerAnnotation(mfc),
+      CompilerAnnotation(lfc),
+      CompilerAnnotation(vc),
+      CompilerAnnotation(svc)
+    )
+    val expected = DriverCompatibilityAnnotation +: annotations
+      .flatMap{
+        case a: CompilerAnnotation => Seq(a, EmitAllModulesAnnotation(a.compiler.emitter.getClass))
+        case a => Seq(a)
+      }
+
+    AddImplicitEmitter.transform(annotations).toSeq should be (expected)
+  }
+
+  behavior of AddImplicitOutputFile.getClass.getName
+
+  it should "add an OutputFileAnnotation derived from a TopNameAnnotation if no OutputFileAnnotation exists" in {
+    val annotations = Seq( TopNameAnnotation("foo") )
+    val expected = Seq(
+      DriverCompatibilityAnnotation,
+      OutputFileAnnotation("foo"),
+      TopNameAnnotation("foo")
+    )
+    AddImplicitOutputFile.transform(annotations).toSeq should be (expected)
+  }
+
+  it should "do nothing if an OutputFileannotation already exists" in {
+    val annotations = Seq(
+      TopNameAnnotation("foo"),
+      OutputFileAnnotation("bar") )
+    val expected = DriverCompatibilityAnnotation +: annotations
+    AddImplicitOutputFile.transform(annotations).toSeq should be (expected)
+  }
+
+  it should "do nothing if no TopNameAnnotation exists" in {
+    val annotations = Seq.empty
+    val expected = DriverCompatibilityAnnotation +: annotations
+    AddImplicitOutputFile.transform(annotations).toSeq should be (expected)
+  }
+
+}

--- a/src/test/scala/firrtlTests/DriverSpec.scala
+++ b/src/test/scala/firrtlTests/DriverSpec.scala
@@ -215,6 +215,7 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
       firrtlOptions = firrtlOptions.copy(firrtlSource = Some(input))
     }
     val annoFile = new File(optionsManager.commonOptions.targetDirName, top + ".anno")
+    val vFile = new File(optionsManager.commonOptions.targetDirName, top + ".v")
     "Using Driver.getAnnotations" in {
       copyResourceToFile("/annotations/SampleAnnotations.anno", annoFile)
       optionsManager.firrtlOptions.annotations.length should be(0)
@@ -222,6 +223,7 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
       annos.length should be(12) // 9 from circuit plus 3 general purpose
       annos.count(_.isInstanceOf[InlineAnnotation]) should be(9)
       annoFile.delete()
+      vFile.delete()
     }
     "Using Driver.execute" in {
       copyResourceToFile("/annotations/SampleAnnotations.anno", annoFile)
@@ -231,6 +233,7 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
           annos.count(_.isInstanceOf[InlineAnnotation]) should be(9)
       }
       annoFile.delete()
+      vFile.delete()
     }
   }
 
@@ -381,14 +384,16 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
 
     "To a single file with file extension depending on the compiler by default" in {
       Seq(
-        "none" -> "./Top.fir",
-        "low" -> "./Top.lo.fir",
-        "high" -> "./Top.hi.fir",
-        "middle" -> "./Top.mid.fir",
-        "verilog" -> "./Top.v"
+        "none" -> "./Foo.fir",
+        "low" -> "./Foo.lo.fir",
+        "high" -> "./Foo.hi.fir",
+        "middle" -> "./Foo.mid.fir",
+        "verilog" -> "./Foo.v",
+        "sverilog" -> "./Foo.sv"
       ).foreach { case (compilerName, expectedOutputFileName) =>
+        info(s"$compilerName -> $expectedOutputFileName")
         val manager = new ExecutionOptionsManager("test") with HasFirrtlOptions {
-          commonOptions = CommonOptions(topName = "Top")
+          commonOptions = CommonOptions(topName = "Foo")
           firrtlOptions = FirrtlExecutionOptions(firrtlSource = Some(input), compilerName = compilerName)
         }
 
@@ -405,11 +410,11 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
         "low" -> Seq("./Top.lo.fir", "./Child.lo.fir"),
         "high" -> Seq("./Top.hi.fir", "./Child.hi.fir"),
         "middle" -> Seq("./Top.mid.fir", "./Child.mid.fir"),
-        "verilog" -> Seq("./Top.v", "./Child.v")
+        "verilog" -> Seq("./Top.v", "./Child.v"),
+        "sverilog" -> Seq("./Top.sv", "./Child.sv")
       ).foreach { case (compilerName, expectedOutputFileNames) =>
-        println(s"$compilerName -> $expectedOutputFileNames")
+        info(s"$compilerName -> $expectedOutputFileNames")
         val manager = new ExecutionOptionsManager("test") with HasFirrtlOptions {
-          commonOptions = CommonOptions(topName = "Top")
           firrtlOptions = FirrtlExecutionOptions(firrtlSource = Some(input),
             compilerName = compilerName,
             emitOneFilePerModule = true)
@@ -418,8 +423,8 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
         firrtl.Driver.execute(manager) match {
           case success: FirrtlExecutionSuccess =>
             success.circuitState.annotations.length should be > (0)
-          case _ =>
-
+          case failure: FirrtlExecutionFailure =>
+            fail(s"Got a FirrtlExecutionFailure! Expected FirrtlExecutionSuccess. Full message:\n${failure.message}")
         }
 
         for (name <- expectedOutputFileNames) {

--- a/src/test/scala/firrtlTests/DriverSpec.scala
+++ b/src/test/scala/firrtlTests/DriverSpec.scala
@@ -203,18 +203,35 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
   }
 
   // Deprecated
-  "Annotations can be read implicitly from the name of the circuit" in {
+  "Annotations can be read implicitly from the name of the circuit" - {
+    val input = """|circuit foo :
+                   |  module foo :
+                   |    input x : UInt<8>
+                   |    output y : UInt<8>
+                   |    y <= x""".stripMargin
     val top = "foo"
     val optionsManager = new ExecutionOptionsManager("test") with HasFirrtlOptions {
       commonOptions = commonOptions.copy(topName = top)
+      firrtlOptions = firrtlOptions.copy(firrtlSource = Some(input))
     }
     val annoFile = new File(optionsManager.commonOptions.targetDirName, top + ".anno")
-    copyResourceToFile("/annotations/SampleAnnotations.anno", annoFile)
-    optionsManager.firrtlOptions.annotations.length should be(0)
-    val annos = Driver.getAnnotations(optionsManager)
-    annos.length should be(12) // 9 from circuit plus 3 general purpose
-    annos.count(_.isInstanceOf[InlineAnnotation]) should be(9)
-    annoFile.delete()
+    "Using Driver.getAnnotations" in {
+      copyResourceToFile("/annotations/SampleAnnotations.anno", annoFile)
+      optionsManager.firrtlOptions.annotations.length should be(0)
+      val annos = Driver.getAnnotations(optionsManager)
+      annos.length should be(12) // 9 from circuit plus 3 general purpose
+      annos.count(_.isInstanceOf[InlineAnnotation]) should be(9)
+      annoFile.delete()
+    }
+    "Using Driver.execute" in {
+      copyResourceToFile("/annotations/SampleAnnotations.anno", annoFile)
+      Driver.execute(optionsManager) match {
+        case r: FirrtlExecutionSuccess =>
+          val annos = r.circuitState.annotations
+          annos.count(_.isInstanceOf[InlineAnnotation]) should be(9)
+      }
+      annoFile.delete()
+    }
   }
 
   // Deprecated

--- a/src/test/scala/firrtlTests/FirrtlSpec.scala
+++ b/src/test/scala/firrtlTests/FirrtlSpec.scala
@@ -3,6 +3,7 @@
 package firrtlTests
 
 import java.io._
+import java.security.Permission
 
 import com.typesafe.scalalogging.LazyLogging
 
@@ -307,4 +308,87 @@ abstract class CompilationTest(name: String, dir: String) extends FirrtlPropSpec
   property(s"$name should compile correctly") {
     compileFirrtlTest(name, dir)
   }
+}
+
+trait Utils {
+
+  /** Run some Scala thunk and return STDOUT and STDERR as strings.
+    * @param thunk some Scala code
+    * @return a tuple containing STDOUT, STDERR, and what the thunk returns
+    */
+  def grabStdOutErr[T](thunk: => T): (String, String, T) = {
+    val stdout, stderr = new ByteArrayOutputStream()
+    val ret = scala.Console.withOut(stdout) { scala.Console.withErr(stderr) { thunk } }
+    (stdout.toString, stderr.toString, ret)
+  }
+
+  /** Encodes a System.exit exit code
+    * @param status the exit code
+    */
+  private case class ExitException(status: Int) extends SecurityException(s"Found a sys.exit with code $status")
+
+  /** A security manager that converts calls to System.exit into [[ExitException]]s by explicitly disabling the ability of
+    * a thread to actually exit. For more information, see:
+    *   - https://docs.oracle.com/javase/tutorial/essential/environment/security.html
+    */
+  private class ExceptOnExit extends SecurityManager {
+    override def checkPermission(perm: Permission): Unit = {}
+    override def checkPermission(perm: Permission, context: Object): Unit = {}
+    override def checkExit(status: Int): Unit = {
+      super.checkExit(status)
+      throw ExitException(status)
+    }
+  }
+
+  /** Encodes a file that some code tries to write to
+    * @param the file name
+    */
+  private case class WriteException(file: String) extends SecurityException(s"Tried to write to file $file")
+
+  /** A security manager that converts writes to any file into [[WriteException]]s.
+    */
+  private class ExceptOnWrite extends SecurityManager {
+    override def checkPermission(perm: Permission): Unit = {}
+    override def checkPermission(perm: Permission, context: Object): Unit = {}
+    override def checkWrite(file: String): Unit = {
+      super.checkWrite(file)
+      throw WriteException(file)
+    }
+  }
+
+  /** Run some Scala code (a thunk) in an environment where all System.exit are caught and returned. This avoids a
+    * situation where a test results in something actually exiting and killing the entire test. This is necessary if you
+    * want to test a command line program, e.g., the `main` method of [[firrtl.options.Stage Stage]].
+    *
+    * NOTE: THIS WILL NOT WORK IN SITUATIONS WHERE THE THUNK IS CATCHING ALL [[Exception]]s OR [[Throwable]]s, E.G.,
+    * SCOPT. IF THIS IS HAPPENING THIS WILL NOT WORK. REPEAT THIS WILL NOT WORK.
+    * @param thunk some Scala code
+    * @return either the output of the thunk (`Right[T]`) or an exit code (`Left[Int]`)
+    */
+  def catchStatus[T](thunk: => T): Either[Int, T] = {
+    try {
+      System.setSecurityManager(new ExceptOnExit())
+      Right(thunk)
+    } catch {
+      case ExitException(a) => Left(a)
+    } finally {
+      System.setSecurityManager(null)
+    }
+  }
+
+  /** Run some Scala code (a thunk) in an environment where file writes are caught and the file that a program tries to
+    * write to is returned. This is useful if you want to test that some thunk either tries to write to a specific file
+    * or doesn't try to write at all.
+    */
+  def catchWrites[T](thunk: => T): Either[String, T] = {
+    try {
+      System.setSecurityManager(new ExceptOnWrite())
+      Right(thunk)
+    } catch {
+      case WriteException(a) => Left(a)
+    } finally {
+      System.setSecurityManager(null)
+    }
+  }
+
 }

--- a/src/test/scala/firrtlTests/annotationTests/TargetDirAnnotationSpec.scala
+++ b/src/test/scala/firrtlTests/annotationTests/TargetDirAnnotationSpec.scala
@@ -5,7 +5,6 @@ package annotationTests
 
 import firrtlTests._
 import firrtl._
-import firrtl.stage.TargetDirAnnotation
 
 /** Looks for [[TargetDirAnnotation]] */
 class FindTargetDirTransform(expected: String) extends Transform {

--- a/src/test/scala/firrtlTests/options/OptionParserSpec.scala
+++ b/src/test/scala/firrtlTests/options/OptionParserSpec.scala
@@ -4,15 +4,13 @@ package firrtlTests.options
 
 import firrtl.{AnnotationSeq, FIRRTLException}
 import firrtl.annotations.{Annotation, NoTargetAnnotation}
-import firrtl.options.{DoNotTerminateOnExit, DuplicateHandling, OptionsException}
+import firrtl.options.{DoNotTerminateOnExit, DuplicateHandling, ExceptOnError, OptionsException}
 
 import scopt.OptionParser
 
 import org.scalatest.{FlatSpec, Matchers}
 
-import java.security.Permission
-
-class OptionParserSpec extends FlatSpec with Matchers {
+class OptionParserSpec extends FlatSpec with Matchers with firrtlTests.Utils {
 
   case class IntAnnotation(x: Int) extends NoTargetAnnotation {
     def extract: Int = x
@@ -32,50 +30,35 @@ class OptionParserSpec extends FlatSpec with Matchers {
       opt[Int]("integer").abbr("m").unbounded.action( (x, c) => IntAnnotation(x) +: c )
   }
 
-  case class ExitException(status: Option[Int]) extends SecurityException("Found a sys.exit")
+  trait WithIntParser { val parser = new IntParser }
 
-  /* Security manager that disallows calls to sys.exit */
-  class ExceptOnExit extends SecurityManager {
-    override def checkPermission(perm: Permission): Unit = {}
-    override def checkPermission(perm: Permission, context: Object): Unit = {}
-    override def checkExit(status: Int): Unit = {
-      super.checkExit(status)
-      throw ExitException(Some(status))
-    }
+  behavior of "A default OptionsParser"
+
+  it should "call sys.exit if terminate is called" in new WithIntParser {
+    info("exit status of 1 for failure")
+    catchStatus { parser.terminate(Left("some message")) } should be (Left(1))
+
+    info("exit status of 0 for success")
+    catchStatus { parser.terminate(Right(Unit)) } should be (Left(0))
   }
 
-  /* Tell a parser to terminate in an environment where sys.exit throws an exception */
-  def catchStatus(parser: OptionParser[_], exitState: Either[String, Unit]): Option[Int] = {
-    System.setSecurityManager(new ExceptOnExit())
-    val status = try {
-      parser.terminate(exitState)
-      throw new ExitException(None)
-    } catch {
-      case ExitException(s) => s
-    }
-    System.setSecurityManager(null)
-    status
+  it should "print to stderr on an invalid option" in new WithIntParser {
+    grabStdOutErr{ parser.parse(Array("--foo"), Seq[Annotation]()) }._2 should include ("Unknown option --foo")
   }
 
-  behavior of "default OptionsParser"
-
-  it should "terminate on exit" in {
-    val parser = new IntParser
-
-    info("By default, exit statuses are reported")
-    catchStatus(parser, Left("some message")) should be (Some(1))
-    catchStatus(parser, Right(Unit))          should be (Some(0))
-  }
-
-  behavior of "DoNotTerminateOnExit"
+  behavior of "An OptionParser with DoNotTerminateOnExit mixed in"
 
   it should "disable sys.exit for terminate method" in {
     val parser = new IntParser with DoNotTerminateOnExit
-    catchStatus(parser, Left("some message")) should be (None)
-    catchStatus(parser, Right(Unit))          should be (None)
+
+    info("no exit for failure")
+    catchStatus { parser.terminate(Left("some message")) } should be (Right(()))
+
+    info("no exit for success")
+    catchStatus { parser.terminate(Right(Unit)) } should be (Right(()))
   }
 
-  behavior of "DuplicateHandling"
+  behavior of "An OptionParser with DuplicateHandling mixed in"
 
   it should "detect short duplicates" in {
     val parser = new IntParser with DuplicateHandling with DuplicateShortOption
@@ -87,6 +70,14 @@ class OptionParserSpec extends FlatSpec with Matchers {
     val parser = new IntParser with DuplicateHandling with DuplicateLongOption
     intercept[OptionsException] { parser.parse(Array[String](), Seq[Annotation]()) }
       .getMessage should startWith ("Duplicate long option")
+  }
+
+  behavior of "An OptionParser with ExceptOnError mixed in"
+
+  it should "cause an OptionsException on an invalid option" in {
+    val parser = new IntParser with ExceptOnError
+    intercept[OptionsException] { parser.parse(Array("--foo"), Seq[Annotation]()) }
+      .getMessage should include ("Unknown option")
   }
 
 }

--- a/src/test/scala/firrtlTests/options/ShellSpec.scala
+++ b/src/test/scala/firrtlTests/options/ShellSpec.scala
@@ -2,11 +2,23 @@
 
 package firrtlTests.options
 
-import org.scalatest._
+import org.scalatest.{FlatSpec, Matchers}
 
+import firrtl.annotations.NoTargetAnnotation
 import firrtl.options.Shell
 
 class ShellSpec extends FlatSpec with Matchers {
+
+  case object A extends NoTargetAnnotation
+  case object B extends NoTargetAnnotation
+  case object C extends NoTargetAnnotation
+  case object D extends NoTargetAnnotation
+  case object E extends NoTargetAnnotation
+
+  trait AlphabeticalCli { this: Shell =>
+    parser.opt[Unit]('c', "c-option").unbounded().action( (x, c) => C +: c )
+    parser.opt[Unit]('d', "d-option").unbounded().action( (x, c) => D +: c )
+    parser.opt[Unit]('e', "e-option").unbounded().action( (x, c) => E +: c ) }
 
   behavior of "Shell"
 
@@ -18,5 +30,11 @@ class ShellSpec extends FlatSpec with Matchers {
 
     info("Found BarLibrary")
     shell.registeredLibraries.map(_.getClass.getName) should contain ("firrtlTests.options.BarLibrary")
+  }
+
+  it should "correctly order annotations and options" in {
+    val shell = new Shell("foo") with AlphabeticalCli
+
+    shell.parse(Array("-c", "-d", "-e"), Seq(A, B)).toSeq should be (Seq(A, B, C, D, E))
   }
 }

--- a/src/test/scala/firrtlTests/options/phases/ChecksSpec.scala
+++ b/src/test/scala/firrtlTests/options/phases/ChecksSpec.scala
@@ -1,0 +1,46 @@
+// See LICENSE for license details.
+
+package firrtlTests.options.phases
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import firrtl.AnnotationSeq
+import firrtl.options.{OptionsException, OutputAnnotationFileAnnotation, Phase, TargetDirAnnotation}
+import firrtl.options.phases.Checks
+
+class ChecksSpec extends FlatSpec with Matchers {
+
+  val targetDir = TargetDirAnnotation("foo")
+  val annoOut = OutputAnnotationFileAnnotation("bar")
+
+  /* A minimum annotation Seq that will pass [[Checks]] */
+  val min = Seq(targetDir)
+
+  def checkExceptionMessage(phase: Phase, annotations: AnnotationSeq, messageStart: String): Unit =
+    intercept[OptionsException]{ phase.transform(annotations) }.getMessage should startWith(messageStart)
+
+  behavior of Checks.getClass.getName
+
+  it should "enforce exactly one TargetDirAnnotation" in {
+    info("0 target directories throws an exception")
+    checkExceptionMessage(Checks, Seq.empty, "Exactly one target directory must be specified")
+
+    info("2 target directories throws an exception")
+    checkExceptionMessage(Checks, Seq(targetDir, targetDir), "Exactly one target directory must be specified")
+  }
+
+  it should "enforce zero or one output annotation files" in {
+    info("0 output annotation files is okay")
+    Checks.transform(Seq(targetDir))
+
+    info("2 output annotation files throws an exception")
+    val in = Seq(targetDir, annoOut, annoOut)
+    checkExceptionMessage(Checks, in, "At most one output annotation file can be specified")
+  }
+
+  it should "pass if the minimum annotations are specified" in {
+    info(s"""Minimum required: ${min.map(_.getClass.getSimpleName).mkString(", ")}""")
+    Checks.transform(min)
+  }
+
+}

--- a/src/test/scala/firrtlTests/options/phases/GetIncludesSpec.scala
+++ b/src/test/scala/firrtlTests/options/phases/GetIncludesSpec.scala
@@ -1,0 +1,96 @@
+// See LICENSE for license details.
+
+package firrtlTests.options.phases
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import java.io.{File, PrintWriter}
+
+import firrtl.AnnotationSeq
+import firrtl.annotations.{Annotation, AnnotationFileNotFoundException, DeletedAnnotation, JsonProtocol,
+  NoTargetAnnotation}
+import firrtl.options.phases.GetIncludes
+import firrtl.options.InputAnnotationFileAnnotation
+import firrtl.util.BackendCompilationUtilities
+
+case object A extends NoTargetAnnotation
+case object B extends NoTargetAnnotation
+case object C extends NoTargetAnnotation
+case object D extends NoTargetAnnotation
+case object E extends NoTargetAnnotation
+
+class GetIncludesSpec extends FlatSpec with Matchers with BackendCompilationUtilities with firrtlTests.Utils {
+
+
+  val dir = new File("test_run_dir/GetIncludesSpec")
+  dir.mkdirs()
+
+  def ref(filename: String): InputAnnotationFileAnnotation = InputAnnotationFileAnnotation(s"$dir/$filename.anno.json")
+
+  def del(annotation: Annotation): DeletedAnnotation = DeletedAnnotation(GetIncludes.name, annotation)
+
+  def checkAnnos(a: AnnotationSeq, b: AnnotationSeq): Unit = {
+    info("read the exepcted number of annotations")
+    a.size should be (b.size)
+
+    info("annotations match exact order")
+    a.zip(b).foreach{ case (ax, bx) => ax should be (bx) }
+  }
+
+  val files = Seq(
+    new File(dir + "/a.anno.json") -> Seq(A, ref("b")),
+    new File(dir + "/b.anno.json") -> Seq(B, ref("c"), ref("a")),
+    new File(dir + "/c.anno.json") -> Seq(C, ref("d"), ref("e")),
+    new File(dir + "/d.anno.json") -> Seq(D),
+    new File(dir + "/e.anno.json") -> Seq(E)
+  )
+
+  files.foreach{ case (file, annotations) =>
+    val pw = new PrintWriter(file)
+    pw.write(JsonProtocol.serialize(annotations))
+    pw.close()
+  }
+
+  behavior of GetIncludes.getClass.getName
+
+  it should "throw an exception if the annotation file doesn't exit" in {
+    intercept[AnnotationFileNotFoundException]{ GetIncludes.transform(Seq(ref("f"))) }
+      .getMessage should startWith("Annotation file")
+  }
+
+  it should "read annotations from a file" in {
+    val e = ref("e")
+    val in = Seq(e)
+    val expect = Seq(del(e), E)
+    val out = GetIncludes.transform(in)
+
+    checkAnnos(out, expect)
+  }
+
+  it should "read annotations from multiple files, but not reading duplicates" in {
+    val Seq(d, e) = Seq("d", "e").map(ref)
+    val in = Seq(d, e, e, d)
+    val expect = Seq(del(d), D, del(e), E, del(e), del(d))
+    val (stdout, _, out) = grabStdOutErr { GetIncludes.transform(in) }
+
+    checkAnnos(out, expect)
+
+    Seq("d", "e").foreach{ x =>
+      info(s"a warning about '$x.anno.json' was printed")
+      stdout should include (s"Warning: Annotation file ($dir/$x.anno.json) already included!")
+    }
+  }
+
+  it should "handle recursive references gracefully, but show a warning" in {
+    val Seq(a, b, c, d, e) = Seq("a", "b", "c", "d", "e").map(ref)
+    val in = Seq(a)
+    val expect = Seq(del(a), A, del(b), B, del(c), C, del(d), D, del(e), E, del(a))
+    val (stdout, _, out) = grabStdOutErr { GetIncludes.transform(in) }
+
+    checkAnnos(out, expect)
+
+    info("a warning about 'a.anno.json' was printed")
+    stdout should include (s"Warning: Annotation file ($dir/a.anno.json)")
+  }
+
+}

--- a/src/test/scala/firrtlTests/options/phases/WriteOutputAnnotationsSpec.scala
+++ b/src/test/scala/firrtlTests/options/phases/WriteOutputAnnotationsSpec.scala
@@ -1,0 +1,85 @@
+// See LICENSE for license details.
+
+package firrtlTests.options.phases
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import java.io.File
+
+import firrtl.{AnnotationSeq, EmittedFirrtlCircuitAnnotation, EmittedFirrtlCircuit}
+import firrtl.annotations.{DeletedAnnotation, NoTargetAnnotation}
+import firrtl.options.{OutputAnnotationFileAnnotation, InputAnnotationFileAnnotation}
+import firrtl.options.phases.{GetIncludes, WriteOutputAnnotations}
+import firrtl.stage.FirrtlFileAnnotation
+
+class WriteOutputAnnotationsSpec extends FlatSpec with Matchers with firrtlTests.Utils {
+
+  val dir = "test_run_dir/WriteOutputAnnotationSpec"
+
+  /** Check if the annotations contained by a [[File]] and the same, and in the same order, as a reference
+    * [[AnnotationSeq]]. This uses [[GetIncludes]] as that already knows how to read annotation files.
+    * @param f a file to read
+    * @param a the expected annotations
+    */
+  private def fileContainsAnnotations(f: File, a: AnnotationSeq): Unit = {
+    info(s"output file '$f' exists")
+    f should (exist)
+
+    info(s"reading '$f' works")
+    val read = GetIncludes
+      .transform(Seq(InputAnnotationFileAnnotation(f.toString)))
+      .filterNot{
+        case a @ DeletedAnnotation(_, _: InputAnnotationFileAnnotation) => true
+        case _                                                          => false }
+
+    info(s"annotations in file are expected size")
+    read.size should be (a.size)
+
+    read
+      .zip(a)
+      .foreach{ case (read, expected) =>
+        info(s"$read matches")
+        read should be (expected) }
+
+    f.delete()
+  }
+
+  behavior of WriteOutputAnnotations.getClass.getName
+
+  it should "write annotations to a file" in {
+    val file = new File(dir + "/should-write-annotations-to-a-file.anno.json")
+    val annotations = Seq( OutputAnnotationFileAnnotation(file.toString),
+                           WriteOutputAnnotationsSpec.FooAnnotation,
+                           WriteOutputAnnotationsSpec.BarAnnotation(0),
+                           WriteOutputAnnotationsSpec.BarAnnotation(1) )
+    val out = WriteOutputAnnotations.transform(annotations)
+
+    info("annotations are unmodified")
+    out.toSeq should be (annotations)
+
+    fileContainsAnnotations(file, annotations)
+  }
+
+  it should "do nothing if no output annotation file is specified" in {
+    val annotations = Seq( WriteOutputAnnotationsSpec.FooAnnotation,
+                           WriteOutputAnnotationsSpec.BarAnnotation(0),
+                           WriteOutputAnnotationsSpec.BarAnnotation(1) )
+
+    val out = catchWrites { WriteOutputAnnotations.transform(annotations) } match {
+      case Right(a) =>
+        info("no file writes occurred")
+        a
+      case Left(a) =>
+        fail(s"No file writes expected, but a write to '$a' ocurred!")
+    }
+
+    info("annotations are unmodified")
+    out.toSeq should be (annotations)
+  }
+
+}
+
+private object WriteOutputAnnotationsSpec {
+  case object FooAnnotation extends NoTargetAnnotation
+  case class BarAnnotation(x: Int) extends NoTargetAnnotation
+}

--- a/src/test/scala/firrtlTests/stage/FirrtlOptionsViewSpec.scala
+++ b/src/test/scala/firrtlTests/stage/FirrtlOptionsViewSpec.scala
@@ -1,0 +1,70 @@
+// See LICENSE for license details.
+
+package firrtlTests.stage
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import firrtl.options._
+import firrtl.stage._
+
+import firrtl.{CircuitForm, CircuitState, ir, NoneCompiler, Parser, UnknownForm}
+import firrtl.options.Viewer.view
+import firrtl.stage.{FirrtlOptions, FirrtlOptionsView}
+
+class BazCompiler extends NoneCompiler
+
+class Baz_Compiler extends NoneCompiler
+
+class FirrtlOptionsViewSpec extends FlatSpec with Matchers {
+
+  behavior of FirrtlOptionsView.getClass.getName
+
+  def circuitString(main: String): String = s"""|circuit $main:
+                                                |  module $main:
+                                                |    node x = UInt<1>("h0")
+                                                |""".stripMargin
+
+  val corge: String = circuitString("corge")
+
+  val grault: ir.Circuit = Parser.parse(circuitString("grault"))
+
+  val annotations = Seq(
+    /* FirrtlOptions */
+    OutputFileAnnotation("bar"),
+    CompilerAnnotation(new BazCompiler()),
+    InfoModeAnnotation("use"),
+    FirrtlCircuitAnnotation(grault)
+  )
+
+  it should "construct a view from an AnnotationSeq" in {
+    val out = view[FirrtlOptions](annotations)
+
+    out.outputFileName should be (Some("bar"))
+    out.compiler.getClass should be (classOf[BazCompiler])
+    out.infoModeName should be ("use")
+    out.firrtlCircuit should be (Some(grault))
+  }
+
+  /* This test only exists to catch changes to existing behavior. This test does not indicate that this is the correct
+   * behavior, only that modifications to existing code will not change behavior that people may expect.
+   */
+  it should "overwrite or append to earlier annotation information with later annotation information" in {
+    val corge_ = circuitString("xyzzy_")
+    val grault_ = Parser.parse(circuitString("thud_"))
+
+    val overwrites = Seq(
+      OutputFileAnnotation("bar_"),
+      CompilerAnnotation(new Baz_Compiler()),
+      InfoModeAnnotation("gen"),
+      FirrtlCircuitAnnotation(grault_)
+    )
+
+    val out = view[FirrtlOptions](annotations ++ overwrites)
+
+    out.outputFileName should be (Some("bar_"))
+    out.compiler.getClass should be (classOf[Baz_Compiler])
+    out.infoModeName should be ("gen")
+    out.firrtlCircuit should be (Some(grault_))
+  }
+
+}

--- a/src/test/scala/firrtlTests/stage/FirrtlStageSpec.scala
+++ b/src/test/scala/firrtlTests/stage/FirrtlStageSpec.scala
@@ -1,0 +1,391 @@
+// See LICENSE for license details.
+
+package firrtlTests.stage
+
+import org.scalatest.{FeatureSpec, GivenWhenThen, Matchers}
+
+import java.io.{File, PrintWriter}
+
+import scala.io.Source
+
+import firrtl.stage.FirrtlStage
+import firrtl.util.BackendCompilationUtilities
+
+/** Testing for the top-level [[FirrtlStage]].
+  *
+  * This test uses the [[org.scalatest.FeatureSpec FeatureSpec]] intentionally as this test exercises the top-level
+  * interface and is more suitable to an Acceptance Testing style.
+  */
+class FirrtlStageSpec extends FeatureSpec with GivenWhenThen with Matchers with firrtlTests.Utils
+    with BackendCompilationUtilities {
+
+  /** Parameterizes one test of [[FirrtlStage]]. Running the [[FirrtlStage]] `main` with certain args should produce
+    * certain files.
+    * @param args arguments to pass
+    * @param circuit a [[FirrtlCircuitFixture]] to use. This will generate an appropriate '-i $targetDir/$main.fi'
+    * argument.
+    * @param files expected files that will be created
+    * @param stdout expected stdout string, None if no output expected
+    * @param stderr expected stderr string, None if no output expected
+    * @param result expected exit code
+    */
+  case class FirrtlStageTest(
+    args: Array[String],
+    circuit: Option[FirrtlCircuitFixture] = Some(new SimpleFirrtlCircuitFixture),
+    files: Seq[String] = Seq.empty,
+    stdout: Option[String] = None,
+    stderr: Option[String] = None,
+    result: Int = 0) {
+    /** Generate a name for the test based on the arguments */
+    def testName: String = "args" + args.mkString("_")
+
+    /** Print the arguments as a single string */
+    def argsString: String = args.mkString(" ")
+  }
+
+  /** Run the FIRRTL stage with some command line arguments expecting output files to be created. The target directory is
+    * implied, but will be created by the stage.
+    * @param p some test parameters
+    */
+  def runStageExpectFiles(p: FirrtlStageTest): Unit = {
+    scenario(s"""User runs FIRRTL Stage with '${p.argsString}'""") {
+      val f = new FirrtlStageFixture
+      val td = new TargetDirectoryFixture(p.testName)
+
+      val inputFile: Array[String] = p.circuit match {
+        case Some(c) =>
+          And("some input FIRRTL IR")
+          val in = new File(td.dir, c.main)
+          val pw = new PrintWriter(in)
+          pw.write(c.input)
+          pw.close()
+          Array("-i", in.toString)
+        case None => Array.empty
+      }
+
+      p.files.foreach( f => new File(td.buildDir + s"/$f").delete() )
+
+      When(s"""the user tries to compile with '${p.argsString}'""")
+      val (stdout, stderr, result) =
+        grabStdOutErr { catchStatus { f.stage.main(inputFile ++ Array("-td", td.buildDir.toString) ++ p.args) } }
+
+      p.stdout match {
+        case Some(a) =>
+          Then(s"""STDOUT should include "$a"""")
+          stdout should include (a)
+        case None =>
+          Then(s"nothing should print to STDOUT")
+          stderr should be (empty)
+      }
+
+      p.stderr match {
+        case Some(a) =>
+          And(s"""STDERR should include "$a"""")
+          stderr should include (a)
+        case None =>
+          And(s"nothing should print to STDERR")
+          stderr should be (empty)
+      }
+
+      p.result match {
+        case 0 =>
+          And(s"the exit code should be 0")
+          result shouldBe a [Right[_,_]]
+        case a =>
+          And(s"the exit code should be $a")
+          result shouldBe (Left(a))
+      }
+
+      p.files.foreach { f =>
+        And(s"file '$f' should be emitted in the target directory")
+        val out = new File(td.buildDir + s"/$f")
+        out should (exist)
+      }
+    }
+  }
+
+
+  /** Test fixture that links to the [[FirrtlStage]] object. This could be done without, but its use matches the
+    * Given/When/Then style more accurately.
+    */
+  class FirrtlStageFixture {
+    Given("the FIRRTL stage")
+    val stage = FirrtlStage
+  }
+
+  /** Test fixture that creates a build directory
+    * @param dirName the name of the base directory; a `build` directory is created under this
+    */
+  class TargetDirectoryFixture(dirName: String) {
+    val dir = new File(s"test_run_dir/FirrtlStageSpec/$dirName")
+    val buildDir = new File(dir + "/build")
+    dir.mkdirs()
+  }
+
+  trait FirrtlCircuitFixture {
+    val main: String
+    val input: String
+  }
+
+  /** Test fixture defining a simple FIRRTL circuit that will emit differently with and without `--split-modules`. */
+  class SimpleFirrtlCircuitFixture extends FirrtlCircuitFixture {
+    val main: String = "Top"
+    val input: String =
+      """|circuit Top:
+         |  module Top:
+         |    output foo: UInt<32>
+         |    inst c of Child
+         |    inst e of External
+         |    foo <= tail(add(c.foo, e.foo), 1)
+         |  module Child:
+         |    output foo: UInt<32>
+         |    inst e of External
+         |    foo <= e.foo
+         |  extmodule External:
+         |    output foo: UInt<32>
+         |""".stripMargin
+  }
+
+  info("As a FIRRTL command line user")
+  info("I want to compile some FIRRTL")
+  feature("FirrtlStage command line interface") {
+    scenario("User tries to discover available options") {
+      val f = new FirrtlStageFixture
+
+      When("the user passes '--help'")
+      /* Note: THIS CANNOT CATCH THE STATUS BECAUSE SCOPT CATCHES ALL THROWABLE!!! The catchStatus is only used to prevent
+       * sys.exit from killing the test. However, this should additionally return an exit code of 0 and not print an
+       * error. The nature of running this through catchStatus causes scopt to intercept the custom SecurityException
+       * and then use that as evidence to exit with a code of 1.
+       */
+      val (out, _, result) = grabStdOutErr { catchStatus { f.stage.main(Array("--help")) } }
+
+      Then("the usage text should be shown")
+      out should include ("Usage: firrtl")
+
+      And("usage text should show known registered transforms")
+      out should include ("--no-dce")
+
+      And("usage text should show known registered libraries")
+      out should include ("MemLib Options")
+
+      info("""And the exit code should be 0, but scopt catches all throwable, so we can't check this... ¯\_(ツ)_/¯""")
+      // And("the exit code should be zero")
+      // out should be (Left(0))
+    }
+
+    Seq(
+      /* Test all standard emitters with and without annotation file outputs */
+      FirrtlStageTest(args    = Array("-X", "none", "-E", "chirrtl"),
+                      files   = Seq("Top.fir")),
+      FirrtlStageTest(args    = Array("-X", "high", "-E", "high"),
+                      files   = Seq("Top.hi.fir")),
+      FirrtlStageTest(args    = Array("-X", "middle", "-E", "middle", "-foaf", "Top"),
+                      files   = Seq("Top.mid.fir", "Top.anno.json")),
+      FirrtlStageTest(args    = Array("-X", "low", "-E", "low", "-foaf", "annotations.anno.json"),
+                      files   = Seq("Top.lo.fir", "annotations.anno.json")),
+      FirrtlStageTest(args    = Array("-X", "verilog", "-E", "verilog", "-foaf", "foo.anno"),
+                      files   = Seq("Top.v", "foo.anno.anno.json")),
+      FirrtlStageTest(args    = Array("-X", "sverilog", "-E", "sverilog", "-foaf", "foo.json"),
+                      files   = Seq("Top.sv", "foo.json.anno.json")),
+
+      /* Test all one file per module emitters */
+      FirrtlStageTest(args    = Array("-X", "none", "-e", "chirrtl"),
+                      files   = Seq("Top.fir", "Child.fir")),
+      FirrtlStageTest(args    = Array("-X", "high", "-e", "high"),
+                      files   = Seq("Top.hi.fir", "Child.hi.fir")),
+      FirrtlStageTest(args    = Array("-X", "middle", "-e", "middle"),
+                      files   = Seq("Top.mid.fir", "Child.mid.fir")),
+      FirrtlStageTest(args    = Array("-X", "low", "-e", "low"),
+                      files   = Seq("Top.lo.fir", "Child.lo.fir")),
+      FirrtlStageTest(args    = Array("-X", "verilog", "-e", "verilog"),
+                      files   = Seq("Top.v", "Child.v")),
+      FirrtlStageTest(args    = Array("-X", "sverilog", "-e", "sverilog"),
+                      files   = Seq("Top.sv", "Child.sv")),
+
+      /* Test changes to output file name */
+      FirrtlStageTest(args    = Array("-X", "none", "-E", "chirrtl", "-o", "foo"),
+                      files   = Seq("foo.fir")),
+      FirrtlStageTest(args    = Array("-X", "high", "-E", "high", "-o", "foo"),
+                      files   = Seq("foo.hi.fir")),
+      FirrtlStageTest(args    = Array("-X", "middle", "-E", "middle", "-o", "foo.middle"),
+                      files   = Seq("foo.middle.mid.fir")),
+      FirrtlStageTest(args    = Array("-X", "low", "-E", "low", "-o", "foo.lo.fir"),
+                      files   = Seq("foo.lo.fir")),
+      FirrtlStageTest(args    = Array("-X", "verilog", "-E", "verilog", "-o", "foo.sv"),
+                      files   = Seq("foo.sv.v")),
+      FirrtlStageTest(args    = Array("-X", "sverilog", "-E", "sverilog", "-o", "Foo"),
+                      files   = Seq("Foo.sv"))
+    )
+      .foreach(runStageExpectFiles)
+
+    scenario("User doesn't specify a target directory") {
+      val f = new FirrtlStageFixture
+
+      When("the user doesn't specify a target directory")
+      val outName = "FirrtlStageSpecNoTargetDirectory"
+      val out = new File(s"$outName.hi.fir")
+      out.delete()
+      val result = catchStatus {
+        f.stage.main(Array("-i", "src/test/resources/integration/GCDTester.fir", "-o", outName, "-X", "high",
+                           "-E", "high")) }
+
+      Then("outputs should be written to current directory")
+      out should (exist)
+      out.delete()
+    }
+
+    scenario("User provides Protocol Buffer input") {
+      val f = new FirrtlStageFixture
+      val td = new TargetDirectoryFixture("protobuf-works")
+
+      And("some Protocol Buffer input")
+      val protobufIn = new File(td.dir + "/Foo.pb")
+      copyResourceToFile("/integration/GCDTester.pb", protobufIn)
+
+      When("the user tries to compile to High FIRRTL")
+      f.stage.main(Array("-i", protobufIn.toString, "-X", "high", "-E", "high", "-td", td.buildDir.toString,
+                         "-o", "Foo"))
+
+      Then("the output should be the same as using FIRRTL input")
+      new File(td.buildDir + "/Foo.hi.fir") should (exist)
+    }
+
+  }
+
+  info("As a FIRRTL command line user")
+  info("I want to receive error messages when I do not specify mandatory inputs")
+  feature("FirrtlStage input validation of mandatory options") {
+    scenario("User gives no command line options (no input circuit specified)") {
+      val f = new FirrtlStageFixture
+
+      When("the user passes no arguments")
+      val (out, err, result) = grabStdOutErr { catchStatus { f.stage.main(Array.empty) } }
+
+      Then("an error should be printed on stdout")
+      out should include (s"Error: Unable to determine FIRRTL source to read")
+
+      And("no usage text should be shown")
+      out should not include ("Usage: firrtl")
+
+      And("nothing should print to stderr")
+      err should be (empty)
+
+      And("the exit code should be 1")
+      result should be (Left(1))
+    }
+  }
+
+  info("As a FIRRTL command line user")
+  info("I want to receive helpful error and warnings message")
+  feature("FirrtlStage input validation") {
+    /* Note: most input validation occurs inside firrtl.stage.phases.Checks. This seeks to validate command line
+     * behavior.
+     */
+
+    scenario("User tries to use an implicit annotation file") {
+      val f = new FirrtlStageFixture
+      val td = new TargetDirectoryFixture("implict-annotation-file")
+      val circuit = new SimpleFirrtlCircuitFixture
+
+      And("implicit legacy and extant annotation files")
+      val annoFiles = Array( (new File(td.dir + "/Top.anno"), "/annotations/SampleAnnotations.anno"),
+                             (new File(td.dir + "/Top.anno.json"), "/annotations/SampleAnnotations.anno.json") )
+      annoFiles.foreach{ case (file, source) => copyResourceToFile(source, file) }
+
+      When("the user implies an annotation file (an annotation file has the same base name as an input file)")
+      val in = new File(td.dir + "/Top.fir")
+      val pw = new PrintWriter(in)
+      pw.write(circuit.input)
+      pw.close()
+      val (out, _, result) = grabStdOutErr{ catchStatus { f.stage.main(Array("-td", td.dir.toString,
+                                                                             "-i", in.toString,
+                                                                             "-foaf", "Top.out",
+                                                                             "-X", "high")) } }
+
+      Then("the implicit annotation file should NOT be read")
+      val annoFileOut = new File(td.dir + "/Top.out.anno.json")
+      val annotationJson = Source.fromFile(annoFileOut).mkString
+      annotationJson should not include ("InlineInstances")
+
+      And("no warning should be printed")
+      out should not include ("Warning:")
+
+      And("no error should be printed")
+      out should not include ("Error:")
+
+      And("the exit code should be 0")
+      result shouldBe a [Right[_,_]]
+    }
+
+    scenario("User provides unsupported legacy annotations") {
+      val f = new FirrtlStageFixture
+      val td = new TargetDirectoryFixture("legacy-annotation-file")
+      val circuit = new SimpleFirrtlCircuitFixture
+
+      And("a legacy annotation file")
+      val annoFile = new File(td.dir + "/legacy.anno")
+      copyResourceToFile("/annotations/SampleAnnotations.anno", annoFile)
+
+      When("the user provides legacy annotations")
+      val in = new File(td.dir + "/Top.fir")
+      val pw = new PrintWriter(in)
+      pw.write(circuit.input)
+      pw.close()
+      val (out, _, result) = grabStdOutErr{ catchStatus { f.stage.main(Array("-td", td.dir.toString,
+                                                                             "-i", in.toString,
+                                                                             "-faf", annoFile.toString,
+                                                                             "-foaf", "Top",
+                                                                             "-X", "high")) } }
+
+      Then("a warning should be printed")
+      out should include ("YAML Annotation files are deprecated")
+
+      And("the exit code should be 0")
+      result shouldBe a [Right[_,_]]
+    }
+
+    Seq(
+      /* Erroneous inputs */
+      FirrtlStageTest(args    = Array("--thisIsNotASupportedOption"),
+                      circuit = None,
+                      stdout  = Some("Error: Unknown option"),
+                      result  = 1),
+      FirrtlStageTest(args    = Array("-i", "foo", "--info-mode", "Use"),
+                      circuit = None,
+                      stdout  = Some("Unknown info mode 'Use'! (Did you misspell it?)"),
+                      result  = 1),
+      FirrtlStageTest(args    = Array("-i", "test_run_dir/I-DO-NOT-EXIST"),
+                      circuit = None,
+                      stdout  = Some("Input file 'test_run_dir/I-DO-NOT-EXIST' not found!"),
+                      result  = 1),
+      FirrtlStageTest(args    = Array("-i", "foo", "-X", "Verilog"),
+                      circuit = None,
+                      stdout  = Some("Unknown compiler name 'Verilog'! (Did you misspell it?)"),
+                      result  = 1)
+    )
+      .foreach(runStageExpectFiles)
+
+  }
+
+  info("As a FIRRTL transform developer")
+  info("I want to register my custom transforms with FIRRTL")
+  feature("FirrtlStage transform registration") {
+    scenario("User doesn't know if their transforms were registered") {
+      val f = new FirrtlStageFixture
+
+      When("the user passes '--show-registrations'")
+      val (out, _, result) = grabStdOutErr { catchStatus { f.stage.main(Array("--show-registrations")) } }
+
+      Then("stdout should show registered transforms")
+      out should include ("firrtl.passes.InlineInstances")
+
+      And("stdout should show registered libraries")
+      out should include("firrtl.passes.memlib.MemLibOptions")
+
+      And("the exit code should be 1")
+      result should be (Left(1))
+    }
+  }
+
+}

--- a/src/test/scala/firrtlTests/stage/phases/AddCircuitSpec.scala
+++ b/src/test/scala/firrtlTests/stage/phases/AddCircuitSpec.scala
@@ -1,0 +1,106 @@
+// See LICENSE for license details.
+
+package firrtlTests.stage.phases
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import firrtl.{AnnotationSeq, Parser}
+import firrtl.annotations.{NoTargetAnnotation, DeletedAnnotation}
+import firrtl.options.{OptionsException, PhasePrerequisiteException}
+import firrtl.stage.{FirrtlCircuitAnnotation, FirrtlSourceAnnotation, InfoModeAnnotation, FirrtlFileAnnotation}
+import firrtl.stage.phases.AddCircuit
+
+import java.io.{File, FileWriter}
+
+class AddCircuitSpec extends FlatSpec with Matchers {
+
+  case class FooAnnotation(x: Int) extends NoTargetAnnotation
+  case class BarAnnotation(x: String) extends NoTargetAnnotation
+
+  behavior of AddCircuit.getClass.getName
+
+  def firrtlSource(name: String): String =
+    s"""|circuit $name:
+        |  module $name:
+        |    input a: UInt<1>
+        |    output b: UInt<1>
+        |    b <= not(a)
+        |""".stripMargin
+
+  it should "throw a PhasePrerequisiteException if a CircuitOption exists without an InfoModeAnnotation" in {
+    {the [PhasePrerequisiteException] thrownBy AddCircuit.transform(Seq(FirrtlSourceAnnotation("foo")))}
+      .message should startWith ("An InfoModeAnnotation must be present")
+  }
+
+  it should "do nothing if no CircuitOption annotations are present" in {
+    val annotations = (1 to 10).map(FooAnnotation) ++
+      ('a' to 'm').map(_.toString).map(BarAnnotation) :+ InfoModeAnnotation("ignore")
+    AddCircuit.transform(annotations).toSeq should be (annotations.toSeq)
+  }
+
+  val (file, fileCircuit) = {
+    val source = firrtlSource("foo")
+    val fileName = "test_run_dir/AddCircuitSpec.fir"
+    val fw = new FileWriter(new File(fileName))
+    fw.write(source)
+    fw.close()
+    (fileName, Parser.parse(source))
+  }
+
+  val (source, sourceCircuit) = {
+    val source = firrtlSource("bar")
+    (source, Parser.parse(source))
+  }
+
+  it should "transform and delete CircuitOption annotations" in {
+    val circuit = Parser.parse(firrtlSource("baz"))
+
+    val annotations = Seq(
+      FirrtlFileAnnotation(file),
+      FirrtlSourceAnnotation(source),
+      FirrtlCircuitAnnotation(circuit),
+      InfoModeAnnotation("ignore") )
+
+    val annotationsExpected = Set(
+      FirrtlCircuitAnnotation(fileCircuit),
+      FirrtlCircuitAnnotation(sourceCircuit),
+      FirrtlCircuitAnnotation(circuit) )
+
+    val deletionsExpected = Set(
+      // AddCircuit is an object, so it gets a trailing '$'
+      DeletedAnnotation(AddCircuit.name, FirrtlFileAnnotation(file)),
+      DeletedAnnotation(AddCircuit.name, FirrtlSourceAnnotation(source))
+    )
+
+    val out = AddCircuit.transform(annotations).toSeq
+
+    info("generated expected FirrtlCircuitAnnotations")
+    out.collect{ case a: FirrtlCircuitAnnotation => a}.toSet should be (annotationsExpected)
+
+    info("generated expected DeletecAnnotations")
+    out.collect{ case a: DeletedAnnotation => a }.toSet should be (deletionsExpected)
+
+    info("no FirrtlFileAnnotations or FirrtlSourceAnnotations present")
+    out.collect{ case a @ (_: FirrtlFileAnnotation | _: FirrtlSourceAnnotation) => a }.toSeq should be (empty)
+  }
+
+  it should """add info for a FirrtlFileAnnotation with a "gen" info mode""" in {
+    AddCircuit.transform(Seq(InfoModeAnnotation("gen"), FirrtlFileAnnotation(file)))
+      .collectFirst{ case a: FirrtlCircuitAnnotation => a.circuit.serialize }
+      .get should include ("AddCircuitSpec")
+  }
+
+  it should """add info for a FirrtlSourceAnnotation with an "append" info mode""" in {
+    AddCircuit.transform(Seq(InfoModeAnnotation("append"), FirrtlSourceAnnotation(source)))
+      .collectFirst{ case a: FirrtlCircuitAnnotation => a.circuit.serialize }
+      .get should include ("anonymous source")
+  }
+
+  it should "throw an OptionsException if the specified file doesn't exist" in {
+    val a = Seq(InfoModeAnnotation("ignore"), FirrtlFileAnnotation("test_run_dir/I-DO-NOT-EXIST"))
+
+    {the [OptionsException] thrownBy AddCircuit.transform(a)}
+      .message should startWith (s"Input file 'test_run_dir/I-DO-NOT-EXIST' not found")
+  }
+
+}

--- a/src/test/scala/firrtlTests/stage/phases/AddDefaultsSpec.scala
+++ b/src/test/scala/firrtlTests/stage/phases/AddDefaultsSpec.scala
@@ -1,0 +1,35 @@
+// See LICENSE for license details.
+
+package firrtlTests.stage.phases
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import firrtl.NoneCompiler
+import firrtl.annotations.Annotation
+import firrtl.stage.phases.AddDefaults
+import firrtl.transforms.BlackBoxTargetDirAnno
+import firrtl.stage.{CompilerAnnotation, InfoModeAnnotation}
+import firrtl.options.TargetDirAnnotation
+
+class AddDefaultsSpec extends FlatSpec with Matchers {
+
+  behavior of AddDefaults.getClass.getName
+
+  it should "add expected default annotations and nothing else" in {
+    val expected = Seq(
+      (a: Annotation) => a match { case BlackBoxTargetDirAnno(b) => b == TargetDirAnnotation().directory },
+      (a: Annotation) => a match { case CompilerAnnotation(b) => b.getClass == CompilerAnnotation().compiler.getClass },
+      (a: Annotation) => a match { case InfoModeAnnotation(b) => b == InfoModeAnnotation().modeName } )
+
+    AddDefaults.transform(Seq.empty).zip(expected).map { case (x, f) => f(x) should be (true) }
+  }
+
+  it should "not overwrite existing annotations" in {
+    val input = Seq(
+      BlackBoxTargetDirAnno("foo"),
+      CompilerAnnotation(new NoneCompiler()),
+      InfoModeAnnotation("ignore"))
+
+    AddDefaults.transform(input).toSeq should be (input)
+  }
+}

--- a/src/test/scala/firrtlTests/stage/phases/AddImplicitOutputFileSpec.scala
+++ b/src/test/scala/firrtlTests/stage/phases/AddImplicitOutputFileSpec.scala
@@ -1,0 +1,43 @@
+// See LICENSE for license details.
+
+package firrtlTests.stage.phases
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import firrtl.{ChirrtlEmitter, EmitAllModulesAnnotation, Parser}
+import firrtl.stage.{FirrtlCircuitAnnotation, OutputFileAnnotation}
+import firrtl.stage.phases.AddImplicitOutputFile
+
+class AddImplicitOutputFileSpec extends FlatSpec with Matchers {
+
+  val foo = """|circuit Foo:
+               |  module Foo:
+               |    node a = UInt<1>("h0")
+               |""".stripMargin
+
+  val circuit = Parser.parse(foo)
+
+  behavior of AddImplicitOutputFile.getClass.getName
+
+  it should "default to an output file named 'a'" in {
+    AddImplicitOutputFile.transform(Seq.empty).toSeq should be (Seq(OutputFileAnnotation("a")))
+  }
+
+  it should "set the output file based on a FirrtlCircuitAnnotation's main" in {
+    val in = Seq(FirrtlCircuitAnnotation(circuit))
+    val out = OutputFileAnnotation(circuit.main) +: in
+    AddImplicitOutputFile.transform(in).toSeq should be (out)
+  }
+
+  it should "do nothing if an OutputFileAnnotation or EmitAllModulesAnnotation already exists" in {
+
+    info("OutputFileAnnotation works")
+    val outputFile = Seq(OutputFileAnnotation("Bar"), FirrtlCircuitAnnotation(circuit))
+    AddImplicitOutputFile.transform(outputFile).toSeq should be (outputFile)
+
+    info("EmitAllModulesAnnotation works")
+    val eam = Seq(EmitAllModulesAnnotation(classOf[ChirrtlEmitter]), FirrtlCircuitAnnotation(circuit))
+    AddImplicitOutputFile.transform(eam).toSeq should be (eam)
+  }
+
+}

--- a/src/test/scala/firrtlTests/stage/phases/ChecksSpec.scala
+++ b/src/test/scala/firrtlTests/stage/phases/ChecksSpec.scala
@@ -1,0 +1,87 @@
+// See LICENSE for license details.
+
+package firrtlTests.stage.phases
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import firrtl.stage._
+
+import firrtl.{AnnotationSeq, ChirrtlEmitter, EmitAllModulesAnnotation, NoneCompiler}
+import firrtl.options.{OptionsException, OutputAnnotationFileAnnotation, Phase}
+import firrtl.stage.phases.{AddImplicitOutputFile, Checks}
+
+class ChecksSpec extends FlatSpec with Matchers {
+
+  val inputFile = FirrtlFileAnnotation("foo")
+  val outputFile = OutputFileAnnotation("bar")
+  val emitAllModules = EmitAllModulesAnnotation(classOf[ChirrtlEmitter])
+  val outputAnnotationFile = OutputAnnotationFileAnnotation("baz")
+  val goodCompiler = CompilerAnnotation(new NoneCompiler())
+  val infoMode = InfoModeAnnotation("ignore")
+
+  val min = Seq(inputFile, goodCompiler, infoMode)
+
+  def checkExceptionMessage(phase: Phase, annotations: AnnotationSeq, messageStart: String): Unit =
+    intercept[OptionsException]{ phase.transform(annotations) }.getMessage should startWith(messageStart)
+
+  behavior of Checks.getClass.getName
+
+  it should "require exactly one input source" in {
+    info("0 input source causes an exception")
+    checkExceptionMessage(Checks, Seq.empty, "Unable to determine FIRRTL source to read")
+
+    info("2 input sources causes an exception")
+    val in = min :+ FirrtlSourceAnnotation("circuit Foo:")
+    checkExceptionMessage(Checks, in, "Multiply defined input FIRRTL sources")
+  }
+
+  it should "require mutual exclusivity of OutputFileAnnotation and EmitAllModulesAnnotation" in {
+    info("OutputFileAnnotation alone works")
+    Checks.transform(min :+ outputFile)
+
+    info("OneFilePerModuleAnnotation alone works")
+    Checks.transform(min :+ emitAllModules)
+
+    info("Together, they throw an exception")
+    val in = min ++ Seq(outputFile, emitAllModules)
+    checkExceptionMessage(Checks, in, "Output file is incompatible with emit all modules annotation")
+  }
+
+  it should "enforce zero or one output files" in {
+    val in = min ++ Seq(outputFile, outputFile)
+    checkExceptionMessage(Checks, in, "No more than one output file can be specified")
+  }
+
+  it should "enforce exactly one compiler" in {
+    info("0 compilers should throw an exception")
+    val inZero = Seq(inputFile, infoMode)
+    checkExceptionMessage(Checks, inZero, "Exactly one compiler must be specified, but none found")
+
+    info("2 compilers should throw an exception")
+    val c = goodCompiler.compiler
+    val inTwo = min :+ goodCompiler
+    checkExceptionMessage(Checks, inTwo, s"Exactly one compiler must be specified, but found '$c, $c'")
+  }
+
+  it should "validate info mode names" in {
+    info("Good info mode names should work")
+    Seq("ignore", "use", "gen", "append")
+      .map(info => Checks.transform(Seq(inputFile, goodCompiler, InfoModeAnnotation(info))))
+  }
+
+  it should "enforce exactly one info mode" in {
+    info("0 info modes should throw an exception")
+    checkExceptionMessage(Checks, Seq(inputFile, goodCompiler),
+                          "Exactly one info mode must be specified, but none found")
+
+    info("2 info modes should throw an exception")
+    val i = infoMode.modeName
+    checkExceptionMessage(Checks, min :+ infoMode, s"Exactly one info mode must be specified, but found '$i, $i'")
+  }
+
+  it should "pass if the minimum annotations are specified" in {
+    info(s"""Minimum required: ${min.map(_.getClass.getSimpleName).mkString(", ")}""")
+    Checks.transform(min)
+  }
+
+}

--- a/src/test/scala/firrtlTests/stage/phases/CompilerSpec.scala
+++ b/src/test/scala/firrtlTests/stage/phases/CompilerSpec.scala
@@ -1,0 +1,148 @@
+// See LICENSE for license details.
+
+package firrtlTests.stage.phases
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import firrtl.{Compiler => _, _}
+import firrtl.annotations.DeletedAnnotation
+import firrtl.options.PhasePrerequisiteException
+import firrtl.stage.{CompilerAnnotation, FirrtlCircuitAnnotation, RunFirrtlTransformAnnotation}
+import firrtl.stage.phases.Compiler
+
+class CompilerSpec extends FlatSpec with Matchers {
+
+  behavior of Compiler.getClass.getName
+
+  it should "do nothing for an empty AnnotationSeq" in {
+    Compiler.transform(Seq.empty).toSeq should be (empty)
+  }
+
+  /** A circuit with a parameterized main (top name) that is different at High, Mid, and Low FIRRTL forms. */
+  private def chirrtl(main: String): String =
+    s"""|circuit $main:
+        |  module $main:
+        |    output foo: {bar: UInt}
+        |
+        |    foo.bar <= UInt<4>("h0")
+        |""".stripMargin
+
+  it should "compile a circuit to Low FIRRTL when using the Verilog compiler" in {
+    val compiler = new VerilogCompiler
+
+    val circuitIn = Parser.parse(chirrtl("top"))
+    val circuitOut = compiler.compile(CircuitState(circuitIn, ChirrtlForm), Seq.empty).circuit
+
+    val input = Seq(
+      FirrtlCircuitAnnotation(circuitIn),
+      CompilerAnnotation(compiler) )
+
+    val expected = FirrtlCircuitAnnotation(circuitOut) +:
+      input.map( a => DeletedAnnotation(Compiler.name, a) )
+
+    Compiler.transform(input).toSeq should be (expected)
+  }
+
+  it should "compile multiple FirrtlCircuitAnnotations" in {
+    val (nc, hfc, mfc, lfc, vc, svc) = (
+      new NoneCompiler,
+      new HighFirrtlCompiler,
+      new MiddleFirrtlCompiler,
+      new LowFirrtlCompiler,
+      new VerilogCompiler,
+      new SystemVerilogCompiler )
+    val (ce, hfe, mfe, lfe, ve, sve) = (
+      new ChirrtlEmitter,
+      new HighFirrtlEmitter,
+      new MiddleFirrtlEmitter,
+      new LowFirrtlEmitter,
+      new VerilogEmitter,
+      new SystemVerilogEmitter )
+
+    val a = Seq(
+      /* Default Compiler is HighFirrtlCompiler */
+      CompilerAnnotation(hfc),
+
+      /* First compiler group, use NoneCompiler */
+      FirrtlCircuitAnnotation(Parser.parse(chirrtl("a"))),
+      CompilerAnnotation(nc),
+      RunFirrtlTransformAnnotation(ce),
+      EmitCircuitAnnotation(ce.getClass),
+
+      /* Second compiler group, use default HighFirrtlCompiler */
+      FirrtlCircuitAnnotation(Parser.parse(chirrtl("b"))),
+      RunFirrtlTransformAnnotation(ce),
+      EmitCircuitAnnotation(ce.getClass),
+      RunFirrtlTransformAnnotation(hfe),
+      EmitCircuitAnnotation(hfe.getClass),
+
+      /* Third compiler group, use MiddleFirrtlCompiler */
+      FirrtlCircuitAnnotation(Parser.parse(chirrtl("c"))),
+      CompilerAnnotation(mfc),
+      RunFirrtlTransformAnnotation(ce),
+      EmitCircuitAnnotation(ce.getClass),
+      RunFirrtlTransformAnnotation(hfe),
+      EmitCircuitAnnotation(hfe.getClass),
+      RunFirrtlTransformAnnotation(mfe),
+      EmitCircuitAnnotation(mfe.getClass),
+
+      /* Fourth compiler group, use LowFirrtlCompiler*/
+      FirrtlCircuitAnnotation(Parser.parse(chirrtl("d"))),
+      CompilerAnnotation(lfc),
+      RunFirrtlTransformAnnotation(ce),
+      EmitCircuitAnnotation(ce.getClass),
+      RunFirrtlTransformAnnotation(hfe),
+      EmitCircuitAnnotation(hfe.getClass),
+      RunFirrtlTransformAnnotation(mfe),
+      EmitCircuitAnnotation(mfe.getClass),
+      RunFirrtlTransformAnnotation(lfe),
+      EmitCircuitAnnotation(lfe.getClass),
+
+      /* Fifth compiler group, use VerilogCompiler */
+      FirrtlCircuitAnnotation(Parser.parse(chirrtl("e"))),
+      CompilerAnnotation(vc),
+      RunFirrtlTransformAnnotation(ce),
+      EmitCircuitAnnotation(ce.getClass),
+      RunFirrtlTransformAnnotation(hfe),
+      EmitCircuitAnnotation(hfe.getClass),
+      RunFirrtlTransformAnnotation(mfe),
+      EmitCircuitAnnotation(mfe.getClass),
+      RunFirrtlTransformAnnotation(lfe),
+      EmitCircuitAnnotation(lfe.getClass),
+      RunFirrtlTransformAnnotation(ve),
+      EmitCircuitAnnotation(ve.getClass),
+
+      /* Sixth compiler group, use SystemVerilogCompiler */
+      FirrtlCircuitAnnotation(Parser.parse(chirrtl("f"))),
+      CompilerAnnotation(svc),
+      RunFirrtlTransformAnnotation(ce),
+      EmitCircuitAnnotation(ce.getClass),
+      RunFirrtlTransformAnnotation(hfe),
+      EmitCircuitAnnotation(hfe.getClass),
+      RunFirrtlTransformAnnotation(mfe),
+      EmitCircuitAnnotation(mfe.getClass),
+      RunFirrtlTransformAnnotation(lfe),
+      EmitCircuitAnnotation(lfe.getClass),
+      RunFirrtlTransformAnnotation(sve),
+      EmitCircuitAnnotation(sve.getClass)
+    )
+
+    val output = Compiler.transform(a)
+
+    info("with the same number of output FirrtlCircuitAnnotations")
+    output
+      .collect{ case a: FirrtlCircuitAnnotation => a }
+      .size should be (6)
+
+    info("and all original FirrtlCircuitAnnotations deleted")
+    output
+      .collect{ case a @ DeletedAnnotation(Compiler.name, _: FirrtlCircuitAnnotation) => a }
+      .size should be (6)
+
+    info("and all expected EmittedAnnotations should be generated")
+    output
+      .collect{ case a: EmittedAnnotation[_] => a }
+      .size should be (20)
+  }
+
+}

--- a/src/test/scala/firrtlTests/stage/phases/StripSpec.scala
+++ b/src/test/scala/firrtlTests/stage/phases/StripSpec.scala
@@ -1,0 +1,38 @@
+// See LICENSE for license details.
+
+package firrtlTests.stage.phases
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import firrtl.NoneCompiler
+import firrtl.stage._
+import firrtl.stage.phases.Strip
+import firrtl.ir
+import firrtl.annotations.{CircuitName, DeletedAnnotation}
+import firrtl.passes.{InlineInstances, InlineAnnotation}
+
+class StripSpec extends FlatSpec with Matchers {
+
+  trait WithAnnotations {
+    val inlineTransform = new InlineInstances
+    val annotations = Seq( FirrtlFileAnnotation("foo"),
+                           OutputFileAnnotation("bar"),
+                           InfoModeAnnotation("append"),
+                           FirrtlSourceAnnotation("qux"),
+                           CompilerAnnotation(new NoneCompiler()),
+                           RunFirrtlTransformAnnotation(inlineTransform),
+                           FirrtlCircuitAnnotation(ir.Circuit(ir.NoInfo, Seq.empty, "quuz")),
+                           DeletedAnnotation("quzz", InlineAnnotation(CircuitName("corge"))) )
+  }
+
+  behavior of Strip.getClass.getName
+
+  it should "strip all unnecessary/unneeded/deleted annotations" in new WithAnnotations {
+    Strip.transform(annotations).toSeq should be (
+      Seq(RunFirrtlTransformAnnotation(inlineTransform)))
+  }
+
+  it should "do nothing if a DontStripAnnotation is present" in new WithAnnotations {
+    Strip.transform(DontStripAnnotation +: annotations).toSeq should be (DontStripAnnotation +: annotations)
+  }
+}

--- a/src/test/scala/firrtlTests/stage/phases/WriteEmittedSpec.scala
+++ b/src/test/scala/firrtlTests/stage/phases/WriteEmittedSpec.scala
@@ -1,0 +1,72 @@
+// See LICENSE for license details.
+
+package firrtlTests.stage.phases
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import java.io.File
+
+import firrtl._
+
+import firrtl.options.TargetDirAnnotation
+import firrtl.stage.OutputFileAnnotation
+import firrtl.stage.phases.WriteEmitted
+
+class WriteEmittedSpec extends FlatSpec with Matchers {
+
+  behavior of WriteEmitted.getClass.getName
+
+  it should "write emitted circuits" in {
+    val annotations = Seq(
+      TargetDirAnnotation("test_run_dir/WriteEmittedSpec"),
+      EmittedFirrtlCircuitAnnotation(EmittedFirrtlCircuit("foo", "", ".foocircuit")),
+      EmittedFirrtlCircuitAnnotation(EmittedFirrtlCircuit("bar", "", ".barcircuit")),
+      EmittedVerilogCircuitAnnotation(EmittedVerilogCircuit("baz", "", ".bazcircuit")) )
+    val expected = Seq("foo.foocircuit", "bar.barcircuit", "baz.bazcircuit")
+      .map(a => new File(s"test_run_dir/WriteEmittedSpec/$a"))
+
+    info("annotations are unmodified")
+    WriteEmitted.transform(annotations).toSeq should be (annotations)
+
+    expected.foreach{ a =>
+      info(s"$a was written")
+      a should (exist)
+      a.delete()
+    }
+  }
+
+  it should "default to the output file name if one exists" in {
+    val annotations = Seq(
+      TargetDirAnnotation("test_run_dir/WriteEmittedSpec"),
+      OutputFileAnnotation("quux"),
+      EmittedFirrtlCircuitAnnotation(EmittedFirrtlCircuit("qux", "", ".quxcircuit")) )
+    val expected = new File("test_run_dir/WriteEmittedSpec/quux.quxcircuit")
+
+    info("annotations are unmodified")
+    WriteEmitted.transform(annotations).toSeq should be (annotations)
+
+    info(s"$expected was written")
+    expected should (exist)
+    expected.delete()
+  }
+
+  it should "write emitted modules" in {
+    val annotations = Seq(
+      TargetDirAnnotation("test_run_dir/WriteEmittedSpec"),
+      EmittedFirrtlModuleAnnotation(EmittedFirrtlModule("foo", "", ".foomodule")),
+      EmittedFirrtlModuleAnnotation(EmittedFirrtlModule("bar", "", ".barmodule")),
+      EmittedVerilogModuleAnnotation(EmittedVerilogModule("baz", "", ".bazmodule")) )
+    val expected = Seq("foo.foomodule", "bar.barmodule", "baz.bazmodule")
+      .map(a => new File(s"test_run_dir/WriteEmittedSpec/$a"))
+
+    info("annotations are unmodified")
+    WriteEmitted.transform(annotations).toSeq should be (annotations)
+
+    expected.foreach{ a =>
+      info(s"$a was written")
+      a should (exist)
+      a.delete()
+    }
+  }
+
+}

--- a/utils/bin/firrtl
+++ b/utils/bin/firrtl
@@ -2,6 +2,6 @@
 
 # This may be a brittle way to find $(root_dir)/utils/bin, is there a better way?
 path=`dirname "$0"`
-cmd="java -cp ${path}/firrtl.jar firrtl.Driver ${@:1}"
+cmd="java -cp ${path}/firrtl.jar firrtl.stage.FirrtlStage ${@:1}"
 eval $cmd
 

--- a/utils/bin/firrtl-profiling
+++ b/utils/bin/firrtl-profiling
@@ -2,6 +2,6 @@
 
 # This may be a brittle way to find $(root_dir)/utils/bin, is there a better way?
 path=`dirname "$0"`
-cmd="java -agentlib:hprof=cpu=samples,depth=100,interval=7,lineno=y,thread=y,file=output.hprof -cp ${path}/firrtl.jar firrtl.Driver ${@:1}"
+cmd="java -agentlib:hprof=cpu=samples,depth=100,interval=7,lineno=y,thread=y,file=output.hprof -cp ${path}/firrtl.jar firrtl.stage.FirrtlStage ${@:1}"
 eval $cmd
 


### PR DESCRIPTION
### Metadata

- @seldridge will rebase and merge

### Overview

This implements a refactor of FIRRTL to use Annotations as a universal source of knowledge. This provides a replacement for both the `Driver` and the `ExecutionOptionsManager` framework. 

This provides:
  - `FirrtlStage`, a replacement for `Driver`
  - A refactor of the `Driver` to act as a compatibility layer around `FirrtlStage`

### Details

#879 introduces `Stage` and #945 introduce `Phase`. A `Phase` is a class that performs a mathematical transformation of an `AnnotationSeq`. In effect, a generalization of FIRRTL's `Transform`. A `Stage` is a `Phase` with a user interface. 

#### `FirrtlStage`

This PR adds `FirrtlStage` which provides a concrete `Stage` that runs the FIRRTL compiler and the chosen emitter. Internally, `FirrtlStage` is broken up into a number of preprocessing phases that transform input annotations in the following steps:
1. Addition of default annotations
2. Validation checking
3. Conversion of compiler name to emitter name
4. Expansion of any input-like annotations in full circuits
5. Addition of an implicit output file if no output file was specified

Differing from previous attempts at an Annotations/Options refactor, all preprocessing work is broken out into these phases. The extraction of information that the `FirrtlStage` needs is done with a lightweight `view[FirrtlOptions]`. This in (aforementioned) previous attempts did much more work (adding defaults, etc.). This is all removed here making the `view` very basic.

Old logic (running the compiler, emitting the circuit) that used to live in `Driver` was hoisted out and put into `FirrtlStage`. This could be targeted by this PR, but is likely out of scope and will be tackled in a subsequent PR.

#### `Driver` as Compatibility Layer

The `Driver` remains largely intact as a shim around `FirrtlStage`. This uses some different `DriverCompatibility` phases for preprocessing that differ from `FirrtlStage`:
1. Try-hard top name determination
2. Implicit annotation file inclusion
3. Implicit FIRRTL file (based on top name)

The logic surrounding these is inordinately complex and likely confusing to a user, but is left in to align with the old `Driver`.

#### Summary

- Fixes #764 
- Fixes #485 
- Uses #793 strategy for annotation pruning
- Depends on #879 and #919  (this includes commits from that PR)

### Benchmarking

I think the performance and memory usage is under control now. This results in a small increase in runtime and a (sometimes) larger increase in memory footprint.
- Memory Increas: -1% up to 10%
- Performance Slowdown: -1% up to 2.5%

### API Changes for FIRRTL Stage

- This changes the FIRRTL fat jar helper script to use the new FIRRTL stage
- When using the FIRRTL stage, one or more emitters can be specified (`-E/--emit-circuit` or `-e/--emit-modules` for whole circuit or one-file-per-module). However, if no emitter is specified, no emitter runs. __This is a change that requires a PR on Rocket Chip.__
- String arguments are now case sensitive and mandate all lowercase, e.g., the compiler is `verilog` not `Verilog`

TODO:

- [x] ~`FirrtlStageResult` should extend `DriverExecutionResult`?~ (This isn't how things work. `DriverExecutionResult` was removed. There's no real need for this.)
- [x] Remove `Driver.dramatic*` stuff in favor of `FirrtlStage.dramatic*`
- [x] `FirrtlStage` Comment on `emittedRes` doesn't make sense (line ~65)
- [x] Should we massage things in the old Driver to fixup the annotations?
  - Yes, this is done via some `Phase`s in `firrtl.stage.phases.DriverCompatibility`
- [x] ~Switch to `view(AnnotationSeq): T` and `viewOption(AnnotationSeq): Option[T]`~
  - Supplanted by #945. The `view` method is `AnnotationSeq => T`.
- [x] Remove `//scalastyle:ignore` in Logger `view`
- [x] Test that both `firrtl.Driver` and `firrtl.stage.FirrtlStage` work with Rocket Chip
- [x] Rocket Chip performance test
  - ~I'm seeing a 4x slowdown~ Caching the `hashCode` of big [Annotation]s fixes this
  - ~Strip `CircuitOption` annotations in `FirrtlStage`~ This shouldn't be necessary
  - [x] `DefaultConfig` is the same
  - [x] @jackkoenig Rocket Chip performance suite
- [x] Fix compatibility problems in `FirrtlStage`
  - [x] `--info-mode` isn't specified
- [x] Remove `--split-modules` in favor of explicit user specification of an emitter to use. I'm not sure on the API here, but `-E/-e` may work for a normal emitter and a one-file-per-module emitter. This would then remove the implicit emitter that `-X` provides. This would be API breaking if we swing the FIRRTL fat jar to use FIRRTL stage.