### PR TITLE
Towards RegPreset support: Add locally available annotations and verilog emission customization

### DIFF
--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -72,7 +72,8 @@ class HighFirrtlToMiddleFirrtl extends CoreTransform {
     passes.CheckWidths,
     passes.ConvertFixedToSInt,
     passes.ZeroWidth,
-    passes.InferTypes)
+    passes.InferTypes,
+    new firrtl.transforms.ApplyLocalAnnotations)
 }
 
 /** Expands all aggregate types into many ground-typed components. Must

--- a/src/main/scala/firrtl/annotations/EmissionAnnotations.scala
+++ b/src/main/scala/firrtl/annotations/EmissionAnnotations.scala
@@ -1,0 +1,21 @@
+// See LICENSE for license details.
+
+package firrtl
+package annotations
+
+trait EmissionOptions
+
+trait RegisterEmissionOptions extends EmissionOptions {
+  def useInitAsPreset : Boolean
+  def disableRandomization : Boolean
+}
+
+abstract class LocalAnnotations extends SingleTargetAnnotation[Target]
+
+case class PresetRegAnnotation(
+    target: Target
+) extends LocalAnnotations with RegisterEmissionOptions {
+  def duplicate(n: Target) = this.copy(target = n)
+  def useInitAsPreset = true
+  def disableRandomization = true
+}

--- a/src/main/scala/firrtl/passes/ConvertFixedToSInt.scala
+++ b/src/main/scala/firrtl/passes/ConvertFixedToSInt.scala
@@ -64,10 +64,10 @@ object ConvertFixedToSInt extends Pass {
         }
       }
       def updateStmtType(s: Statement): Statement = s match {
-        case DefRegister(info, name, tpe, clock, reset, init) =>
-          val newType = toSIntType(tpe)
-          types(name) = newType
-          DefRegister(info, name, newType, clock, reset, init) map updateExpType
+        case sx: DefRegister =>
+          val newType = toSIntType(sx.tpe)
+          types(sx.name) = newType
+          sx.copy(tpe = newType) map updateExpType
         case DefWire(info, name, tpe) =>
           val newType = toSIntType(tpe)
           types(name) = newType

--- a/src/main/scala/firrtl/passes/LowerTypes.scala
+++ b/src/main/scala/firrtl/passes/LowerTypes.scala
@@ -182,7 +182,7 @@ object LowerTypes extends Transform {
           val clock = lowerTypesExp(memDataTypeMap, info, mname)(sx.clock)
           val reset = lowerTypesExp(memDataTypeMap, info, mname)(sx.reset)
           Block((es zip names) zip inits map { case ((e, n), i) =>
-            DefRegister(sx.info, n, e.tpe, clock, reset, i)
+            sx.copy(name=n, tpe=e.tpe, clock=clock, reset=reset, init=i)
           })
       }
       // Could instead just save the type of each Module as it gets processed

--- a/src/main/scala/firrtl/passes/Uniquify.scala
+++ b/src/main/scala/firrtl/passes/Uniquify.scala
@@ -282,7 +282,7 @@ object Uniquify extends Transform {
               (Utils.create_exps(sx.name, sx.tpe) zip Utils.create_exps(node.name, newType)) foreach {
                 case (from, to) => renames.rename(from.serialize, to.serialize)
               }
-              DefRegister(sx.info, node.name, newType, sx.clock, sx.reset, sx.init)
+              sx.copy(name = node.name, tpe = newType)
             } else {
               sx
             }

--- a/src/main/scala/firrtl/passes/ZeroWidth.scala
+++ b/src/main/scala/firrtl/passes/ZeroWidth.scala
@@ -127,12 +127,12 @@ object ZeroWidth extends Transform {
         case None => EmptyStmt
         case Some(t) => DefWire(info, name, t)
       }
-    case d @ DefRegister(info, name, tpe, clock, reset, init) =>
+    case d @ DefRegister(info, name, tpe, clock, reset, init, _) =>
       renames.delete(getRemoved(d))
       removeZero(tpe) match {
         case None => EmptyStmt
         case Some(t) =>
-         DefRegister(info, name, t, onExp(clock), onExp(reset), onExp(init))
+          d.copy(tpe = t, clock = onExp(clock), reset = onExp(reset), init = onExp(init))
       }
     case d: DefMemory =>
       renames.delete(getRemoved(d))

--- a/src/main/scala/firrtl/passes/wiring/WiringUtils.scala
+++ b/src/main/scala/firrtl/passes/wiring/WiringUtils.scala
@@ -211,7 +211,7 @@ object WiringUtils {
     val root = getRoot(eComp)
     var tpe: Option[Type] = None
     def getType(s: Statement): Statement = s match {
-      case DefRegister(_, n, t, _, _, _) if n == root =>
+      case DefRegister(_, n, t, _, _, _, _) if n == root =>
         tpe = Some(t)
         s
       case DefWire(_, n, t) if n == root =>

--- a/src/main/scala/firrtl/proto/ToProto.scala
+++ b/src/main/scala/firrtl/proto/ToProto.scala
@@ -206,7 +206,7 @@ object ToProto {
               .setId(name)
               .setType(convert(tpe))
             sb.setWire(wb)
-          case ir.DefRegister(_, name, tpe, clock, reset, init) =>
+          case ir.DefRegister(_, name, tpe, clock, reset, init, _) =>
             val rb = Firrtl.Statement.Register.newBuilder()
               .setId(name)
               .setType(convert(tpe))

--- a/src/main/scala/firrtl/transforms/ApplyLocalAnnotations.scala
+++ b/src/main/scala/firrtl/transforms/ApplyLocalAnnotations.scala
@@ -1,0 +1,69 @@
+// See LICENSE for license details.
+
+package firrtl
+package transforms
+
+import firrtl.ir._
+import firrtl.Mappers._
+import firrtl.annotations._
+
+import scala.collection.mutable
+
+/** Apply Local Annotations to all nodes from the one found in annotations
+  * @note Currently handle only registers
+  * @note This pass must run before LowerTypes and RemoveReset
+  */
+class ApplyLocalAnnotations extends Transform {
+  def inputForm = MidForm
+  def outputForm = MidForm
+
+  /**
+    * run the transform
+    * @param circuit the circuit
+    * @param annotations all the annotations
+    * @return annotated circuit
+    */
+  def run(circuit: Circuit, annotations: AnnotationSeq): Circuit = {
+
+    val groups = annotations
+      .collect{ case m : LocalAnnotations => m }
+      .groupBy(_.target.serialize)
+
+    val modulesByName = circuit.modules.collect { case module: firrtl.ir.Module =>  module.name -> module }.toMap
+
+    /**
+      * walk the module
+      * add the annotation locally
+      *
+      * @param myModule module being searched for annotations
+      */
+    def processModule(myModule: DefModule): DefModule = {
+
+      def processRegister(myRegister: DefRegister): DefRegister = {
+        val fullNodeName = "~" + circuit.main + "|" + myModule.name + ">" + myRegister.name
+        groups.get(fullNodeName) match {
+          case Some(list : List[SingleTargetAnnotation[Target]]) => myRegister.copy(annos = myRegister.annos ::: list)
+          case _ => myRegister
+        }
+      }
+
+      def processStatements(statement: Statement): Statement = {
+        statement match {
+          case r : DefRegister => processRegister(r)
+          case s               => s map processStatements
+        }
+      }
+      myModule match {
+        case module: firrtl.ir.Module =>
+          module.copy(body = processStatements(module.body))
+        case _ => myModule
+      }
+    }
+    circuit map processModule
+  }
+
+  def execute(state: CircuitState): CircuitState = {
+    val circuit = run(state.circuit, state.annotations)
+    state.copy(annotations = state.annotations, circuit = circuit)
+  }
+}

