### PR TITLE
Asynchronous Reset

### DIFF
--- a/src/main/antlr4/FIRRTL.g4
+++ b/src/main/antlr4/FIRRTL.g4
@@ -56,6 +56,7 @@ type
   | 'SInt' ('<' intLit '>')?
   | 'Fixed' ('<' intLit '>')? ('<' '<' intLit '>' '>')?
   | 'Clock'
+  | 'AsyncReset'
   | 'Analog' ('<' intLit '>')?
   | '{' field* '}'        // Bundle
   | type '[' intLit ']'   // Vector
@@ -253,6 +254,7 @@ primop
   | 'neq('
   | 'pad('
   | 'asUInt('
+  | 'asAsyncReset('
   | 'asSInt('
   | 'asClock('
   | 'shl('

--- a/src/main/proto/firrtl.proto
+++ b/src/main/proto/firrtl.proto
@@ -262,6 +262,10 @@ message Firrtl {
       // Empty.
     }
 
+    message AsyncResetType {
+      // Empty.
+    }
+
     message BundleType {
       message Field {
         // Required.
@@ -299,6 +303,7 @@ message Firrtl {
       VectorType vector_type = 6;
       FixedType fixed_type = 7;
       AnalogType analog_type = 8;
+      AsyncResetType async_reset_type = 9;
     }
   }
 
@@ -425,6 +430,7 @@ message Firrtl {
         OP_SHIFT_BINARY_POINT_LEFT = 35;
         OP_SHIFT_BINARY_POINT_RIGHT = 36;
         OP_SET_BINARY_POINT = 37;
+        OP_AS_ASYNC_RESET = 38;
       }
 
       // Required.

--- a/src/main/scala/firrtl/PrimOps.scala
+++ b/src/main/scala/firrtl/PrimOps.scala
@@ -39,6 +39,8 @@ object PrimOps extends LazyLogging {
   case object AsSInt extends PrimOp { override def toString = "asSInt" }
   /** Interpret As Clock */
   case object AsClock extends PrimOp { override def toString = "asClock" }
+  /** Interpret As AsyncReset */
+  case object AsAsyncReset extends PrimOp { override def toString = "asAsyncReset" }
   /** Static Shift Left */
   case object Shl extends PrimOp { override def toString = "shl" }
   /** Static Shift Right */
@@ -83,8 +85,9 @@ object PrimOps extends LazyLogging {
   case object BPSet extends PrimOp { override def toString = "bpset" }
 
   private lazy val builtinPrimOps: Seq[PrimOp] =
-    Seq(Add, Sub, Mul, Div, Rem, Lt, Leq, Gt, Geq, Eq, Neq, Pad, AsUInt, AsSInt, AsClock, Shl, Shr,
-        Dshl, Dshr, Neg, Cvt, Not, And, Or, Xor, Andr, Orr, Xorr, Cat, Bits, Head, Tail, AsFixedPoint, BPShl, BPShr, BPSet)
+    Seq(Add, Sub, Mul, Div, Rem, Lt, Leq, Gt, Geq, Eq, Neq, Pad, AsUInt, AsSInt, AsClock,
+      AsAsyncReset, Shl, Shr, Dshl, Dshr, Neg, Cvt, Not, And, Or, Xor, Andr, Orr, Xorr, Cat, Bits,
+      Head, Tail, AsFixedPoint, BPShl, BPShr, BPSet)
   private lazy val strToPrimOp: Map[String, PrimOp] = builtinPrimOps.map { case op : PrimOp=> op.toString -> op }.toMap
 
   /** Seq of String representations of [[ir.PrimOp]]s */
@@ -203,6 +206,7 @@ object PrimOps extends LazyLogging {
         case _: FixedType => UIntType(w1)
         case ClockType => UIntType(IntWidth(1))
         case AnalogType(w) => UIntType(w1)
+        case AsyncResetType => UIntType(IntWidth(1))
         case _ => UnknownType
       }
       case AsSInt => t1 match {
@@ -211,6 +215,7 @@ object PrimOps extends LazyLogging {
         case _: FixedType => SIntType(w1)
         case ClockType => SIntType(IntWidth(1))
         case _: AnalogType => SIntType(w1)
+        case AsyncResetType => SIntType(IntWidth(1))
         case _ => UnknownType
       }
       case AsFixedPoint => t1 match {
@@ -219,6 +224,7 @@ object PrimOps extends LazyLogging {
         case _: FixedType => FixedType(w1, c1)
         case ClockType => FixedType(IntWidth(1), c1)
         case _: AnalogType => FixedType(w1, c1)
+        case AsyncResetType => FixedType(IntWidth(1), c1)
         case _ => UnknownType
       }
       case AsClock => t1 match {
@@ -226,6 +232,15 @@ object PrimOps extends LazyLogging {
         case _: SIntType => ClockType
         case ClockType => ClockType
         case _: AnalogType => ClockType
+        case AsyncResetType => ClockType
+        case _ => UnknownType
+      }
+      case AsAsyncReset => t1 match {
+        case _: UIntType => AsyncResetType
+        case _: SIntType => AsyncResetType
+        case ClockType => AsyncResetType
+        case _: AnalogType => AsyncResetType
+        case AsyncResetType => AsyncResetType
         case _ => UnknownType
       }
       case Shl => t1 match {

--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -388,6 +388,7 @@ object Utils extends LazyLogging {
   def mux_type(e1: Expression, e2: Expression): Type = mux_type(e1.tpe, e2.tpe)
   def mux_type(t1: Type, t2: Type): Type = (t1, t2) match {
     case (ClockType, ClockType) => ClockType
+    case (AsyncResetType, AsyncResetType) => AsyncResetType
     case (t1: UIntType, t2: UIntType) => UIntType(UnknownWidth)
     case (t1: SIntType, t2: SIntType) => SIntType(UnknownWidth)
     case (t1: FixedType, t2: FixedType) => FixedType(UnknownWidth, UnknownWidth)
@@ -406,6 +407,7 @@ object Utils extends LazyLogging {
     }
     (t1, t2) match {
       case (ClockType, ClockType) => ClockType
+      case (AsyncResetType, AsyncResetType) => AsyncResetType
       case (t1x: UIntType, t2x: UIntType) => UIntType(wmax(t1x.width, t2x.width))
       case (t1x: SIntType, t2x: SIntType) => SIntType(wmax(t1x.width, t2x.width))
       case (FixedType(w1, p1), FixedType(w2, p2)) =>

--- a/src/main/scala/firrtl/Visitor.scala
+++ b/src/main/scala/firrtl/Visitor.scala
@@ -130,6 +130,7 @@ class Visitor(infoMode: InfoMode) extends FIRRTLBaseVisitor[FirrtlNode] {
             case 2 => FixedType(getWidth(ctx.intLit(0)), getWidth(ctx.intLit(1)))
           }
           case "Clock" => ClockType
+          case "AsyncReset" => AsyncResetType
           case "Analog" => if (ctx.getChildCount > 1) AnalogType(IntWidth(string2BigInt(ctx.intLit(0).getText)))
           else AnalogType(UnknownWidth)
           case "{" => BundleType(ctx.field.asScala.map(visitField))

--- a/src/main/scala/firrtl/WIR.scala
+++ b/src/main/scala/firrtl/WIR.scala
@@ -223,6 +223,7 @@ class WrappedType(val t: Type) {
       case (_: UIntType, _: UIntType) => true
       case (_: SIntType, _: SIntType) => true
       case (ClockType, ClockType) => true
+      case (AsyncResetType, AsyncResetType) => true
       case (_: FixedType, _: FixedType) => true
       // Analog totally skips out of the Firrtl type system.
       // The only way Analog can play with another Analog component is through Attach.

--- a/src/main/scala/firrtl/ir/IR.scala
+++ b/src/main/scala/firrtl/ir/IR.scala
@@ -591,6 +591,12 @@ case object ClockType extends GroundType {
   def mapWidth(f: Width => Width): Type = this
   def foreachWidth(f: Width => Unit): Unit = Unit
 }
+case object AsyncResetType extends GroundType {
+  val width = IntWidth(1)
+  def serialize: String = "AsyncReset"
+  def mapWidth(f: Width => Width): Type = this
+  def foreachWidth(f: Width => Unit): Unit = Unit
+}
 case class AnalogType(width: Width) extends GroundType {
   def serialize: String = "Analog" + width.serialize
   def mapWidth(f: Width => Width): Type = AnalogType(f(width))

--- a/src/main/scala/firrtl/passes/CheckWidths.scala
+++ b/src/main/scala/firrtl/passes/CheckWidths.scala
@@ -107,6 +107,7 @@ object CheckWidths extends Pass {
         case sx: DefRegister =>
           sx.reset.tpe match {
             case UIntType(IntWidth(w)) if w == 1 =>
+            case AsyncResetType =>
             case _ => errors.append(new CheckTypes.IllegalResetType(info, target.serialize, sx.name))
           }
         case _ =>

--- a/src/main/scala/firrtl/passes/Checks.scala
+++ b/src/main/scala/firrtl/passes/Checks.scala
@@ -53,6 +53,8 @@ object CheckHighForm extends Pass {
     s"$info: [module $mname] Primop $op argument $value < 0.")
   class LsbLargerThanMsbException(info: Info, mname: String, op: String, lsb: Int, msb: Int) extends PassException(
     s"$info: [module $mname] Primop $op lsb $lsb > $msb.")
+  class NonLiteralAsyncResetValueException(info: Info, mname: String, reg: String, init: String) extends PassException(
+    s"$info: [module $mname] AsyncReset Reg '$reg' reset to non-literal '$init'")
 
   def run(c: Circuit): Circuit = {
     val errors = new Errors()
@@ -74,7 +76,7 @@ object CheckHighForm extends Pass {
         case Add | Sub | Mul | Div | Rem | Lt | Leq | Gt | Geq |
              Eq | Neq | Dshl | Dshr | And | Or | Xor | Cat =>
           correctNum(Option(2), 0)
-        case AsUInt | AsSInt | AsClock | Cvt | Neq | Not =>
+        case AsUInt | AsSInt | AsClock | AsAsyncReset | Cvt | Neq | Not =>
           correctNum(Option(1), 0)
         case AsFixedPoint | Pad | Head | Tail | BPShl | BPShr | BPSet =>
           correctNum(Option(1), 1)
@@ -164,6 +166,13 @@ object CheckHighForm extends Pass {
       val info = get_info(s) match {case NoInfo => minfo case x => x}
       s foreach checkName(info, mname, names)
       s match {
+        case DefRegister(info, name, _,_, reset, init) if reset.tpe == AsyncResetType =>
+          init match {
+            case _: Literal => // okay
+            case nonlit =>
+              val e = new NonLiteralAsyncResetValueException(info, mname, name, nonlit.serialize)
+              errors.append(e)
+          }
         case sx: DefMemory =>
           if (hasFlip(sx.dataType))
             errors.append(new MemWithFlipException(info, mname, sx.name))
@@ -291,41 +300,43 @@ object CheckTypes extends Pass {
       case tx => true
     }
     def check_types_primop(info: Info, mname: String, e: DoPrim): Unit = {
-      def checkAllTypes(exprs: Seq[Expression], okUInt: Boolean, okSInt: Boolean, okClock: Boolean, okFix: Boolean): Unit = {
-        exprs.foldLeft((false, false, false, false)) {
-          case ((isUInt, isSInt, isClock, isFix), expr) => expr.tpe match {
-            case u: UIntType  => (true, isSInt, isClock, isFix)
-            case s: SIntType  => (isUInt, true, isClock, isFix)
-            case ClockType    => (isUInt, isSInt, true, isFix)
-            case f: FixedType => (isUInt, isSInt, isClock, true)
-            case UnknownType =>
+      def checkAllTypes(exprs: Seq[Expression], okUInt: Boolean, okSInt: Boolean, okClock: Boolean, okFix: Boolean, okAsync: Boolean): Unit = {
+        exprs.foldLeft((false, false, false, false, false)) {
+          case ((isUInt, isSInt, isClock, isFix, isAsync), expr) => expr.tpe match {
+            case u: UIntType    => (true,   isSInt, isClock, isFix, isAsync)
+            case s: SIntType    => (isUInt, true,   isClock, isFix, isAsync)
+            case ClockType      => (isUInt, isSInt, true,    isFix, isAsync)
+            case f: FixedType   => (isUInt, isSInt, isClock, true,  isAsync)
+            case AsyncResetType => (isUInt, isSInt, isClock, isFix, true)
+            case UnknownType    =>
               errors.append(new IllegalUnknownType(info, mname, e.serialize))
-              (isUInt, isSInt, isClock, isFix)
+              (isUInt, isSInt, isClock, isFix, isAsync)
             case other => throwInternalError(s"Illegal Type: ${other.serialize}")
           }
         } match {
           //   (UInt,  SInt,  Clock, Fixed)
-          case (isAll, false, false, false) if isAll == okUInt  =>
-          case (false, isAll, false, false) if isAll == okSInt  =>
-          case (false, false, isAll, false) if isAll == okClock =>
-          case (false, false, false, isAll) if isAll == okFix   =>
+          case (isAll, false, false, false, false) if isAll == okUInt  =>
+          case (false, isAll, false, false, false) if isAll == okSInt  =>
+          case (false, false, isAll, false, false) if isAll == okClock =>
+          case (false, false, false, isAll, false) if isAll == okFix   =>
+          case (false, false, false, false, isAll) if isAll == okAsync =>
           case x => errors.append(new OpNotCorrectType(info, mname, e.op.serialize, exprs.map(_.tpe.serialize)))
         }
       }
       e.op match {
-        case AsUInt | AsSInt | AsClock | AsFixedPoint =>
+        case AsUInt | AsSInt | AsClock | AsFixedPoint | AsAsyncReset =>
           // All types are ok
         case Dshl | Dshr =>
-          checkAllTypes(Seq(e.args.head), okUInt=true, okSInt=true,  okClock=false, okFix=true)
-          checkAllTypes(Seq(e.args(1)),   okUInt=true, okSInt=false, okClock=false, okFix=false)
+          checkAllTypes(Seq(e.args.head), okUInt=true, okSInt=true,  okClock=false, okFix=true, okAsync=false)
+          checkAllTypes(Seq(e.args(1)),   okUInt=true, okSInt=false, okClock=false, okFix=false, okAsync=false)
         case Add | Sub | Mul | Lt | Leq | Gt | Geq | Eq | Neq =>
-          checkAllTypes(e.args, okUInt=true, okSInt=true, okClock=false, okFix=true)
+          checkAllTypes(e.args, okUInt=true, okSInt=true, okClock=false, okFix=true, okAsync=false)
         case Pad | Shl | Shr | Cat | Bits | Head | Tail =>
-          checkAllTypes(e.args, okUInt=true, okSInt=true, okClock=false, okFix=true)
+          checkAllTypes(e.args, okUInt=true, okSInt=true, okClock=false, okFix=true, okAsync=false)
         case BPShl | BPShr | BPSet =>
-          checkAllTypes(e.args, okUInt=false, okSInt=false, okClock=false, okFix=true)
+          checkAllTypes(e.args, okUInt=false, okSInt=false, okClock=false, okFix=true, okAsync=false)
         case _ =>
-          checkAllTypes(e.args, okUInt=true, okSInt=true, okClock=false, okFix=false)
+          checkAllTypes(e.args, okUInt=true, okSInt=true, okClock=false, okFix=false, okAsync=false)
       }
     }
 
@@ -415,6 +426,7 @@ object CheckTypes extends Pass {
           }
           sx.reset.tpe match {
             case UIntType(IntWidth(w)) if w == 1 =>
+            case AsyncResetType =>
             case UIntType(UnknownWidth) => // cannot catch here, though width may ultimately be wrong
             case _ => errors.append(new IllegalResetType(info, mname, sx.name))
           }

--- a/src/main/scala/firrtl/passes/InferWidths.scala
+++ b/src/main/scala/firrtl/passes/InferWidths.scala
@@ -228,6 +228,7 @@ object InferWidths extends Pass {
       case (t1: UIntType, t2: UIntType) => Seq(WGeq(t1.width, t2.width))
       case (t1: SIntType, t2: SIntType) => Seq(WGeq(t1.width, t2.width))
       case (ClockType, ClockType) => Nil
+      case (AsyncResetType, AsyncResetType) => Nil
       case (FixedType(w1, p1), FixedType(w2, p2)) => Seq(WGeq(w1,w2), WGeq(p1,p2))
       case (AnalogType(w1), AnalogType(w2)) => Seq(WGeq(w1,w2), WGeq(w2,w1))
       case (t1: BundleType, t2: BundleType) =>
@@ -282,10 +283,13 @@ object InferWidths extends Pass {
               case Flip => get_constraints_t(expx.tpe, locx.tpe)//WGeq(getWidth(expx), getWidth(locx))
             }
           })
-        case (s: DefRegister) => v ++= (
-           get_constraints_t(s.reset.tpe, UIntType(IntWidth(1))) ++
-           get_constraints_t(UIntType(IntWidth(1)), s.reset.tpe) ++ 
-           get_constraints_t(s.tpe, s.init.tpe))
+        case (s: DefRegister) =>
+          if (s.reset.tpe != AsyncResetType ) {
+            v ++= (
+               get_constraints_t(s.reset.tpe, UIntType(IntWidth(1))) ++
+               get_constraints_t(UIntType(IntWidth(1)), s.reset.tpe))
+           }
+          v ++= get_constraints_t(s.tpe, s.init.tpe)
         case (s:Conditionally) => v ++= 
            get_constraints_t(s.pred.tpe, UIntType(IntWidth(1))) ++
            get_constraints_t(UIntType(IntWidth(1)), s.pred.tpe)

--- a/src/main/scala/firrtl/proto/FromProto.scala
+++ b/src/main/scala/firrtl/proto/FromProto.scala
@@ -240,6 +240,7 @@ object FromProto {
       case SINT_TYPE_FIELD_NUMBER => convert(tpe.getSintType)
       case FIXED_TYPE_FIELD_NUMBER => convert(tpe.getFixedType)
       case CLOCK_TYPE_FIELD_NUMBER => ir.ClockType
+      case ASYNC_RESET_TYPE_FIELD_NUMBER => ir.AsyncResetType
       case ANALOG_TYPE_FIELD_NUMBER => convert(tpe.getAnalogType)
       case BUNDLE_TYPE_FIELD_NUMBER =>
         ir.BundleType(tpe.getBundleType.getFieldList.asScala.map(convert(_)))

--- a/src/main/scala/firrtl/proto/ToProto.scala
+++ b/src/main/scala/firrtl/proto/ToProto.scala
@@ -80,6 +80,7 @@ object ToProto {
     AsSInt -> Op.OP_AS_SINT,
     AsClock -> Op.OP_AS_CLOCK,
     AsFixedPoint -> Op.OP_AS_FIXED_POINT,
+    AsAsyncReset -> Op.OP_AS_ASYNC_RESET,
     Shl -> Op.OP_SHIFT_LEFT,
     Shr -> Op.OP_SHIFT_RIGHT,
     Dshl -> Op.OP_DYNAMIC_SHIFT_LEFT,
@@ -335,6 +336,9 @@ object ToProto {
       case ir.ClockType =>
         val ct = Firrtl.Type.ClockType.newBuilder()
         tb.setClockType(ct)
+      case ir.AsyncResetType =>
+        val at = Firrtl.Type.AsyncResetType.newBuilder()
+        tb.setAsyncResetType(at)
       case ir.AnalogType(width) =>
         val at = Firrtl.Type.AnalogType.newBuilder()
           convert(width).foreach(at.setWidth)

--- a/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
+++ b/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
@@ -81,7 +81,8 @@ object FlattenRegUpdate {
 
     def onStmt(stmt: Statement): Statement = stmt.map(onStmt) match {
       case reg @ DefRegister(_, rname, _,_, resetCond, _) =>
-        assert(resetCond == Utils.zero, "Register reset should have already been made explicit!")
+        assert(resetCond.tpe == AsyncResetType || resetCond == Utils.zero,
+          "Synchronous reset should have already been made explicit!")
         val ref = WRef(reg)
         val update = Connect(NoInfo, ref, constructRegUpdate(netlist.getOrElse(ref, ref)))
         regUpdates += update

--- a/src/main/scala/firrtl/transforms/RemoveReset.scala
+++ b/src/main/scala/firrtl/transforms/RemoveReset.scala
@@ -22,7 +22,8 @@ class RemoveReset extends Transform {
     val resets = mutable.HashMap.empty[String, Reset]
     def onStmt(stmt: Statement): Statement = {
       stmt match {
-        case reg @ DefRegister(_, rname, _, _, reset, init) if reset != Utils.zero =>
+        case reg @ DefRegister(_, rname, _, _, reset, init)
+            if reset != Utils.zero && reset.tpe != AsyncResetType =>
           // Add register reset to map
           resets(rname) = Reset(reset, init)
           reg.copy(reset = Utils.zero, init = WRef(reg))

--- a/src/main/scala/firrtl/transforms/RemoveWires.scala
+++ b/src/main/scala/firrtl/transforms/RemoveWires.scala
@@ -6,6 +6,7 @@ package transforms
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
+import firrtl.traversals.Foreachers._
 import firrtl.WrappedExpression._
 import firrtl.graph.{DiGraph, MutableDiGraph, CyclicException}
 
@@ -29,7 +30,7 @@ class RemoveWires extends Transform {
     def rec(e: Expression): Expression = {
       e match {
         case ref @ WRef(_,_, WireKind | NodeKind | RegKind, _) => refs += ref
-        case nested @ (_: Mux | _: DoPrim | _: ValidIf) => nested map rec
+        case nested @ (_: Mux | _: DoPrim | _: ValidIf) => nested.foreach(rec)
         case _ => // Do nothing
       }
       e
@@ -40,13 +41,15 @@ class RemoveWires extends Transform {
 
   // Transform netlist into DefNodes
   private def getOrderedNodes(
-    netlist: mutable.LinkedHashMap[WrappedExpression, (Expression, Info)],
+    netlist: mutable.LinkedHashMap[WrappedExpression, (Seq[Expression], Info)],
     regInfo: mutable.Map[WrappedExpression, DefRegister]): Try[Seq[Statement]] = {
     val digraph = new MutableDiGraph[WrappedExpression]
-    for ((sink, (expr, _)) <- netlist) {
+    for ((sink, (exprs, _)) <- netlist) {
       digraph.addVertex(sink)
-      for (source <- extractNodeWireRegRefs(expr)) {
-        digraph.addPairWithEdge(sink, source)
+      for (expr <- exprs) {
+        for (source <- extractNodeWireRegRefs(expr)) {
+          digraph.addPairWithEdge(sink, source)
+        }
       }
     }
 
@@ -57,10 +60,11 @@ class RemoveWires extends Transform {
       val ordered = digraph.linearize.reverse
       ordered.map { key =>
         val WRef(name, _, kind, _) = key.e1
-        val (rhs, info) = netlist(key)
         kind match {
           case RegKind => regInfo(key)
-          case WireKind | NodeKind => DefNode(info, name, rhs)
+          case WireKind | NodeKind =>
+            val (Seq(rhs), info) = netlist(key)
+            DefNode(info, name, rhs)
         }
       }
     }
@@ -72,7 +76,7 @@ class RemoveWires extends Transform {
     // Store all "other" statements here, non-wire, non-node connections, printfs, etc.
     val otherStmts = mutable.ArrayBuffer.empty[Statement]
     // Add nodes and wire connection here
-    val netlist = mutable.LinkedHashMap.empty[WrappedExpression, (Expression, Info)]
+    val netlist = mutable.LinkedHashMap.empty[WrappedExpression, (Seq[Expression], Info)]
     // Info at definition of wires for combining into node
     val wireInfo = mutable.HashMap.empty[WrappedExpression, Info]
     // Additional info about registers
@@ -81,12 +85,16 @@ class RemoveWires extends Transform {
     def onStmt(stmt: Statement): Statement = {
       stmt match {
         case node: DefNode =>
-          netlist(we(WRef(node))) = (node.value, node.info)
+          netlist(we(WRef(node))) = (Seq(node.value), node.info)
         case wire: DefWire if !wire.tpe.isInstanceOf[AnalogType] => // Remove all non-Analog wires
           wireInfo(WRef(wire)) = wire.info
         case reg: DefRegister =>
+          val resetDep = reg.reset.tpe match {
+            case AsyncResetType => reg.reset :: Nil
+            case _ => Nil
+          }
           regInfo(we(WRef(reg))) = reg
-          netlist(we(WRef(reg))) = (reg.clock, reg.info)
+          netlist(we(WRef(reg))) = (reg.clock :: resetDep, reg.info)
         case decl: IsDeclaration => // Keep all declarations except for nodes and non-Analog wires
           decls += decl
         case con @ Connect(cinfo, lhs, rhs) => kind(lhs) match {
@@ -94,20 +102,20 @@ class RemoveWires extends Transform {
             // Be sure to pad the rhs since nodes get their type from the rhs
             val paddedRhs = ConstantPropagation.pad(rhs, lhs.tpe)
             val dinfo = wireInfo(lhs)
-            netlist(we(lhs)) = (paddedRhs, MultiInfo(dinfo, cinfo))
+            netlist(we(lhs)) = (Seq(paddedRhs), MultiInfo(dinfo, cinfo))
           case _ => otherStmts += con // Other connections just pass through
         }
         case invalid @ IsInvalid(info, expr) =>
           kind(expr) match {
             case WireKind =>
               val width = expr.tpe match { case GroundType(width) => width } // LowFirrtl
-              netlist(we(expr)) = (ValidIf(Utils.zero, UIntLiteral(BigInt(0), width), expr.tpe), info)
+              netlist(we(expr)) = (Seq(ValidIf(Utils.zero, UIntLiteral(BigInt(0), width), expr.tpe)), info)
             case _ => otherStmts += invalid
           }
         case other @ (_: Print | _: Stop | _: Attach) =>
           otherStmts += other
         case EmptyStmt => // Dont bother keeping EmptyStmts around
-        case block: Block => block map onStmt
+        case block: Block => block.foreach(onStmt)
         case _ => throwInternalError()
       }
       stmt
@@ -136,7 +144,7 @@ class RemoveWires extends Transform {
   )
 
   def execute(state: CircuitState): CircuitState = {
-    val result = state.copy(circuit = state.circuit map onModule)
+    val result = state.copy(circuit = state.circuit.map(onModule))
     cleanup.foldLeft(result) { case (in, xform) => xform.execute(in) }
   }
 }

--- a/src/test/resources/features/AsyncResetTester.fir
+++ b/src/test/resources/features/AsyncResetTester.fir
@@ -1,0 +1,43 @@
+
+circuit AsyncResetTester :
+  module AsyncResetTester :
+    input clock : Clock
+    input reset : UInt<1>
+
+    reg div : UInt<2>, clock with : (reset => (reset, UInt(0)))
+    div <= tail(add(div, UInt(1)), 1)
+
+    reg slowClkReg : UInt<1>, clock with : (reset => (reset, UInt(0)))
+    slowClkReg <= eq(div, UInt(0))
+    node slowClk = asClock(slowClkReg)
+
+    reg counter : UInt<4>, clock with : (reset => (reset, UInt(0)))
+    counter <= tail(add(counter, UInt(1)), 1)
+
+    reg asyncResetReg : UInt<1>, clock with : (reset => (reset, UInt(0)))
+    asyncResetReg <= eq(counter, UInt(2))
+    node asyncReset = asAsyncReset(asyncResetReg)
+
+    reg r : UInt<8>, slowClk with : (reset => (asyncReset, UInt("h55")))
+    ; We always set the register on slowClk
+    when UInt(1) :
+      r <= UInt("hff")
+
+    when and(leq(counter, UInt(2)), neq(counter, UInt(0))) :
+      when neq(r, UInt("hff")) :
+        printf(clock, UInt(1), "Assertion 1 failed!\n")
+        stop(clock, UInt(1), 1)
+    ; Do the async reset
+    when eq(counter, UInt(3)) :
+      when neq(r, UInt("h55")) :
+        printf(clock, UInt(1), "Assertion 2 failed!\n")
+        stop(clock, UInt(1), 1)
+    ; Back to normal value
+    when eq(counter, UInt(5)) :
+      when neq(r, UInt("hff")) :
+        printf(clock, UInt(1), "Assertion 3 failed!\n")
+        stop(clock, UInt(1), 1)
+    ; Success!
+    when eq(counter, UInt(6)) :
+      stop(clock, UInt(1), 0)
+

--- a/src/test/scala/firrtlTests/AsyncResetSpec.scala
+++ b/src/test/scala/firrtlTests/AsyncResetSpec.scala
@@ -1,0 +1,169 @@
+// See LICENSE for license details.
+
+package firrtlTests
+
+import firrtl._
+import firrtl.ir._
+import FirrtlCheckers._
+
+class AsyncResetSpec extends FirrtlFlatSpec {
+  def compile(input: String): CircuitState =
+    (new VerilogCompiler).compileAndEmit(CircuitState(parse(input), ChirrtlForm), List.empty)
+  def compileBody(body: String) = {
+    val str = """
+      |circuit Test :
+      |  module Test :
+      |""".stripMargin + body.split("\n").mkString("    ", "\n    ", "")
+    compile(str)
+  }
+
+  "AsyncReset" should "generate async-reset always blocks" in {
+    val result = compileBody(s"""
+      |input clock : Clock
+      |input reset : AsyncReset
+      |input x : UInt<8>
+      |output z : UInt<8>
+      |reg r : UInt<8>, clock with : (reset => (reset, UInt(123)))
+      |r <= x
+      |z <= r""".stripMargin
+    )
+    result should containLine ("always @(posedge clock or posedge reset) begin")
+  }
+
+  it should "support casting to other types" in {
+    val result = compileBody(s"""
+      |input a : AsyncReset
+      |output v : UInt<1>
+      |output w : SInt<1>
+      |output x : Clock
+      |output y : Fixed<1><<0>>
+      |output z : AsyncReset
+      |v <= asUInt(a)
+      |w <= asSInt(a)
+      |x <= asClock(a)
+      |y <= asFixedPoint(a, 0)
+      |z <= asAsyncReset(a)""".stripMargin
+    )
+    result should containLine ("assign v = $unsigned(a);")
+    result should containLine ("assign w = $signed(a);")
+    result should containLine ("assign x = a;")
+    result should containLine ("assign y = $signed(a);")
+    result should containLine ("assign z = a;")
+  }
+
+  "Other types" should "support casting to AsyncReset" in {
+    val result = compileBody(s"""
+      |input a : UInt<1>
+      |input b : SInt<1>
+      |input c : Clock
+      |input d : Fixed<1><<0>>
+      |input e : AsyncReset
+      |output v : AsyncReset
+      |output w : AsyncReset
+      |output x : AsyncReset
+      |output y : AsyncReset
+      |output z : AsyncReset
+      |v <= asAsyncReset(a)
+      |w <= asAsyncReset(a)
+      |x <= asAsyncReset(a)
+      |y <= asAsyncReset(a)
+      |z <= asAsyncReset(a)""".stripMargin
+    )
+    result should containLine ("assign v = a;")
+    result should containLine ("assign w = a;")
+    result should containLine ("assign x = a;")
+    result should containLine ("assign y = a;")
+    result should containLine ("assign z = a;")
+  }
+
+  "Non-literals" should "NOT be allowed as reset values for AsyncReset" in {
+    an [passes.CheckHighForm.NonLiteralAsyncResetValueException] shouldBe thrownBy {
+      compileBody(s"""
+        |input clock : Clock
+        |input reset : AsyncReset
+        |input x : UInt<8>
+        |input y : UInt<8>
+        |output z : UInt<8>
+        |reg r : UInt<8>, clock with : (reset => (reset, y))
+        |r <= x
+        |z <= r""".stripMargin
+      )
+    }
+  }
+
+
+  "Every async reset reg" should "generate its own always block" in {
+    val result = compileBody(s"""
+      |input clock0 : Clock
+      |input clock1 : Clock
+      |input syncReset : UInt<1>
+      |input asyncReset : AsyncReset
+      |input x : UInt<8>[5]
+      |output z : UInt<8>[5]
+      |reg r0 : UInt<8>, clock0 with : (reset => (syncReset, UInt(123)))
+      |reg r1 : UInt<8>, clock1 with : (reset => (syncReset, UInt(123)))
+      |reg r2 : UInt<8>, clock0 with : (reset => (asyncReset, UInt(123)))
+      |reg r3 : UInt<8>, clock0 with : (reset => (asyncReset, UInt(123)))
+      |reg r4 : UInt<8>, clock1 with : (reset => (asyncReset, UInt(123)))
+      |r0 <= x[0]
+      |r1 <= x[1]
+      |r2 <= x[2]
+      |r3 <= x[3]
+      |r4 <= x[4]
+      |z[0] <= r0
+      |z[1] <= r1
+      |z[2] <= r2
+      |z[3] <= r3
+      |z[4] <= r4""".stripMargin
+    )
+    result should containLines (
+      "always @(posedge clock0) begin",
+      "if (syncReset) begin",
+      "r0 <= 8'h7b;",
+      "end else begin",
+      "r0 <= x_0;",
+      "end",
+      "end"
+    )
+    result should containLines (
+      "always @(posedge clock1) begin",
+      "if (syncReset) begin",
+      "r1 <= 8'h7b;",
+      "end else begin",
+      "r1 <= x_1;",
+      "end",
+      "end"
+    )
+    result should containLines (
+      "always @(posedge clock0 or posedge asyncReset) begin",
+      "if (asyncReset) begin",
+      "r2 <= 8'h7b;",
+      "end else begin",
+      "r2 <= x_2;",
+      "end",
+      "end"
+    )
+    result should containLines (
+      "always @(posedge clock0 or posedge asyncReset) begin",
+      "if (asyncReset) begin",
+      "r3 <= 8'h7b;",
+      "end else begin",
+      "r3 <= x_3;",
+      "end",
+      "end"
+    )
+    result should containLines (
+      "always @(posedge clock1 or posedge asyncReset) begin",
+      "if (asyncReset) begin",
+      "r4 <= 8'h7b;",
+      "end else begin",
+      "r4 <= x_4;",
+      "end",
+      "end"
+    )
+  }
+
+}
+
+class AsyncResetExecutionTest extends ExecutionTest("AsyncResetTester", "/features")
+

--- a/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+++ b/src/test/scala/firrtlTests/ConstantPropagationTests.scala
@@ -1005,6 +1005,32 @@ class ConstantPropagationIntegrationSpec extends LowTransformSpec {
     execute(input, check, Seq.empty)
   }
 
+  "Registers async reset and a constant connection" should "NOT be removed" in {
+      val input =
+        """circuit Top :
+          |  module Top :
+          |    input clock : Clock
+          |    input reset : AsyncReset
+          |    input en : UInt<1>
+          |    output z : UInt<8>
+          |    reg r : UInt<8>, clock with : (reset => (reset, UInt<4>("hb")))
+          |    when en :
+          |      r <= UInt<4>("h0")
+          |    z <= r""".stripMargin
+      val check =
+        """circuit Top :
+          |  module Top :
+          |    input clock : Clock
+          |    input reset : AsyncReset
+          |    input en : UInt<1>
+          |    output z : UInt<8>
+          |    reg r : UInt<8>, clock with :
+          |      reset => (reset, UInt<8>("hb"))
+          |    z <= r
+          |    r <= mux(en, UInt<8>("h0"), r)""".stripMargin
+    execute(input, check, Seq.empty)
+  }
+
   "Registers with constant reset and connection to the same constant" should "be replaced with that constant" in {
       val input =
         """circuit Top :

--- a/src/test/scala/firrtlTests/FirrtlSpec.scala
+++ b/src/test/scala/firrtlTests/FirrtlSpec.scala
@@ -216,15 +216,18 @@ object FirrtlCheckers extends FirrtlMatchers {
   }
 
   /** Checks that the emitted circuit has the expected line, both will be normalized */
-  def containLine(expectedLine: String) = new CircuitStateStringMatcher(expectedLine)
+  def containLine(expectedLine: String) = containLines(expectedLine)
 
-  class CircuitStateStringMatcher(expectedLine: String) extends Matcher[CircuitState] {
+  /** Checks that the emitted circuit has the expected lines in order, all lines will be normalized */
+  def containLines(expectedLines: String*) = new CircuitStateStringsMatcher(expectedLines)
+
+  class CircuitStateStringsMatcher(expectedLines: Seq[String]) extends Matcher[CircuitState] {
     override def apply(state: CircuitState): MatchResult = {
       val emitted = state.getEmittedCircuit.value
       MatchResult(
-        emitted.split("\n").map(normalized).contains(normalized(expectedLine)),
-        emitted + "\n did not contain \"" + expectedLine + "\"",
-        s"${state.circuit.main} contained $expectedLine"
+        emitted.split("\n").map(normalized).containsSlice(expectedLines.map(normalized)),
+        emitted + "\n did not contain \"" + expectedLines + "\"",
+        s"${state.circuit.main} contained $expectedLines"
       )
     }
   }

--- a/src/test/scala/firrtlTests/ProtoBufSpec.scala
+++ b/src/test/scala/firrtlTests/ProtoBufSpec.scala
@@ -24,7 +24,8 @@ class ProtoBufSpec extends FirrtlFlatSpec {
     FirrtlResourceTest("Rob", "/regress"),
     FirrtlResourceTest("RocketCore", "/regress"),
     FirrtlResourceTest("ICache", "/regress"),
-    FirrtlResourceTest("FPU", "/regress")
+    FirrtlResourceTest("FPU", "/regress"),
+    FirrtlResourceTest("AsyncResetTester", "/features")
   )
 
   for (FirrtlResourceTest(name, dir) <- firrtlResourceTests) {
@@ -135,5 +136,10 @@ class ProtoBufSpec extends FirrtlFlatSpec {
   it should "support SIntLiteral with a width" in {
     val slit = ir.SIntLiteral(-123)
     FromProto.convert(ToProto.convert(slit).build) should equal (slit)
+  }
+
+  it should "support AsyncResetTypes" in {
+    val port = ir.Port(ir.NoInfo, "reset", ir.Input, ir.AsyncResetType)
+    FromProto.convert(ToProto.convert(port).build) should equal (port)
   }
 }

--- a/src/test/scala/firrtlTests/RemoveWiresSpec.scala
+++ b/src/test/scala/firrtlTests/RemoveWiresSpec.scala
@@ -165,4 +165,21 @@ class RemoveWiresSpec extends FirrtlFlatSpec {
     // Check declaration before use is maintained
     passes.CheckHighForm.execute(result)
   }
+
+  it should "order registers with async reset correctly" in {
+    val result = compileBody(s"""
+      |input clock : Clock
+      |input reset : UInt<1>
+      |input in : UInt<8>
+      |output out : UInt<8>
+      |wire areset : AsyncReset
+      |reg r : UInt<8>, clock with : (reset => (areset, UInt(0)))
+      |areset <= asAsyncReset(reset)
+      |r <= in
+      |out <= r
+      |""".stripMargin
+    )
+    // Check declaration before use is maintained
+    passes.CheckHighForm.execute(result)
+  }
 }


### PR DESCRIPTION
I think this is more-or-less good to review!

Summary of changes:
* Adds AsyncResetType (similar to ClockType)
* Registers who's reset signal is of type AsyncResetType are async reset registers
* Registers with async reset can only be reset to literal values

I've probably missed a weird interaction somewhere but this does have several tests including an execution driven one.

@edwardcwang, per discussion with @aswaterman (and please pipe up if I miss[characterize] something), but it seems that the restriction of only allowing literals for async reset registers reset values is the right way to go. You generally can't have an async reset register with the init value driven by an input because in hierarchical synthesis and place-and-route flows you are doing things hierarchically (obviously) so as far as the tool is concerned the "constant" input is just an arbitrary input. Put another way, making constant values inputs makes them treated as arbitrary inputs so the tools can't synthesize asynchronous reset registers from them. Due to this restriction, it's just not a thing that people generally need to express.

TODO:
- [ ] Add AsyncReset to the spec
- [ ] Audit for assumptions based on synchronous reset
- [ ] Use in rocket-chip as proof

META:
- Fixes #219 