### PR TITLE
Fix typo for -c: compiler -> circuit

### DIFF
--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
@@ -81,7 +81,7 @@ Usage:
 
 Required Arguments:
   -o<filename>         Specify the output configuration file
-  -c<compiler>         Specify the target circuit
+  -c<circuit>          Specify the target circuit
 
 Optional Arguments:
   -i<filename>         Specify the input configuration file (for additional optimizations)


### PR DESCRIPTION
Maybe I'm misunderstanding this flag, but this looks like a typo to me.