### PR TITLE
[Top Wiring] Expand top wiring to work on aggregates

### DIFF
--- a/src/main/scala/firrtl/transforms/TopWiring.scala
+++ b/src/main/scala/firrtl/transforms/TopWiring.scala
@@ -36,8 +36,8 @@ case class TopWiringAnnotation(target: ComponentName, prefix: String) extends
   * @note This *does* work for deduped modules
   */
 class TopWiringTransform extends Transform {
-  def inputForm: CircuitForm = LowForm
-  def outputForm: CircuitForm = LowForm
+  def inputForm: CircuitForm = MidForm
+  def outputForm: CircuitForm = MidForm
 
   type InstPath = Seq[String]
 


### PR DESCRIPTION
There was fundamentally no reason top wiring could not act on aggregates. I changed the form to reflect this, and added a couple tests to check cases involving aggregates. 

