### PR TITLE
Fix NoneCompiler outputForm

### DIFF
--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -373,6 +373,10 @@ trait Compiler extends LazyLogging {
     */
   def transforms: Seq[Transform]
 
+  require(transforms.size >= 1,
+          s"Compiler transforms for '${this.getClass.getName}' must have at least ONE Transform! " +
+            "Use IdentityTransform if you need an identity/no-op transform.")
+
   // Similar to (input|output)Form on [[Transform]] but derived from this Compiler's transforms
   def inputForm: CircuitForm = transforms.head.inputForm
   def outputForm: CircuitForm = transforms.last.outputForm

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -2,6 +2,8 @@
 
 package firrtl
 
+import firrtl.transforms.IdentityTransform
+
 sealed abstract class CoreTransform extends SeqTransform
 
 /** This transforms "CHIRRTL", the chisel3 IR, to "Firrtl". Note the resulting
@@ -132,7 +134,7 @@ import firrtl.transforms.BlackBoxSourceHelper
   */
 class NoneCompiler extends Compiler {
   def emitter = new ChirrtlEmitter
-  def transforms: Seq[Transform] = Seq.empty
+  def transforms: Seq[Transform] = Seq(new IdentityTransform(ChirrtlForm))
 }
 
 /** Emits input circuit

--- a/src/main/scala/firrtl/transforms/IdentityTransform.scala
+++ b/src/main/scala/firrtl/transforms/IdentityTransform.scala
@@ -1,0 +1,17 @@
+// See LICENSE for license details.
+
+package firrtl.transforms
+
+import firrtl.{CircuitForm, CircuitState, Transform}
+
+/** Transform that applies an identity function. This returns an unmodified [[CircuitState]].
+  * @param form the input and output [[CircuitForm]]
+  */
+class IdentityTransform(form: CircuitForm) extends Transform {
+
+  final override def inputForm: CircuitForm = form
+  final override def outputForm: CircuitForm = form
+
+  final def execute(state: CircuitState): CircuitState = state
+
+}


### PR DESCRIPTION
Every `Compiler` has an implicit assumption that it's transform sequence is non-empty as `inputForm` and `outputForm` are defined as follows:

```scala
val transforms: Seq[Transform]
val inputForm: CircuitForm = transforms.head.inputForm
val outputForm: CircuitForm = transforms.last.outputForm
```

This causes problems for `NoneCompiler` as this is an empty transform sequence. This PR fixes this in three ways:

1. An `IdentityTransform` is added that applies an identity function to some `CircuitState`
2. The `IdentityTransform` is used as the lone transform in the `NoneCompiler`
3. A run time requirement is added that checks to see if a `Compiler` was constructed with an empty sequence of transforms.

I'd like to be able to do (3)'s check at compile time, but I think that would require dependent types...