### PR TITLE
Remove side effect from DiGraph sum

### DIFF
--- a/src/main/scala/firrtl/graph/DiGraph.scala
+++ b/src/main/scala/firrtl/graph/DiGraph.scala
@@ -349,8 +349,8 @@ class DiGraph[T] private[graph] (private[graph] val edges: LinkedHashMap[T, Link
     * @return a DiGraph[T] containing all vertices and edges of each graph
     */
   def +(that: DiGraph[T]): DiGraph[T] = {
-    val eprime = edges.clone
-    that.edges.map({ case (k, v) => eprime.getOrElseUpdate(k, new LinkedHashSet[T]) ++= v })
+    val eprime = edges.map({ case (k, v) => (k, v.clone) })
+    that.edges.foreach({ case (k, v) => eprime.getOrElseUpdate(k, new LinkedHashSet[T]) ++= v })
     new DiGraph(eprime)
   }
 }


### PR DESCRIPTION
This fixes a bug in the `DiGraph` summation/`+` method (added in #744).

Previously, computing the summation of `this` graph and `that` graph would mutate the `this` graph because the edges were not being deeply cloned. This fixes that by explicitly cloning the internal `LinkedHashSet`. 

Consider the following test case with `println`s added:

```scala
  it should "be idempotent" in {
    val first = acyclicGraph.subgraph(Set("a", "b", "c"))
    val second = acyclicGraph.subgraph(Set("b", "c", "d", "e"))

    println(first.getEdgeMap) // Added a println before the addition
    (first + second + second + second).getEdgeMap should equal (acyclicGraph.getEdgeMap)
    println(first.getEdgeMap) // Added a println after the addition
  }
```

Old behavior:
```
Map(a -> Set(b, c), b -> Set(), c -> Set())
Map(a -> Set(b, c), b -> Set(d), c -> Set(d))
```

New behavior:
```
Map(a -> Set(b, c), b -> Set(), c -> Set())
Map(a -> Set(b, c), b -> Set(), c -> Set())
```