### PR TITLE
Performance fix of Uniquify for deep bundles

### DIFF
--- a/src/main/scala/firrtl/annotations/AnnotationUtils.scala
+++ b/src/main/scala/firrtl/annotations/AnnotationUtils.scala
@@ -51,8 +51,8 @@ object AnnotationUtils {
     case Some(_) =>
       val i = s.indexWhere(c => "[].".contains(c))
       s.slice(0, i) match {
-        case "" => Seq(s(i).toString) ++ tokenize(s.drop(i + 1))
-        case x => Seq(x, s(i).toString) ++ tokenize(s.drop(i + 1))
+        case "" => s(i).toString +: tokenize(s.drop(i + 1))
+        case x => x +: s(i).toString +: tokenize(s.drop(i + 1))
       }
     case None if s == "" => Nil
     case None => Seq(s)

--- a/src/test/scala/firrtlTests/UniquifySpec.scala
+++ b/src/test/scala/firrtlTests/UniquifySpec.scala
@@ -283,4 +283,23 @@ class UniquifySpec extends FirrtlFlatSpec {
 
     executeTest(input, expected)
   }
+
+  it should "quickly rename deep bundles" in {
+    def mkType(i: Int): String = {
+      if(i == 0) "UInt<8>" else s"{x: ${mkType(i - 1)}}"
+    }
+
+    val depth = 500
+
+    val input =
+      s"""circuit Test:
+         |  module Test :
+         |    input in: ${mkType(depth)}
+         |    output out: ${mkType(depth)}
+         |    out <= in
+         |""".stripMargin
+
+    val (ms, _) = Utils.time(compileToVerilog(input))
+    (ms < 8000) shouldBe true
+  }
 }


### PR DESCRIPTION
Includes test case. The basic problem was the original code was recursing in both `recUniquifyNames` and `enumerateNames`. Instead, this commit does both in `recUniquifyNames`, returning both the uniquified type and the recursive partial solution that `enumerateNames` returns.