### PR TITLE
Replace Mappers with Foreachers in several passes

### DIFF
--- a/src/main/scala/firrtl/Namespace.scala
+++ b/src/main/scala/firrtl/Namespace.scala
@@ -5,7 +5,6 @@ package firrtl
 import scala.collection.mutable
 import scala.collection.mutable.HashSet
 import firrtl.ir._
-import Mappers._
 
 class Namespace private {
   private val tempNamePrefix: String = "_GEN"

--- a/src/main/scala/firrtl/analyses/InstanceGraph.scala
+++ b/src/main/scala/firrtl/analyses/InstanceGraph.scala
@@ -7,7 +7,7 @@ import firrtl._
 import firrtl.ir._
 import firrtl.graph._
 import firrtl.Utils._
-import firrtl.Mappers._
+import firrtl.traversals.Foreachers._
 import firrtl.annotations.TargetToken.{Instance, OfModule}
 
 
@@ -24,7 +24,7 @@ class InstanceGraph(c: Circuit) {
     new mutable.LinkedHashMap[String, mutable.LinkedHashSet[WDefInstance]]
   for (m <- c.modules) {
     childInstances(m.name) = new mutable.LinkedHashSet[WDefInstance]
-    m map InstanceGraph.collectInstances(childInstances(m.name))
+    m.foreach(InstanceGraph.collectInstances(childInstances(m.name)))
     instantiated ++= childInstances(m.name).map(i => i.module)
   }
 
@@ -117,12 +117,10 @@ object InstanceGraph {
     * @return
     */
   def collectInstances(insts: mutable.Set[WDefInstance])
-                      (s: Statement): Statement = s match {
-    case i: WDefInstance =>
-      insts += i
-      i
+                      (s: Statement): Unit = s match {
+    case i: WDefInstance => insts += i
     case i: DefInstance => throwInternalError("Expecting WDefInstance, found a DefInstance!")
     case i: WDefInstanceConnector => throwInternalError("Expecting WDefInstance, found a WDefInstanceConnector!")
-    case _ => s map collectInstances(insts)
+    case _ => s.foreach(collectInstances(insts))
   }
 }

--- a/src/main/scala/firrtl/passes/CheckChirrtl.scala
+++ b/src/main/scala/firrtl/passes/CheckChirrtl.scala
@@ -5,7 +5,7 @@ package firrtl.passes
 import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
-import firrtl.Mappers._
+import firrtl.traversals.Foreachers._
 
 object CheckChirrtl extends Pass {
   type NameSet = collection.mutable.HashSet[String]
@@ -40,54 +40,51 @@ object CheckChirrtl extends Pass {
         errors append new InvalidLOCException(info, mname)
       case _ => // Do Nothing
     }
-    def checkChirrtlW(info: Info, mname: String)(w: Width): Width = w match {
-      case w: IntWidth if (w.width < BigInt(0)) =>
-        errors.append(new NegWidthException(info, mname))
-        w
-      case _ => w
+    def checkChirrtlW(info: Info, mname: String)(w: Width): Unit = w match {
+      case w: IntWidth if (w.width < BigInt(0)) => errors.append(new NegWidthException(info, mname))
+      case _ =>
     }
 
-    def checkChirrtlT(info: Info, mname: String)(t: Type): Type =
-      t map checkChirrtlT(info, mname) match {
+    def checkChirrtlT(info: Info, mname: String)(t: Type): Unit = {
+      t.foreach(checkChirrtlT(info, mname))
+      t match {
         case t: VectorType if t.size < 0 =>
           errors append new NegVecSizeException(info, mname)
-          t map checkChirrtlW(info, mname)
+          t.foreach(checkChirrtlW(info, mname))
         //case FixedType(width, point) => FixedType(checkChirrtlW(width), point)
-        case _ => t map checkChirrtlW(info, mname)
+        case _ => t.foreach(checkChirrtlW(info, mname))
       }
-
-    def validSubexp(info: Info, mname: String)(e: Expression): Expression = {
-      e match {
-        case _: Reference | _: SubField | _: SubIndex | _: SubAccess |
-             _: Mux | _: ValidIf => // No error
-        case _ => errors append new InvalidAccessException(info, mname)
-      }
-      e
     }
 
-    def checkChirrtlE(info: Info, mname: String, names: NameSet)(e: Expression): Expression = {
+    def validSubexp(info: Info, mname: String)(e: Expression): Unit = e match {
+      case _: Reference | _: SubField | _: SubIndex | _: SubAccess |
+           _: Mux | _: ValidIf => // No error
+      case _ => errors append new InvalidAccessException(info, mname)
+    }
+
+    def checkChirrtlE(info: Info, mname: String, names: NameSet)(e: Expression): Unit = {
       e match {
         case _: DoPrim | _:Mux | _:ValidIf | _: UIntLiteral =>
         case ex: Reference if !names(ex.name) =>
           errors append new UndeclaredReferenceException(info, mname, ex.name)
         case ex: SubAccess => validSubexp(info, mname)(ex.expr)
-        case ex => ex map validSubexp(info, mname)
+        case ex => ex.foreach(validSubexp(info, mname))
       }
-      (e map checkChirrtlW(info, mname)
-         map checkChirrtlT(info, mname)
-         map checkChirrtlE(info, mname, names))
+      e.foreach(checkChirrtlW(info, mname))
+      e.foreach(checkChirrtlT(info, mname))
+      e.foreach(checkChirrtlE(info, mname, names))
     }
 
-    def checkName(info: Info, mname: String, names: NameSet)(name: String): String = {
+    def checkName(info: Info, mname: String, names: NameSet)(name: String): Unit = {
       if (names(name))
         errors append new NotUniqueException(info, mname, name)
       names += name
-      name 
     }
 
-    def checkChirrtlS(minfo: Info, mname: String, names: NameSet)(s: Statement): Statement = {
+    def checkChirrtlS(minfo: Info, mname: String, names: NameSet)(s: Statement): Unit = {
       val info = get_info(s) match {case NoInfo => minfo case x => x}
-      s map checkName(info, mname, names) match {
+      s.foreach(checkName(info, mname, names))
+      s match {
         case sx: DefMemory =>
           if (hasFlip(sx.dataType)) errors append new MemWithFlipException(info, mname, sx.name)
           if (sx.depth <= 0) errors append new NegMemSizeException(info, mname)
@@ -97,27 +94,26 @@ object CheckChirrtl extends Pass {
         case sx: PartialConnect => checkValidLoc(info, mname, sx.loc)
         case _ => // Do Nothing
       }
-      (s map checkChirrtlT(info, mname)
-         map checkChirrtlE(info, mname, names)
-         map checkChirrtlS(info, mname, names))
+      s.foreach(checkChirrtlT(info, mname))
+      s.foreach(checkChirrtlE(info, mname, names))
+      s.foreach(checkChirrtlS(info, mname, names))
     }
 
-    def checkChirrtlP(mname: String, names: NameSet)(p: Port): Port = {
+    def checkChirrtlP(mname: String, names: NameSet)(p: Port): Unit = {
       if (names(p.name))
         errors append new NotUniqueException(NoInfo, mname, p.name)
       names += p.name
-      (p.tpe map checkChirrtlT(p.info, mname)
-             map checkChirrtlW(p.info, mname))
-      p
+      p.tpe.foreach(checkChirrtlT(p.info, mname))
+      p.tpe.foreach(checkChirrtlW(p.info, mname))
     }
 
     def checkChirrtlM(m: DefModule) {
       val names = new NameSet
-      (m map checkChirrtlP(m.name, names)
-         map checkChirrtlS(m.info, m.name, names))
+      m.foreach(checkChirrtlP(m.name, names))
+      m.foreach(checkChirrtlS(m.info, m.name, names))
     }
     
-    c.modules foreach checkChirrtlM
+    c.modules.foreach(checkChirrtlM)
     c.modules count (_.name == c.main) match {
       case 1 =>
       case _ => errors append new NoTopModuleException(c.info, c.main)

--- a/src/main/scala/firrtl/passes/Checks.scala
+++ b/src/main/scala/firrtl/passes/Checks.scala
@@ -6,7 +6,6 @@ import firrtl._
 import firrtl.ir._
 import firrtl.PrimOps._
 import firrtl.Utils._
-import firrtl.Mappers._
 import firrtl.traversals.Foreachers._
 import firrtl.WrappedType._
 
@@ -539,7 +538,7 @@ object CheckGenders extends Pass {
           check_gender(info, mname, genders, FEMALE)(s.loc)
           check_gender(info, mname, genders, MALE)(s.expr)
         case (s: Print) =>
-          s.args map check_gender(info, mname, genders, MALE)
+          s.args foreach check_gender(info, mname, genders, MALE)
           check_gender(info, mname, genders, MALE)(s.en)
           check_gender(info, mname, genders, MALE)(s.clk)
         case (s: PartialConnect) =>

--- a/src/main/scala/firrtl/passes/clocklist/ClockList.scala
+++ b/src/main/scala/firrtl/passes/clocklist/ClockList.scala
@@ -14,7 +14,6 @@ import ClockListUtils._
 import Utils._
 import memlib.AnalysisUtils._
 import memlib._
-import Mappers._
 
 /** Starting with a top module, determine the clock origins of each child instance.
  *  Write the result to writer.

--- a/src/main/scala/firrtl/passes/clocklist/ClockListTransform.scala
+++ b/src/main/scala/firrtl/passes/clocklist/ClockListTransform.scala
@@ -13,7 +13,6 @@ import ClockListUtils._
 import Utils._
 import memlib.AnalysisUtils._
 import memlib._
-import Mappers._
 import firrtl.options.RegisteredTransform
 import scopt.OptionParser
 import firrtl.stage.RunFirrtlTransformAnnotation

--- a/src/main/scala/firrtl/passes/clocklist/ClockListUtils.scala
+++ b/src/main/scala/firrtl/passes/clocklist/ClockListUtils.scala
@@ -13,7 +13,6 @@ import ClockListUtils._
 import Utils._
 import memlib.AnalysisUtils._
 import memlib._
-import Mappers._
 
 object ClockListUtils {
   /** Returns a list of clock outputs from instances of external modules

--- a/src/main/scala/firrtl/passes/wiring/WiringUtils.scala
+++ b/src/main/scala/firrtl/passes/wiring/WiringUtils.scala
@@ -7,6 +7,7 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
+import firrtl.traversals.Foreachers._
 import scala.collection.mutable
 import firrtl.annotations._
 import firrtl.annotations.AnnotationUtils._
@@ -84,18 +85,16 @@ object WiringUtils {
   @deprecated("Use DiGraph/InstanceGraph", "1.1.1")
   def getChildrenMap(c: Circuit): ChildrenMap = {
     val childrenMap = new ChildrenMap()
-    def getChildren(mname: String)(s: Statement): Statement = s match {
+    def getChildren(mname: String)(s: Statement): Unit = s match {
       case s: WDefInstance =>
         childrenMap(mname) = childrenMap(mname) :+ (s.name, s.module)
-        s
       case s: DefInstance =>
         childrenMap(mname) = childrenMap(mname) :+ (s.name, s.module)
-        s
-      case s => s map getChildren(mname)
+      case s => s.foreach(getChildren(mname))
     }
     c.modules.foreach{ m =>
       childrenMap(m.name) = Nil
-      m map getChildren(m.name)
+      m.foreach(getChildren(m.name))
     }
     childrenMap
   }

--- a/src/test/scala/firrtlTests/CInferMDirSpec.scala
+++ b/src/test/scala/firrtlTests/CInferMDirSpec.scala
@@ -6,7 +6,6 @@ import firrtl._
 import firrtl.ir._
 import firrtl.passes._
 import firrtl.transforms._
-import firrtl.Mappers._
 import annotations._
 
 class CInferMDir extends LowTransformSpec {

--- a/src/test/scala/firrtlTests/CheckCombLoopsSpec.scala
+++ b/src/test/scala/firrtlTests/CheckCombLoopsSpec.scala
@@ -6,7 +6,6 @@ import firrtl._
 import firrtl.ir._
 import firrtl.passes._
 import firrtl.transforms._
-import firrtl.Mappers._
 import annotations._
 import java.io.File
 import java.nio.file.Paths

--- a/src/test/scala/firrtlTests/ProtoBufSpec.scala
+++ b/src/test/scala/firrtlTests/ProtoBufSpec.scala
@@ -7,7 +7,6 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import firrtl.FirrtlProtos.Firrtl
 import firrtl._
 import firrtl.ir._
-import firrtl.Mappers._
 
 class ProtoBufSpec extends FirrtlFlatSpec {
 


### PR DESCRIPTION
Drops ~40 LoC and helps with clarity in some cases by eliminating spurious return value expressions.