### PR TITLE
Add "none" compiler

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -112,6 +112,7 @@ sealed abstract class FirrtlEmitter(form: CircuitForm) extends Transform with Em
 }
 
 // ***** Start actual Emitters *****
+class ChirrtlEmitter extends FirrtlEmitter(ChirrtlForm)
 class HighFirrtlEmitter extends FirrtlEmitter(HighForm)
 class MiddleFirrtlEmitter extends FirrtlEmitter(MidForm)
 class LowFirrtlEmitter extends FirrtlEmitter(LowForm)

--- a/src/main/scala/firrtl/ExecutionOptionsManager.scala
+++ b/src/main/scala/firrtl/ExecutionOptionsManager.scala
@@ -202,6 +202,7 @@ extends ComposableOptions {
 
   def compiler: Compiler = {
     compilerName match {
+      case "none"      => new NoneCompiler()
       case "high"      => new HighFirrtlCompiler()
       case "low"       => new LowFirrtlCompiler()
       case "middle"    => new MiddleFirrtlCompiler()
@@ -215,8 +216,9 @@ extends ComposableOptions {
       case "verilog"   => "v"
       case "sverilog"  => "sv"
       case "low"       => "lo.fir"
-      case "high"      => "hi.fir"
       case "middle"    => "mid.fir"
+      case "high"      => "hi.fir"
+      case "none"      => "fir"
       case _ =>
         throw new Exception(s"Illegal compiler name $compilerName")
     }
@@ -260,6 +262,7 @@ extends ComposableOptions {
   def getEmitterAnnos(optionsManager: ExecutionOptionsManager): Seq[Annotation] = {
     // TODO should this be a public function?
     val emitter = compilerName match {
+      case "none" => classOf[HighFirrtlEmitter]
       case "high" => classOf[HighFirrtlEmitter]
       case "middle" => classOf[MiddleFirrtlEmitter]
       case "low" => classOf[LowFirrtlEmitter]
@@ -341,12 +344,12 @@ trait HasFirrtlOptions {
 
   parser.opt[String]("compiler")
     .abbr("X")
-    .valueName ("<high|middle|low|verilog|sverilog>")
+    .valueName ("<high|middle|low|verilog|sverilog|none>")
     .foreach { x =>
       firrtlOptions = firrtlOptions.copy(compilerName = x)
     }
     .validate { x =>
-      if (Array("high", "middle", "low", "verilog", "sverilog").contains(x.toLowerCase)) parser.success
+      if (Array("high", "middle", "low", "verilog", "sverilog", "none").contains(x.toLowerCase)) parser.success
       else parser.failure(s"$x not a legal compiler")
     }.text {
       s"compiler to use, default is ${firrtlOptions.compilerName}"

--- a/src/main/scala/firrtl/ExecutionOptionsManager.scala
+++ b/src/main/scala/firrtl/ExecutionOptionsManager.scala
@@ -262,7 +262,7 @@ extends ComposableOptions {
   def getEmitterAnnos(optionsManager: ExecutionOptionsManager): Seq[Annotation] = {
     // TODO should this be a public function?
     val emitter = compilerName match {
-      case "none" => classOf[HighFirrtlEmitter]
+      case "none" => classOf[ChirrtlEmitter]
       case "high" => classOf[HighFirrtlEmitter]
       case "middle" => classOf[MiddleFirrtlEmitter]
       case "low" => classOf[LowFirrtlEmitter]

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -131,7 +131,7 @@ import firrtl.transforms.BlackBoxSourceHelper
   * Primarily useful for changing between .fir and .pb serialized formats
   */
 class NoneCompiler extends Compiler {
-  def emitter = new HighFirrtlEmitter
+  def emitter = new ChirrtlEmitter
   def transforms: Seq[Transform] = Seq.empty
 }
 

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -126,6 +126,15 @@ class MinimumLowFirrtlOptimization extends CoreTransform {
 import CompilerUtils.getLoweringTransforms
 import firrtl.transforms.BlackBoxSourceHelper
 
+/** Emits input circuit with no changes
+  *
+  * Primarily useful for changing between .fir and .pb serialized formats
+  */
+class NoneCompiler extends Compiler {
+  def emitter = new HighFirrtlEmitter
+  def transforms: Seq[Transform] = Seq.empty
+}
+
 /** Emits input circuit
   * Will replace Chirrtl constructs with Firrtl
   */

--- a/src/test/scala/firrtlTests/DriverSpec.scala
+++ b/src/test/scala/firrtlTests/DriverSpec.scala
@@ -364,6 +364,7 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
 
     "To a single file with file extension depending on the compiler by default" in {
       Seq(
+        "none" -> "./Top.fir",
         "low" -> "./Top.lo.fir",
         "high" -> "./Top.hi.fir",
         "middle" -> "./Top.mid.fir",
@@ -383,6 +384,7 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
     }
     "To a single file per module if OneFilePerModule is specified" in {
       Seq(
+        "none" -> Seq("./Top.fir", "./Child.fir"),
         "low" -> Seq("./Top.lo.fir", "./Child.lo.fir"),
         "high" -> Seq("./Top.hi.fir", "./Child.hi.fir"),
         "middle" -> Seq("./Top.mid.fir", "./Child.mid.fir"),


### PR DESCRIPTION
Where the high form compiler removes Chirrtl (and runs some checks),
this compiler does nothing but read in the circuit and then emit it

Also looking for a better name if anyone has suggestions. I thought about making it "Chirrtl" but since the plan is to delete Chirrtl I'm not sure it's worth introducing more things to ultimately change