### PR TITLE
Fix grouping

### DIFF
--- a/src/main/scala/firrtl/transforms/GroupComponents.scala
+++ b/src/main/scala/firrtl/transforms/GroupComponents.scala
@@ -4,7 +4,7 @@ import firrtl._
 import firrtl.Mappers._
 import firrtl.ir._
 import firrtl.annotations.{Annotation, ComponentName}
-import firrtl.passes.{InferTypes, LowerTypes, MemPortUtils}
+import firrtl.passes.{InferTypes, LowerTypes, MemPortUtils, ResolveKinds}
 import firrtl.Utils.kind
 import firrtl.graph.{DiGraph, MutableDiGraph}
 
@@ -62,7 +62,7 @@ class GroupComponents extends firrtl.Transform {
       case other => Seq(other)
     }
     val cs = state.copy(circuit = state.circuit.copy(modules = newModules))
-    val csx = InferTypes.execute(cs)
+    val csx = ResolveKinds.execute(InferTypes.execute(cs))
     csx
   }
 

--- a/src/test/scala/firrtlTests/transforms/GroupComponentsSpec.scala
+++ b/src/test/scala/firrtlTests/transforms/GroupComponentsSpec.scala
@@ -3,6 +3,10 @@ package transforms
 
 import firrtl.annotations.{CircuitName, ComponentName, ModuleName}
 import firrtl.transforms.{GroupAnnotation, GroupComponents}
+import firrtl._
+import firrtl.ir._
+
+import FirrtlCheckers._
 
 class GroupComponentsSpec extends LowTransformSpec {
   def transform = new GroupComponents()
@@ -286,5 +290,37 @@ class GroupComponentsSpec extends LowTransformSpec {
          |    second_0 <= second
       """.stripMargin
     execute(input, check, groups)
+  }
+}
+
+class GroupComponentsIntegrationSpec extends FirrtlFlatSpec {
+  def topComp(name: String): ComponentName = ComponentName(name, ModuleName("Top", CircuitName("Top")))
+  "Grouping" should "properly set kinds" in {
+    val input =
+     """circuit Top :
+        |  module Top :
+        |    input clk: Clock
+        |    input data: UInt<16>
+        |    output out: UInt<16>
+        |    reg r: UInt<16>, clk
+        |    r <= data
+        |    out <= r
+      """.stripMargin
+    val groups = Seq(
+      GroupAnnotation(Seq(topComp("r")), "MyModule", "inst", Some("_OUT"), Some("_IN"))
+    )
+    val result = (new VerilogCompiler).compileAndEmit(
+      CircuitState(parse(input), ChirrtlForm, groups),
+      Seq(new GroupComponents)
+    )
+    result should containTree {
+      case Connect(_, WSubField(WRef("inst",_, InstanceKind,_), "data_IN", _,_), WRef("data",_,_,_)) => true
+    }
+    result should containTree {
+      case Connect(_, WSubField(WRef("inst",_, InstanceKind,_), "clk_IN", _,_), WRef("clk",_,_,_)) => true
+    }
+    result should containTree {
+      case Connect(_, WRef("out",_,_,_), WSubField(WRef("inst",_, InstanceKind,_), "r_OUT", _,_)) => true
+    }
   }
 }


### PR DESCRIPTION
This fixes 2 bugs in GroupComponents, from the commit messages:


1. Make GroupComponents run ResolveKinds

    This fixes an issue where expressions created by GroupComponents would
be improperly lowered because they were not marked as references to
instance ports.

1. Fix GroupComponents to work with unused components

    Previously, components that did not affect the output would cause
exceptions because they were missing from the label2group Map. This
commit treats them as "reachable" by the ports so they are included in
the default "ungrouped" group.