### PR TITLE
Add "mverilog" Compiler Option, MinimumVerilogEmitter

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -882,3 +882,13 @@ class VerilogEmitter extends SeqTransform with Emitter {
     state.copy(annotations = newAnnos ++ state.annotations)
   }
 }
+
+class MinimumVerilogEmitter extends VerilogEmitter with Emitter {
+
+
+  override def transforms = super.transforms.filter{
+    case _: DeadCodeElimination => false
+    case _ => true
+  }
+
+}

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -166,9 +166,9 @@ class VerilogCompiler extends Compiler {
 
 /** Emits Verilog without optimizations */
 class MinimumVerilogCompiler extends Compiler {
-  def emitter = new VerilogEmitter
+  def emitter = new MinimumVerilogEmitter
   def transforms: Seq[Transform] = getLoweringTransforms(ChirrtlForm, LowForm) ++
-    Seq(new MinimumLowFirrtlOptimization, new BlackBoxSourceHelper)
+    Seq(new MinimumLowFirrtlOptimization)
 }
 
 /** Currently just an alias for the [[VerilogCompiler]] */

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -119,6 +119,7 @@ class MinimumLowFirrtlOptimization extends CoreTransform {
   def inputForm = LowForm
   def outputForm = LowForm
   def transforms = Seq(
+    passes.RemoveValidIf,
     passes.Legalize,
     passes.memlib.VerilogMemDelays, // TODO move to Verilog emitter
     passes.SplitExpressions)

--- a/src/main/scala/firrtl/passes/Passes.scala
+++ b/src/main/scala/firrtl/passes/Passes.scala
@@ -183,19 +183,23 @@ object ExpandConnects extends Pass {
 object Legalize extends Pass {
   private def legalizeShiftRight(e: DoPrim): Expression = {
     require(e.op == Shr)
-    val amount = e.consts.head.toInt
-    val width = bitWidth(e.args.head.tpe)
-    lazy val msb = width - 1
-    if (amount >= width) {
-      e.tpe match {
-        case UIntType(_) => zero
-        case SIntType(_) =>
-          val bits = DoPrim(Bits, e.args, Seq(msb, msb), BoolType)
-          DoPrim(AsSInt, Seq(bits), Seq.empty, SIntType(IntWidth(1)))
-        case t => error(s"Unsupported type $t for Primop Shift Right")
-      }
-    } else {
-      e
+    e.args.head match {
+      case _: UIntLiteral | _: SIntLiteral => ConstantPropagation.foldShiftRight(e)
+      case _ =>
+        val amount = e.consts.head.toInt
+        val width = bitWidth(e.args.head.tpe)
+        lazy val msb = width - 1
+        if (amount >= width) {
+          e.tpe match {
+            case UIntType(_) => zero
+            case SIntType(_) =>
+              val bits = DoPrim(Bits, e.args, Seq(msb, msb), BoolType)
+              DoPrim(AsSInt, Seq(bits), Seq.empty, SIntType(IntWidth(1)))
+            case t => error(s"Unsupported type $t for Primop Shift Right")
+          }
+        } else {
+          e
+        }
     }
   }
   private def legalizeBitExtract(expr: DoPrim): Expression = {

--- a/src/test/scala/firrtlTests/CompilerTests.scala
+++ b/src/test/scala/firrtlTests/CompilerTests.scala
@@ -13,6 +13,7 @@ import firrtl.{
   Compiler,
   HighFirrtlCompiler,
   MiddleFirrtlCompiler,
+  MinimumVerilogCompiler,
   LowFirrtlCompiler,
   Parser,
   VerilogCompiler
@@ -152,4 +153,32 @@ class VerilogCompilerSpec extends CompilerSpec with Matchers {
    "A circuit's verilog output" should "match the given string and not have RANDOMIZE if no invalids" in {
       getOutput should be (check)
    }
+}
+
+class MinimumVerilogCompilerSpec extends CompilerSpec with Matchers {
+  val input = """|circuit Top:
+                 |  module Top:
+                 |    output b: UInt<1>[2]
+                 |    node c = UInt<1>("h0")
+                 |    node d = UInt<1>("h0")
+                 |    b[0] <= UInt<1>("h0")
+                 |    b[1] <= c
+                 |""".stripMargin
+  val check = """|module Top(
+                 |  output  b_0,
+                 |  output  b_1
+                 |);
+                 |  wire  c;
+                 |  wire  d;
+                 |  assign c = 1'h0;
+                 |  assign d = 1'h0;
+                 |  assign b_0 = 1'h0;
+                 |  assign b_1 = c;
+                 |endmodule
+                 |""".stripMargin
+  def compiler = new MinimumVerilogCompiler()
+
+  "A circuit's minimum Verilog output" should "not have constants propagated or dead code eliminated" in {
+    getOutput should be (check)
+  }
 }

--- a/src/test/scala/firrtlTests/CompilerTests.scala
+++ b/src/test/scala/firrtlTests/CompilerTests.scala
@@ -159,21 +159,18 @@ class MinimumVerilogCompilerSpec extends CompilerSpec with Matchers {
   val input = """|circuit Top:
                  |  module Top:
                  |    output b: UInt<1>[2]
-                 |    node c = UInt<1>("h0")
-                 |    node d = UInt<1>("h0")
-                 |    b[0] <= UInt<1>("h0")
-                 |    b[1] <= c
+                 |    node c = UInt<1>("h1")
+                 |    b[0] <= c
+                 |    b[1] is invalid
                  |""".stripMargin
   val check = """|module Top(
                  |  output  b_0,
                  |  output  b_1
                  |);
                  |  wire  c;
-                 |  wire  d;
-                 |  assign c = 1'h0;
-                 |  assign d = 1'h0;
-                 |  assign b_0 = 1'h0;
-                 |  assign b_1 = c;
+                 |  assign c = 1'h1;
+                 |  assign b_0 = c;
+                 |  assign b_1 = 1'h0;
                  |endmodule
                  |""".stripMargin
   def compiler = new MinimumVerilogCompiler()

--- a/src/test/scala/firrtlTests/CompilerTests.scala
+++ b/src/test/scala/firrtlTests/CompilerTests.scala
@@ -158,19 +158,25 @@ class VerilogCompilerSpec extends CompilerSpec with Matchers {
 class MinimumVerilogCompilerSpec extends CompilerSpec with Matchers {
   val input = """|circuit Top:
                  |  module Top:
-                 |    output b: UInt<1>[2]
-                 |    node c = UInt<1>("h1")
-                 |    b[0] <= c
-                 |    b[1] is invalid
+                 |    output b: UInt<1>[3]
+                 |    node c = bits(UInt<3>("h7"), 2, 2)
+                 |    node d = shr(UInt<3>("h7"), 2)
+                 |    b[0] is invalid
+                 |    b[1] <= c
+                 |    b[2] <= d
                  |""".stripMargin
   val check = """|module Top(
                  |  output  b_0,
-                 |  output  b_1
+                 |  output  b_1,
+                 |  output  b_2
                  |);
                  |  wire  c;
+                 |  wire  d;
                  |  assign c = 1'h1;
-                 |  assign b_0 = c;
-                 |  assign b_1 = 1'h0;
+                 |  assign d = 1'h1;
+                 |  assign b_0 = 1'h0;
+                 |  assign b_1 = c;
+                 |  assign b_2 = d;
                  |endmodule
                  |""".stripMargin
   def compiler = new MinimumVerilogCompiler()

--- a/src/test/scala/firrtlTests/DriverSpec.scala
+++ b/src/test/scala/firrtlTests/DriverSpec.scala
@@ -371,7 +371,9 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
         "low" -> "./Top.lo.fir",
         "high" -> "./Top.hi.fir",
         "middle" -> "./Top.mid.fir",
-        "verilog" -> "./Top.v"
+        "verilog" -> "./Top.v",
+        "mverilog" -> "./Top.v",
+        "sverilog" -> "./Top.sv"
       ).foreach { case (compilerName, expectedOutputFileName) =>
         val manager = new ExecutionOptionsManager("test") with HasFirrtlOptions {
           commonOptions = CommonOptions(topName = "Top")
@@ -391,7 +393,9 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
         "low" -> Seq("./Top.lo.fir", "./Child.lo.fir"),
         "high" -> Seq("./Top.hi.fir", "./Child.hi.fir"),
         "middle" -> Seq("./Top.mid.fir", "./Child.mid.fir"),
-        "verilog" -> Seq("./Top.v", "./Child.v")
+        "verilog" -> Seq("./Top.v", "./Child.v"),
+        "mverilog" -> Seq("./Top.v", "./Child.v"),
+        "sverilog" -> Seq("./Top.sv", "./Child.sv")
       ).foreach { case (compilerName, expectedOutputFileNames) =>
         println(s"$compilerName -> $expectedOutputFileNames")
         val manager = new ExecutionOptionsManager("test") with HasFirrtlOptions {


### PR DESCRIPTION
This adds "mverilog" to the "--compiler" command line option. This
will run the MinimumVerilogCompiler.

This additionally fixes the `MinimumVerilogCompiler` such that
`DeadCodeElimination` will not be run (it's not supposed to be).
Previously, the `VerilogEmitter` would run `DeadCodeElimination`. This
resulted in the `MinimumVerilogCompiler` only effectively disabling
`ConstantPropagation`.

Additionally, `BlackBoxSourceHelper` is removed from the
`MinimumVerilogCompiler` since this will be run by the `VerilogEmitter`
already.

@jackkoenig, @azidar: Question about `DeadCodeElimination`. Is there a reason why this was being included in the `VerilogEmitter` directly?

Fixes #423.

TODO:

- [ ] Add `RemoveValidIf` to `MinimumLowFirrtlOptimization`
- [ ] Handle literals with bit extract