### PR TITLE
Mem helpers

### DIFF
--- a/src/main/scala/firrtl/WIR.scala
+++ b/src/main/scala/firrtl/WIR.scala
@@ -44,6 +44,8 @@ object WRef {
   def apply(port: Port): WRef = new WRef(port.name, port.tpe, PortKind, UNKNOWNGENDER)
   /** Creates a WRef from a WDefInstance */
   def apply(wi: WDefInstance): WRef = new WRef(wi.name, wi.tpe, InstanceKind, UNKNOWNGENDER)
+  /** Creates a WRef from a DefMemory */
+  def apply(mem: DefMemory): WRef = new WRef(mem.name, passes.MemPortUtils.memType(mem), WireKind, UNKNOWNGENDER)
   /** Creates a WRef from an arbitrary string name */
   def apply(n: String, t: Type = UnknownType, k: Kind = ExpKind): WRef = new WRef(n, t, k, UNKNOWNGENDER)
 }

--- a/src/main/scala/firrtl/passes/memlib/MemIR.scala
+++ b/src/main/scala/firrtl/passes/memlib/MemIR.scala
@@ -7,6 +7,25 @@ import firrtl._
 import firrtl.ir._
 import Utils.indent
 
+object DefAnnotatedMemory {
+  def apply(m: DefMemory): DefAnnotatedMemory = {
+    new DefAnnotatedMemory(
+      m.info,
+      m.name,
+      m.dataType,
+      m.depth,
+      m.writeLatency,
+      m.readLatency,
+      m.readers,
+      m.writers,
+      m.readwriters,
+      m.readUnderWrite,
+      None, // mask granularity annotation
+      None  // No reference yet to another memory
+    )
+  }
+}
+
 case class DefAnnotatedMemory(
     info: Info,
     name: String,

--- a/src/main/scala/firrtl/passes/memlib/ToMemIR.scala
+++ b/src/main/scala/firrtl/passes/memlib/ToMemIR.scala
@@ -19,20 +19,7 @@ object ToMemIR extends Pass {
   def updateStmts(s: Statement): Statement = s match {
     case m: DefMemory if m.readLatency == 1 && m.writeLatency == 1 &&
         (m.writers.length + m.readwriters.length) == 1 && m.readers.length <= 1 =>
-      DefAnnotatedMemory(
-        m.info,
-        m.name,
-        m.dataType,
-        m.depth,
-        m.writeLatency,
-        m.readLatency,
-        m.readers,
-        m.writers,
-        m.readwriters,
-        m.readUnderWrite,
-        None, // mask granularity annotation
-        None  // No reference yet to another memory
-      )
+      DefAnnotatedMemory(m)
     case sx => sx map updateStmts
   }
 


### PR DESCRIPTION
This adds a couple of small tweaks to make writing memory-modifying passes cleaner:

- `WRef` was missing a factory that takes a `DefMemory`; this adds one
- While `DefAnnotatedMemory` doesn't extend `DefMemory`, moving the ad-hoc copying into a factory method makes the code clearer and avoids repetition