--- a/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
+++ b/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
@@ -99,7 +99,7 @@ class DeadCodeElimination extends Transform with ResolvedAnnotationPaths with Re
     def getDeps(expr: Expression): Seq[LogicNode] = getDepsImpl(mod.name, instMap)(expr)
 
     def onStmt(stmt: Statement): Unit = stmt match {
-      case DefRegister(_, name, _, clock, reset, init) =>
+      case DefRegister(_, name, _, clock, reset, init, _) =>
         val node = LogicNode(mod.name, name)
         depGraph.addVertex(node)
         Seq(clock, reset, init).flatMap(getDeps(_)).foreach(ref => depGraph.addPairWithEdge(node, ref))

--- a/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
+++ b/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
@@ -80,7 +80,7 @@ object FlattenRegUpdate {
     }
 
     def onStmt(stmt: Statement): Statement = stmt.map(onStmt) match {
-      case reg @ DefRegister(_, rname, _,_, resetCond, _) =>
+      case reg @ DefRegister(_, rname, _,_, resetCond, _, _) =>
         assert(resetCond == Utils.zero, "Register reset should have already been made explicit!")
         val ref = WRef(reg)
         val update = Connect(NoInfo, ref, constructRegUpdate(netlist.getOrElse(ref, ref)))

--- a/src/test/scala/firrtlTests/AnnotationTests.scala
+++ b/src/test/scala/firrtlTests/AnnotationTests.scala
@@ -466,7 +466,7 @@ abstract class AnnotationTests extends AnnotationSpec with Matchers {
 }
 
 class LegacyAnnotationTests extends AnnotationTests {
-  def anno(s: String, value: String ="this is a value", mod: String = "Top"): Annotation =
+  def anno(s: String, value: String = "this is a value", mod: String = "Top"): Annotation =
     Annotation(ComponentName(s, ModuleName(mod, CircuitName("Top"))), classOf[Transform], value)
   def manno(mod: String): Annotation =
     Annotation(ModuleName(mod, CircuitName("Top")), classOf[Transform], "some value")

--- a/src/test/scala/firrtlTests/InfoSpec.scala
+++ b/src/test/scala/firrtlTests/InfoSpec.scala
@@ -57,7 +57,7 @@ class InfoSpec extends FirrtlFlatSpec {
       |r <= or(n, r)
       |y <= r""".stripMargin
     )
-    result should containTree { case DefRegister(Info1, "r", _,_,_,_) => true }
+    result should containTree { case DefRegister(Info1, "r", _,_,_,_,_) => true }
     result should containLine (s"reg [7:0] r; //$Info1")
     result should containTree { case DefNode(Info2, "w", _) => true }
     result should containLine (s"wire [7:0] w; //$Info2") // Node "w" declaration in Verilog


### PR DESCRIPTION
### For context see #991

As stated last week during developers' meeting, I rewrote my proposal with
- no impact on the IR
- no chisel compatibility issue

### What I've done
- (chisel, to be commited) created a new Object in chisel called RegPreset which is basically a RegInit annotated
- (chisel, to be commited) created a Chisel annotation 
- created a new kind of firrtl annotation` LocalAnnotations `derived from `SingleTargetAnnotation[Target]`
- added a transform that applies all `LocalAnnotations` to their respective Target
- modified some transforms and passes such as applied `LocalAnnotations` do not get deleted along the way
- modified the verilog emitter

I know I've made a bold move when applying the annotation which does not seem to be the way they are supposed  to work, however I thought it would be a shame to check multiple times each register to get their annotations instead of storing them along once and for all.

With all of this changes (and the chisel below) I've the whole chain working as I would expect: `val my_valid = RegPreset(false.B)` infers a `reg my_valid = 1'h0;`

Please give me your feedback on it :)

### Note
I've not achieved to integrate my chisel lib as a part of the chiselFrontend so here it is:
```scala
package my_working_package

import chisel3._
import chisel3.internal.InstanceId
import chisel3.experimental.{annotate, ChiselAnnotation}

import firrtl.annotations.PresetRegAnnotation

// for implicit 
import chisel3.internal.sourceinfo.SourceInfo
import chisel3.core.CompileOptions


case class PresetRegChiselAnnotation(target: InstanceId)
    extends ChiselAnnotation {
  def toFirrtl = PresetRegAnnotation(target.toNamed)
}

object RegPreset {
  /** @usecase def apply[T <: Data](t: T, preset: T): T
    *   Construct a [[Reg]] from a type template preset to the specified value on FPGA startup (note: does not make sense for ASIC design)
    *   @param t The type template used to construct this [[Reg]]
    *   @param preset The value the [[Reg]] is preset to on FPGA startup
    */
  def apply[T <: Data](t: T, preset: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
  // def apply[T <: Data](t: T, preset: T): T = {
    val reg = RegInit(t, preset)
    val anno = PresetRegChiselAnnotation(reg)
    annotate(anno)
    reg
  }

  /** @usecase def apply[T <: Data](preset: T): T
    *   Construct a [[Reg]] preset to the specified value.
    *   @param preset The value that serves as a type template and preset value
    */
  def apply[T <: Data](preset: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
  // def apply[T <: Data](preset: T): T = {
    val model = chiselTypeOf(preset).asInstanceOf[T]
    RegPreset(model, preset)
  }
}
```