### PR TITLE
Better error message on missing BlackBox resource

### DIFF
--- a/src/test/scala/firrtlTests/transforms/BlacklBoxSourceHelperSpec.scala
+++ b/src/test/scala/firrtlTests/transforms/BlacklBoxSourceHelperSpec.scala
@@ -105,5 +105,24 @@ class BlacklBoxSourceHelperTransformSpec extends LowTransformSpec {
     val verilogCompiler = new VerilogEmitter
     verilogCompiler.transforms.map { x => x.getClass } should contain (classOf[BlackBoxSourceHelper])
   }
-}
 
+  behavior of "BlackBox resources that do not exist"
+
+  it should "provide a useful error message for BlackBoxResourceAnno" in {
+    val annos = Seq( BlackBoxTargetDirAnno("test_run_dir"),
+                     BlackBoxResourceAnno(moduleName, "/blackboxes/IDontExist.v") )
+
+    (the [BlackBoxNotFoundException] thrownBy { execute(input, "", annos) })
+      .getMessage should include ("Did you misspell it?")
+  }
+
+  it should "provide a useful error message for BlackBoxPathAnno" in {
+    val absPath = new java.io.File("src/test/resources/blackboxes/IDontExist.v").getCanonicalPath
+    val annos = Seq( BlackBoxTargetDirAnno("test_run_dir"),
+                     BlackBoxPathAnno(moduleName, absPath) )
+
+    (the [BlackBoxNotFoundException] thrownBy { execute(input, "", annos) })
+      .getMessage should include ("Did you misspell it?")
+  }
+
+}


### PR DESCRIPTION
Fixes #893 

If you try to access a non-existent BlackBox resource, this should generate a `FIRRTLException` child and not a raw `FileNotFoundException`. The latter will cause the "internal FIRRTL error, file an issue" message while the former does not. 

This fixes this for both `BlackBoxPathAnno` and `BlackBoxResourceAnno` by wrapping calls that interact with the (possibly non-existent) resource file in a method that will rethrow `FileNotFoundException` as a new `BlackBoxNotFoundException extends FIRRTLException`. 

Small changes:
  - The manually thrown `FileNotFoundException` by `BlackBoxSourceHelper.copyResourceToFile` is changed to match what other java methods will do (e.g., `FileInputStream.getChannel`)

Example output looks like:
```
[info] - should provide a useful error message for BlackBoxResourceAnno *** FAILED ***
[info]   firrtl.transforms.BlackBoxNotFoundException: BlackBox '/blackboxes/IDontExist.v' not found. Did you misspell it? Is it in src/{main,test}/resources?
[info]   at firrtl.transforms.BlackBoxSourceHelper.firrtl$transforms$BlackBoxSourceHelper$$safeFile(BlackBoxSourceHelper.scala:80)
[info]   at firrtl.transforms.BlackBoxSourceHelper$$anonfun$1.applyOrElse(BlackBoxSourceHelper.scala:95)
[info]   at firrtl.transforms.BlackBoxSourceHelper$$anonfun$1.applyOrElse(BlackBoxSourceHelper.scala:93)
[info]   at scala.PartialFunction.$anonfun$runWith$1$adapted(PartialFunction.scala:141)
[info]   at scala.collection.Iterator.foreach(Iterator.scala:929)
[info]   at scala.collection.Iterator.foreach$(Iterator.scala:929)
[info]   at scala.collection.AbstractIterator.foreach(Iterator.scala:1417)
[info]   at scala.collection.IterableLike.foreach(IterableLike.scala:71)
[info]   at scala.collection.IterableLike.foreach$(IterableLike.scala:70)
[info]   at scala.collection.AbstractIterable.foreach(Iterable.scala:54)
[info]   ...
[info]   Cause: java.io.FileNotFoundException: /blackboxes/IDontExist.v (No such file or directory)
[info]   at firrtl.transforms.BlackBoxSourceHelper$.copyResourceToFile(BlackBoxSourceHelper.scala:144)
[info]   at firrtl.transforms.BlackBoxSourceHelper$.writeResourceToDirectory(BlackBoxSourceHelper.scala:132)
[info]   at firrtl.transforms.BlackBoxSourceHelper$$anonfun$1.$anonfun$applyOrElse$1(BlackBoxSourceHelper.scala:95)
[info]   at firrtl.transforms.BlackBoxSourceHelper.firrtl$transforms$BlackBoxSourceHelper$$safeFile(BlackBoxSourceHelper.scala:79)
[info]   at firrtl.transforms.BlackBoxSourceHelper$$anonfun$1.applyOrElse(BlackBoxSourceHelper.scala:95)
[info]   at firrtl.transforms.BlackBoxSourceHelper$$anonfun$1.applyOrElse(BlackBoxSourceHelper.scala:93)
[info]   at scala.PartialFunction.$anonfun$runWith$1$adapted(PartialFunction.scala:141)
[info]   at scala.collection.Iterator.foreach(Iterator.scala:929)
[info]   at scala.collection.Iterator.foreach$(Iterator.scala:929)
[info]   at scala.collection.AbstractIterator.foreach(Iterator.scala:1417)
[info]   ...
```