### PR TITLE
Small convenience tweaks to IR/WIR APIs

### DIFF
--- a/src/main/scala/firrtl/WIR.scala
+++ b/src/main/scala/firrtl/WIR.scala
@@ -40,6 +40,11 @@ object WRef {
   def apply(reg: DefRegister): WRef = new WRef(reg.name, reg.tpe, RegKind, UNKNOWNGENDER)
   /** Creates a WRef from a Node */
   def apply(node: DefNode): WRef = new WRef(node.name, node.value.tpe, NodeKind, MALE)
+  /** Creates a WRef from a Port */
+  def apply(port: Port): WRef = new WRef(port.name, port.tpe, PortKind, UNKNOWNGENDER)
+  /** Creates a WRef from a WDefInstance */
+  def apply(wi: WDefInstance): WRef = new WRef(wi.name, wi.tpe, InstanceKind, UNKNOWNGENDER)
+  /** Creates a WRef from an arbitrary string name */
   def apply(n: String, t: Type = UnknownType, k: Kind = ExpKind): WRef = new WRef(n, t, k, UNKNOWNGENDER)
 }
 case class WSubField(expr: Expression, name: String, tpe: Type, gender: Gender) extends Expression {

--- a/src/main/scala/firrtl/ir/IR.scala
+++ b/src/main/scala/firrtl/ir/IR.scala
@@ -607,7 +607,7 @@ case object UnknownType extends Type {
 }
 
 /** [[Port]] Direction */
-abstract class Direction extends FirrtlNode
+sealed abstract class Direction extends FirrtlNode
 case object Input extends Direction {
   def serialize: String = "input"
 }


### PR DESCRIPTION
This adds some `WRef` factories and seals `Direction`. Given that the assumption is encoded many places, it's probably a good idea to make that explicit unless future support is added.