### PR TITLE
Fix $TRAVIS_COMMIT_RANGE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
     $INSTALL_DIR
 
 git:
-  depth: 128
+  depth: 10
 
 env:
   global:
@@ -16,6 +16,11 @@ env:
     VERILATOR_ROOT=$INSTALL_DIR
     PATH=$PATH:$VERILATOR_ROOT/bin:$TRAVIS_BUILD_DIR/utils/bin
     SBT_ARGS="-Dsbt.log.noformat=true"
+
+before_script:
+  - OLDEST_SHARED=`git log --format=%H --no-merges $TRAVIS_COMMIT_RANGE | tail -n1`
+  - OLDEST_COMMIT=`git log --format=%H | tail -n1`
+  - if [ $OLDEST_SHARED == $OLDEST_COMMIT ]; then git fetch --unshallow; fi
 
 stages:
   - prepare

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
     SBT_ARGS="-Dsbt.log.noformat=true"
 
 before_script:
-  - OLDEST_SHARED=`git log --format=%H --no-merges $TRAVIS_COMMIT_RANGE | tail -n1`
+  - OLDEST_SHARED=`git log --format=%H $TRAVIS_COMMIT_RANGE | tail -n1`
   - OLDEST_COMMIT=`git log --format=%H | tail -n1`
   - if [ $OLDEST_SHARED == $OLDEST_COMMIT ]; then git fetch --unshallow; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
     $INSTALL_DIR
 
 git:
-  depth: 10
+  depth: 128
 
 env:
   global:


### PR DESCRIPTION
Fixes #923 

This adds a `before_script` block to the Travis configuration that fixes problems with use of `$TRAVIS_COMMIT_RANGE`. This looks at the oldest commit contained in this range. If this is the oldest commit in the repository then this indicates that a shallow clone was not able to fully capture where the base branch and the PR merge. This will then unshallow the repo before running any scripts.

Requested merge strategy: squash.

And note that this is cherry-picked onto the protobuf commit to exercise this code path in Travis.

Old, cherry-picked build: https://travis-ci.org/freechipsproject/firrtl/builds/448632802?utm_source=github_status&utm_medium=notification
Rebased build: https://travis-ci.org/freechipsproject/firrtl/builds/448639357?utm_source=github_status&utm_medium=notification