### PR TITLE
Improve Shl codegen; eliminate Shlw WIR node

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -303,8 +303,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
          case (_: SIntType) => Seq(cast(a0)," >>> ", a1)
          case (_) => Seq(cast(a0), " >> ", a1)
        }
-       case Shlw => Seq(cast(a0), " << ", c0)
-       case Shl => Seq(cast(a0), " << ", c0)
+       case Shl => if (c0 > 0) Seq("{", cast(a0), s", $c0'h0}") else Seq(cast(a0))
        case Shr if c0 >= bitWidth(a0.tpe) =>
          error("Verilog emitter does not support SHIFT_RIGHT >= arg width")
        case Shr => Seq(a0,"[", bitWidth(a0.tpe) - 1, ":", c0, "]")

--- a/src/main/scala/firrtl/WIR.scala
+++ b/src/main/scala/firrtl/WIR.scala
@@ -147,8 +147,6 @@ case object Addw extends PrimOp { override def toString = "addw" }
 case object Subw extends PrimOp { override def toString = "subw" }
 // Resultant width is the same as input argument width
 case object Dshlw extends PrimOp { override def toString = "dshlw" }
-// Resultant width is the same as input argument width
-case object Shlw extends PrimOp { override def toString = "shlw" }
 
 object WrappedExpression {
   def apply(e: Expression) = new WrappedExpression(e)

--- a/src/main/scala/firrtl/passes/PadWidths.scala
+++ b/src/main/scala/firrtl/passes/PadWidths.scala
@@ -44,9 +44,6 @@ object PadWidths extends Pass {
       case Dshl =>
         // special case as args aren't all same width
         ex copy (op = Dshlw, args = Seq(fixup(width(ex.tpe))(ex.args.head), ex.args(1)))
-      case Shl =>
-        // special case as arg should be same width as result
-        ex copy (op = Shlw, args = Seq(fixup(width(ex.tpe))(ex.args.head)))
       case _ => ex
     }
     case ex => ex


### PR DESCRIPTION
If we emit `shl(x, k)` as `{x, k'h0}` instead of `x << k`, then there's no need for Verilog-specific padding in the PadWidths pass.  Avoiding the redundant padding improves compiler/simulator performance and renders the `Shlw` working-IR node unnecessary.