### PR TITLE
Fix bug in dedup where lots of annotations could prevent dedup

### DIFF
--- a/src/main/scala/firrtl/transforms/Dedup.scala
+++ b/src/main/scala/firrtl/transforms/Dedup.scala
@@ -335,7 +335,7 @@ object DedupModules {
         // Build tag
         val builder = new mutable.ArrayBuffer[Any]()
         agnosticModule.ports.foreach { builder ++= _.serialize }
-        builder ++= agnosticAnnos
+        builder += agnosticAnnos
 
         agnosticModule match {
           case Module(i, n, ps, b) => builder ++= fastSerializedHash(b).toString()//.serialize

--- a/src/test/scala/firrtlTests/transforms/DedupTests.scala
+++ b/src/test/scala/firrtlTests/transforms/DedupTests.scala
@@ -376,6 +376,34 @@ class DedupModuleTests extends HighTransformSpec {
       """.stripMargin
     execute(input, check, Seq(dontTouch("A.b"), dontTouch("A_.b")))
   }
+  "The module A and A_" should "be deduped with same annotation targets when there are a lot" in {
+    val input =
+      """circuit Top :
+        |  module Top :
+        |    inst a1 of A
+        |    inst a2 of A_
+        |  module A :
+        |    output x: UInt<1>[100]
+        |    wire b: UInt<1>[100]
+        |    x <= b
+        |  module A_ :
+        |    output x: UInt<1>[100]
+        |    wire b: UInt<1>[100]
+        |    x <= b
+      """.stripMargin
+    val check =
+      """circuit Top :
+        |  module Top :
+        |    inst a1 of A
+        |    inst a2 of A
+        |  module A :
+        |    output x: UInt<1>[100]
+        |    wire b: UInt<1>[100]
+        |    x <= b
+      """.stripMargin
+    val annos = (0 until 100).flatMap(i => Seq(dontTouch(s"A.b[$i]"), dontTouch(s"A_.b[$i]")))
+    execute(input, check, annos)
+  }
   "The module A and A_" should "not be deduped with same annotations with same multi-targets, but which have different root modules" in {
     val input =
       """circuit Top :


### PR DESCRIPTION
Iterating on a HashSet could cause identical modules (including
annotations) to not dedup

Changing builder (which is an `ArrayBuffer[Any]`) to just include the HashSet as a member (thus letting it call it's own `.hashCode`) rather than iterating on it.

This is a hard thing to test for, so I wrote a test that just has lots of annotations and failed (at least for me) without this change.

@ucbjrl I think this should be included in 1.1.4 if possible