### PR TITLE
Make return types of utility functions more specific

### DIFF
--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -419,7 +419,7 @@ object Utils extends LazyLogging {
     }
   }
 
-  def module_type(m: DefModule): Type = BundleType(m.ports map {
+  def module_type(m: DefModule): BundleType = BundleType(m.ports map {
     case Port(_, name, dir, tpe) => Field(name, to_flip(dir), tpe)
   })
   def sub_type(v: Type): Type = v match {

--- a/src/main/scala/firrtl/passes/memlib/MemUtils.scala
+++ b/src/main/scala/firrtl/passes/memlib/MemUtils.scala
@@ -63,7 +63,7 @@ object MemPortUtils {
   )
 
   // Todo: merge it with memToBundle
-  def memType(mem: DefMemory): Type = {
+  def memType(mem: DefMemory): BundleType = {
     val rType = BundleType(defaultPortSeq(mem) :+
       Field("data", Flip, mem.dataType))
     val wType = BundleType(defaultPortSeq(mem) ++ Seq(


### PR DESCRIPTION
This "covariance" makes utility functions that always return `BundleType` a little bit easier to use, since it eliminates some pattern matching.