### PR TITLE
Use apache commons for string escaping instead of reflection

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,6 +69,8 @@ libraryDependencies += "net.jcazevedo" %% "moultingyaml" % "0.4.0"
 
 libraryDependencies += "org.json4s" %% "json4s-native" % "3.6.1"
 
+libraryDependencies += "org.apache.commons" % "commons-text" % "1.6"
+
 // Java PB
 
 enablePlugins(ProtobufPlugin)

--- a/src/main/scala/firrtl/ir/IR.scala
+++ b/src/main/scala/firrtl/ir/IR.scala
@@ -58,15 +58,13 @@ trait HasInfo {
 trait IsDeclaration extends HasName with HasInfo
 
 case class StringLit(string: String) extends FirrtlNode {
+  import org.apache.commons.text.StringEscapeUtils
   /** Returns an escaped and quoted String */
   def escape: String = {
-    import scala.reflect.runtime.universe._
-    Literal(Constant(string)).toString
+    "\"" + serialize + "\""
   }
-  def serialize: String = {
-    val str = escape
-    str.slice(1, str.size - 1)
-  }
+  def serialize: String = StringEscapeUtils.escapeJava(string)
+
   /** Format the string for Verilog */
   def verilogFormat: StringLit = {
     StringLit(string.replaceAll("%x", "%h"))
@@ -81,6 +79,7 @@ case class StringLit(string: String) extends FirrtlNode {
   }
 }
 object StringLit {
+  import org.apache.commons.text.StringEscapeUtils
   /** Maps characters to ASCII for Verilog emission */
   private def toASCII(char: Char): List[Char] = char match {
     case nonASCII if !nonASCII.isValidByte => List('?')
@@ -94,8 +93,7 @@ object StringLit {
 
   /** Create a StringLit from a raw parsed String */
   def unescape(raw: String): StringLit = {
-    val str = StringContext.processEscapes(raw)
-    StringLit(str)
+    StringLit(StringEscapeUtils.unescapeJava(raw))
   }
 }
 

--- a/src/test/scala/firrtlTests/StringSpec.scala
+++ b/src/test/scala/firrtlTests/StringSpec.scala
@@ -59,16 +59,16 @@ class StringSpec extends FirrtlPropSpec {
 
   // Whitelist is [0x20 - 0x7e]
   val whitelist =
-    """ !\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ""" +
+    """ !\"#$%&\''()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ""" +
     """[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"""
 
   property(s"Character whitelist should be supported: [$whitelist] ") {
     val lit = StringLit.unescape(whitelist)
+    // We accept \' but don't bother escaping it ourselves
+    val res = whitelist.replaceAll("""\\'""", "'")
     // Check result
-    assert(lit.serialize == whitelist)
-    // Scala likes to escape ' as \', Verilog doesn't
-    val verilogWhitelist = whitelist.replaceAll("""\\'""", "'")
-    assert(lit.verilogEscape.tail.init == verilogWhitelist)
+    assert(lit.serialize == res)
+    assert(lit.verilogEscape.tail.init == res)
   }
 
   // Valid escapes = \n, \t, \\, \", \'


### PR DESCRIPTION
In order to avoid writing escaping/unescaping logic, I used the internal Scala String escaping. It **might** be the case that this is causing the out of metaspace issues so I'm trying this out. I don't love pulling in a whole dependency just for this, so we can write it ourselves instead, but this was lower effort.

Possible Fix to #978 

This also should speed stuff up a bit