### PR TITLE
Avoid enforcing time constrains during coverage tests.

### DIFF
--- a/src/main/scala/firrtl/util/ClassUtils.scala
+++ b/src/main/scala/firrtl/util/ClassUtils.scala
@@ -1,0 +1,19 @@
+package firrtl.util
+
+object ClassUtils {
+  /** Determine if a named class is loaded.
+    *
+    * @param name - name of the class: "foo.bar" or "org.foo.bar"
+    * @return true if the class has been loaded (is accessible), false otherwise.
+    */
+  def isClassLoaded(name: String): Boolean = {
+    val found = try {
+      Class.forName(name, false, getClass.getClassLoader) != null
+    } catch {
+      case e: ClassNotFoundException => false
+      case x: Throwable => throw x
+    }
+//    println(s"isClassLoaded: %s $name".format(if (found) "found" else "didn't find"))
+    found
+  }
+}

--- a/src/main/scala/firrtl/util/TestOptions.scala
+++ b/src/main/scala/firrtl/util/TestOptions.scala
@@ -1,0 +1,13 @@
+package firrtl.util
+
+import ClassUtils.isClassLoaded
+
+object TestOptions {
+  // Our timing is inaccurate if we're running tests under coverage.
+  // If any of the classes known to be associated with evaluating coverage are loaded,
+  //  assume we're running tests under coverage.
+  // NOTE: We assume we need only ask the class loader that loaded us.
+  // If it was loaded by another class loader (outside of our hierarchy), it wouldn't be available to us.
+  val coverageClasses = List("scoverage.Platform", "com.intellij.rt.coverage.instrumentation.TouchCounter")
+  val accurateTiming = !coverageClasses.exists(isClassLoaded(_))
+}


### PR DESCRIPTION
This fixes issue #988
I tried one alternative to this fix: record the time to do a *no rename* run (`depth = 0`) and check that the time to do the *deep rename* (`depth = 500`) was a reasonable multiple of the *no rename* test. Unfortunately, the discrepancies were all over the map, sometime as much as three orders of magnitude difference.
I decided the current fix was the simplest - don't enforce timing checks if we're doing coverage testing, although determining the latter is brittle.