### PR TITLE
Remove GhpagesPlugin.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,10 +4,6 @@
 
 enablePlugins(SiteScaladocPlugin)
 
-enablePlugins(GhpagesPlugin)
-
-git.remoteRepo := "git@github.com:freechipsproject/firrtl.git"
-
 // Firrtl code
 
 organization := "edu.berkeley.cs"


### PR DESCRIPTION
I don't know if this GhpagesPlugin is important to anyone, but I'm proposing removing it from firrtl and Chisel3 to eliminate some friction it is causing in another project.

If this plugin is in fact useful to anyway, I would like to make it configurable so that it may be disabled where it is not needed.