### PR TITLE
Fix bug in TargetDirAnnotation compatibility

### DIFF
--- a/src/main/scala/firrtl/package.scala
+++ b/src/main/scala/firrtl/package.scala
@@ -1,3 +1,4 @@
+// See LICENSE for license details.
 
 import firrtl.AnnotationSeq
 import firrtl.annotations.Annotation
@@ -7,6 +8,9 @@ package object firrtl {
   implicit def annoSeqToSeq(as: AnnotationSeq): Seq[Annotation] = as.underlying
 
   /* Options as annotations compatibility items */
+  @deprecated("Use firrtl.stage.TargetDirAnnotation", "3.2")
+  type TargetDirAnnotation = firrtl.stage.TargetDirAnnotation
+
   @deprecated("Use firrtl.stage.TargetDirAnnotation", "3.2")
   val TargetDirAnnotation = firrtl.stage.TargetDirAnnotation
 }


### PR DESCRIPTION
TargetDirAnnotation was moved from firrtl to firrtl.stage. However, this
is only aliased as a val in the firrtl package object. This also needs to
be type aliased for unapply to work (apparently). This fixes a bug I ran
across in the visualizer.