### PR TITLE
Dependency API

### DIFF
--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -14,7 +14,7 @@ import firrtl.Utils.{error, throwInternalError}
 import firrtl.annotations.TargetToken
 import firrtl.annotations.TargetToken.{Field, Index}
 import firrtl.annotations.transforms.{EliminateTargetPaths, ResolvePaths}
-import firrtl.options.StageUtils
+import firrtl.options.{StageUtils, TransformLike}
 
 /** Container of all annotations for a Firrtl compiler */
 class AnnotationSeq private (private[firrtl] val underlying: List[Annotation]) {
@@ -172,7 +172,7 @@ final case object UnknownForm extends CircuitForm(-1) {
 // scalastyle:on magic.number
 
 /** The basic unit of operating on a Firrtl AST */
-abstract class Transform extends LazyLogging {
+abstract class Transform extends TransformLike[CircuitState] {
   /** A convenience function useful for debugging and error messages */
   def name: String = this.getClass.getSimpleName
   /** The [[firrtl.CircuitForm]] that this transform requires to operate on */
@@ -187,6 +187,8 @@ abstract class Transform extends LazyLogging {
     * @return A transformed Firrtl AST
     */
   protected def execute(state: CircuitState): CircuitState
+
+  def transform(state: CircuitState): CircuitState = execute(state)
 
   /** Convenience method to get annotations relevant to this Transform
     *

--- a/src/main/scala/firrtl/Driver.scala
+++ b/src/main/scala/firrtl/Driver.scala
@@ -2,7 +2,6 @@
 
 package firrtl
 
-import scala.collection._
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
 import scala.util.control.ControlThrowable
@@ -18,7 +17,7 @@ import firrtl.transforms._
 import firrtl.Utils.throwInternalError
 import firrtl.stage.{FirrtlExecutionResultView, FirrtlStage}
 import firrtl.stage.phases.DriverCompatibility
-import firrtl.options.{StageUtils, Phase, Viewer}
+import firrtl.options.{Phase, PhaseManager, StageUtils, Viewer}
 import firrtl.options.phases.DeletedWrapper
 
 
@@ -216,13 +215,18 @@ object Driver {
 
     val annos = optionsManager.firrtlOptions.toAnnotations ++ optionsManager.commonOptions.toAnnotations
 
-    val phases: Seq[Phase] =
-      Seq( new DriverCompatibility.AddImplicitAnnotationFile,
-           new DriverCompatibility.AddImplicitFirrtlFile,
-           new DriverCompatibility.AddImplicitOutputFile,
-           new DriverCompatibility.AddImplicitEmitter,
-           new FirrtlStage )
+    val phases: Seq[Phase] = {
+      import DriverCompatibility._
+      new PhaseManager(
+        Set( classOf[AddImplicitAnnotationFile],
+             classOf[AddImplicitFirrtlFile],
+             classOf[AddImplicitOutputFile],
+             classOf[AddImplicitEmitter],
+             classOf[FirrtlStage] )
+          .map(_.asInstanceOf[Class[Phase]]) )
+        .transformOrder
         .map(DeletedWrapper(_))
+    }
 
     val annosx = try {
       phases.foldLeft(annos)( (a, p) => p.transform(a) )

--- a/src/main/scala/firrtl/options/DependencyManager.scala
+++ b/src/main/scala/firrtl/options/DependencyManager.scala
@@ -1,0 +1,294 @@
+// See LICENSE for license details.
+
+package firrtl.options
+
+import firrtl.AnnotationSeq
+import firrtl.graph.{DiGraph, CyclicException}
+
+import scala.collection.mutable.{ArrayBuffer, HashMap, LinkedHashMap, LinkedHashSet, Queue}
+
+/** An exception arising from an in a [[DependencyManager]] */
+case class DependencyManagerException(message: String, cause: Throwable = null) extends RuntimeException(message, cause)
+
+/** A [[TransformLike]] that resolves a linear ordering of dependencies based on requirements.
+  * @tparam A the type over which this transforms
+  * @tparam B the type of the [[TransformLike]]
+  * @param targets the set of transforms that should be run
+  * @param currentState the set of transforms that have been run
+  * @param knownObjects existing transform objects that have already been constructed
+  */
+abstract class DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]](
+  val targets: Set[Class[B]],
+  val currentState: Set[Class[B]],
+  val knownObjects: Set[B]) extends TransformLike[A] with DependencyAPI[B]  {
+
+  /** Store of conversions between classes and objects. Objects that do not exist in the map will be lazily constructed.
+    */
+  protected lazy val classToObject: HashMap[Class[B], B] = {
+    val init = HashMap[Class[B], B](knownObjects.map(x => x.getClass.asInstanceOf[Class[B]] -> x).toSeq: _*)
+    (targets ++ currentState)
+      .filter(!init.contains(_))
+      .map(x => init(x) = safeConstruct(x))
+    init
+  }
+
+  /** A method that will create a copy of this [[DependencyManager]], but with different requirements. This is used by
+    * this [[DependencyManager]] to solve sub-problems arising from invalidations.
+    */
+  protected def copy(
+    targets: Set[Class[B]],
+    currentState: Set[Class[B]],
+    knownObjects: Set[B] = classToObject.values.toSet): B
+
+  /** Implicit conversion from Class[B] to B */
+  private implicit def cToO(c: Class[B]): B = classToObject.getOrElseUpdate(c, safeConstruct(c))
+
+  /** Implicit conversion from B to Class[B] */
+  private implicit def oToC(b: B): Class[B] = b.getClass.asInstanceOf[Class[B]]
+
+  /** Modified breadth-first search that supports multiple starting nodes and a custom extractor that can be used to
+    * generate/filter the edges to explore. Additionally, this will include edges to previously discovered nodes.
+    */
+  private def bfs( start: Set[Class[B]],
+                   blacklist: Set[Class[B]],
+                   extractor: B => Set[Class[B]] ): LinkedHashMap[B, LinkedHashSet[B]] = {
+
+    val (queue, edges) = {
+      val a: Queue[Class[B]]                    = Queue(start.toSeq:_*)
+      val b: LinkedHashMap[B, LinkedHashSet[B]] = LinkedHashMap[B, LinkedHashSet[B]](
+        start.map((cToO(_) -> LinkedHashSet[B]())).toSeq:_*)
+      (a, b)
+    }
+
+    while (queue.nonEmpty) {
+      val u: Class[B] = queue.dequeue
+      for (v: Class[B] <- extractor(classToObject(u))) {
+        if (!blacklist.contains(v) && !edges.contains(v)) {
+          queue.enqueue(v)
+        }
+        if (!edges.contains(v)) {
+          val obj = cToO(v)
+          edges(obj) = LinkedHashSet.empty
+          classToObject += (v -> obj)
+        }
+        edges(classToObject(u)) = edges(classToObject(u)) + classToObject(v)
+      }
+    }
+
+    edges
+  }
+
+  /** Pull in all registered [[TransformLike]] once [[TransformLike]] registration is integrated
+    * @todo implement this
+    */
+  private lazy val registeredTransforms: Set[B] = Set.empty
+
+  /** A directed graph consisting of prerequisite edges */
+  private lazy val prerequisiteGraph: DiGraph[B] = {
+    val edges = bfs(
+      start = targets,
+      blacklist = currentState,
+      extractor = (p: B) => p.prerequisites)
+    DiGraph(edges)
+  }
+
+  /** A directed graph of consisting of dependent edges */
+  private lazy val dependentsGraph: DiGraph[B] = {
+    val v = prerequisiteGraph.getVertices
+    DiGraph(v.map(vv => vv -> (vv.dependents.map(cToO) & v)).toMap).reverse
+  }
+
+  /** A directed graph consisting of all prerequisites, including prerequisites derived from dependents */
+  lazy val dependencyGraph: DiGraph[B] = prerequisiteGraph + dependentsGraph
+
+  /** A directed graph consisting of invalidation edges */
+  lazy val invalidateGraph: DiGraph[B] = {
+    val v = dependencyGraph.getVertices
+    DiGraph(
+      bfs(
+        start = targets,
+        blacklist = currentState,
+        extractor = (p: B) => v.filter(p.invalidates).map(_.asClass).toSet))
+      .reverse
+  }
+
+  /** Wrap a possible [[CyclicException]] thrown by a thunk in a [[DependencyManagerException]] */
+  private def cyclePossible[A](a: String, thunk: => A): A = try { thunk } catch {
+    case e: CyclicException =>
+      throw new DependencyManagerException(
+        s"No transform ordering possible due to cyclic dependency in $a at node '${e.node}'.", e)
+  }
+
+  /** Wrap an [[IllegalAccessException]] due to attempted object construction in a [[DependencyManagerException]] */
+  private def safeConstruct[A](a: Class[A]): A = try { a.newInstance } catch {
+    case e: IllegalAccessException => throw new DependencyManagerException(
+      s"Failed to construct '$a'! (Did you try to construct an object?)", e)
+    case e: InstantiationException => throw new DependencyManagerException(
+      s"Failed to construct '$a'! (Did you try to construct an inner class?)" , e)
+  }
+
+  /** An ordering of [[TransformLike]]s that causes the requested [[DependencyManager.targets targets]] to be executed
+    * starting from the [[DependencyManager.currentState currentState]]. This ordering respects prerequisites,
+    * dependents, and invalidates of all constituent [[TransformLike]]s. This uses an algorithm that attempts to reduce
+    * the number of re-lowerings due to invalidations. Re-lowerings are implemented as new [[DependencyManager]]s.
+    * @throws DependencyManagerException if a cycle exists in either the [[DependencyManager.dependencyGraph
+    * dependencyGraph]] or the [[DependencyManager.invalidateGraph invalidateGraph]].
+    */
+  lazy val transformOrder: Seq[B] = {
+
+    /* Topologically sort the dependency graph using the invalidate graph topological sort as a seed. This has the effect of
+     * reducing (perhaps minimizing?) the number of work re-lowerings.
+     */
+    val sorted = {
+      val seed = cyclePossible("invalidates", invalidateGraph.linearize).reverse
+      cyclePossible("prerequisites",
+                    dependencyGraph
+                      .seededLinearize(Some(seed))
+                      .reverse
+                      .dropWhile(b => currentState.contains(b)))
+    }
+
+    val (state, lowerers) = {
+      /* [todo] Seq is inefficient here, but Array has ClassTag problems. Use something else? */
+      val (s, l) = sorted.foldLeft((currentState, Seq[B]())){ case ((state, out), in) =>
+        val missing = (in.prerequisites -- state)
+        val preprocessing: Option[B] = {
+          if (missing.nonEmpty) { Some(this.copy(missing, state)) }
+          else                  { None                            }
+        }
+        ((state ++ missing + in).map(cToO).filterNot(in.invalidates).map(oToC), out ++ preprocessing :+ in)
+      }
+      val missing = (targets -- s)
+      val postprocessing: Option[B] = {
+        if (missing.nonEmpty) { Some(this.copy(missing, s)) }
+        else                  { None                        }
+      }
+
+      (s ++ missing, l ++ postprocessing)
+    }
+
+    if (!targets.subsetOf(state)) {
+      throw new DependencyManagerException(
+        s"The final state ($state) did not include the requested targets (${targets})!")
+    }
+    lowerers
+  }
+
+  /** A version of the [[DependencyManager.transformOrder transformOrder]] that flattens the transforms of any internal
+    * [[DependencyManager]]s.
+    */
+  lazy val flattenedTransformOrder: Seq[B] = transformOrder.flatMap {
+    case p: DependencyManager[A, B] => p.flattenedTransformOrder
+    case p => Some(p)
+  }
+
+  final def transform(annotations: A): A =
+    transformOrder
+      .foldLeft(annotations){ case (a, p) => p.transform(a) }
+
+  /** This colormap uses Colorbrewer's 4-class OrRd color scheme */
+  protected val colormap = Seq("#fef0d9", "#fdcc8a", "#fc8d59", "#d7301f")
+
+  /** Get a name of some [[TransformLike]] */
+  private def transformName(transform: B, suffix: String = ""): String = {
+    val a =
+      transform
+        .getClass
+        .getSimpleName
+
+    s""""$a$suffix""""
+  }
+
+  /** Convert all prerequisites, dependents, and invalidates to a Graphviz representation.
+    * @param file the name of the output file
+    */
+  def dependenciesToGraphviz: String = {
+
+    def toGraphviz(digraph: DiGraph[B], attributes: String = "", tab: String = "    "): Option[String] = {
+      val edges =
+        digraph
+          .getEdgeMap
+          .collect{ case (v, edges) if edges.nonEmpty => (v -> edges) }
+          .map{ case (v, edges) =>
+            s"""${transformName(v)} -> ${edges.map(e => transformName(e)).mkString("{ ", " ", " }")}""" }
+
+      if (edges.isEmpty) { None } else {
+        Some(
+          s"""|  { $attributes
+              |${edges.mkString(tab, "\n" + tab, "")}
+              |  }""".stripMargin
+        )
+      }
+    }
+
+    val connections =
+      Seq( (prerequisiteGraph, "edge []"),
+           (dependentsGraph,   "edge []"),
+           (invalidateGraph,   "edge [minlen=2,style=dashed,constraint=false]") )
+        .flatMap{ case (a, b) => toGraphviz(a, b) }
+        .mkString("\n")
+
+    s"""|digraph DependencyManager {
+        |  graph [rankdir=BT]
+        |  node [fillcolor="${colormap(0)}",style=filled,shape=box]
+        |$connections
+        |}""".stripMargin
+  }
+
+  def transformOrderToGraphviz(colormap: Seq[String] = colormap): String = {
+
+    def rotate[A](a: Seq[A]): Seq[A] = a match {
+      case Nil => Nil
+      case car :: cdr => cdr :+ car
+      case car => car
+    }
+
+    val sorted = ArrayBuffer.empty[String]
+
+    def rec(pm: DependencyManager[A, B], cm: Seq[String], tab: String = "", id: Int = 0): (String, Int) = {
+      var offset = 0
+
+      val header = s"""|${tab}subgraph cluster_$id {
+                       |$tab  label="target=${pm.targets}, state=${pm.currentState}"
+                       |$tab  labeljust=r
+                       |$tab  node [fillcolor="${cm.head}"]""".stripMargin
+
+      val body = pm.transformOrder.map{
+        case a: DependencyManager[A, B] =>
+          val (str, d) = rec(a, rotate(cm), tab + "  ", id + 1 + offset)
+          offset += d
+          str
+        case a =>
+          val name = s"""${transformName(a, "_" + id)}"""
+          sorted += name
+          s"""$tab  $name"""
+      }.mkString("\n")
+
+      (Seq(header, body, s"$tab}").mkString("\n"), id + offset)
+    }
+
+    s"""|digraph DependencyManagerTransformOrder {
+        |  graph [rankdir=TB]
+        |  node [style=filled,shape=box]
+        |${rec(this, colormap, "  ")._1}
+        |  ${sorted.mkString(" -> ")}
+        |}""".stripMargin
+  }
+
+}
+
+/** A [[Phase]] that will ensure that some other [[Phase]]s and their prerequisites are executed.
+  *
+  * This tries to determine a phase ordering such that an [[AnnotationSeq]] ''output'' is produced that has had all of
+  * the requested [[Phase]] target transforms run without having them be invalidated.
+  * @param targets the [[Phase]]s you want to run
+  */
+class PhaseManager(
+  targets: Set[Class[Phase]],
+  currentState: Set[Class[Phase]] = Set.empty,
+  knownObjects: Set[Phase] = Set.empty)
+    extends DependencyManager[AnnotationSeq, Phase](targets, currentState, knownObjects) with Phase {
+
+  protected def copy(a: Set[Class[Phase]], b: Set[Class[Phase]], c: Set[Phase]) = new PhaseManager(a, b, c)
+
+}

--- a/src/main/scala/firrtl/options/Phase.scala
+++ b/src/main/scala/firrtl/options/Phase.scala
@@ -57,6 +57,15 @@ trait DependencyAPI[A <: DependencyAPI[A]] {
 
 }
 
+/** A trait indicating that no invalidations occur, i.e., all previous transforms are preserved
+  * @tparam A some [[TransformLike]]
+  */
+trait PreservesAll[A <: DependencyAPI[A]] extends DependencyAPI[A] {
+
+  override def invalidates(a: A): Boolean = false
+
+}
+
 /** A mathematical transformation of an [[AnnotationSeq]].
   *
   * A [[Phase]] forms one unit in the Chisel/FIRRTL Hardware Compiler Framework (HCF). The HCF is built from a sequence

--- a/src/main/scala/firrtl/stage/phases/AddCircuit.scala
+++ b/src/main/scala/firrtl/stage/phases/AddCircuit.scala
@@ -5,7 +5,7 @@ package firrtl.stage.phases
 import firrtl.stage._
 
 import firrtl.{AnnotationSeq, Parser, proto}
-import firrtl.options.{OptionsException, Phase, PhasePrerequisiteException}
+import firrtl.options.{OptionsException, Phase, PhasePrerequisiteException, PreservesAll}
 
 /** [[firrtl.options.Phase Phase]] that expands [[FirrtlFileAnnotation]]/[[FirrtlSourceAnnotation]] into
   * [[FirrtlCircuitAnnotation]]s and deletes the originals. This is part of the preprocessing done on an input
@@ -25,7 +25,9 @@ import firrtl.options.{OptionsException, Phase, PhasePrerequisiteException}
   * an [[InfoModeAnnotation]].'''.
   * @define infoModeException firrtl.options.PhasePrerequisiteException if no [[InfoModeAnnotation]] is present
   */
-class AddCircuit extends Phase {
+class AddCircuit extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites: Set[Class[Phase]] = Set(classOf[AddDefaults], classOf[Checks])
 
   /** Extract the info mode from an [[AnnotationSeq]] or use the default info mode if no annotation exists
     * @param annotations some annotations

--- a/src/main/scala/firrtl/stage/phases/AddDefaults.scala
+++ b/src/main/scala/firrtl/stage/phases/AddDefaults.scala
@@ -3,14 +3,14 @@
 package firrtl.stage.phases
 
 import firrtl.AnnotationSeq
-import firrtl.options.{Phase, TargetDirAnnotation}
+import firrtl.options.{Phase, PreservesAll, TargetDirAnnotation}
 import firrtl.transforms.BlackBoxTargetDirAnno
 import firrtl.stage.{CompilerAnnotation, InfoModeAnnotation, FirrtlOptions}
 
 /** [[firrtl.options.Phase Phase]] that adds default [[FirrtlOption]] [[firrtl.annotations.Annotation Annotation]]s.
   * This is a part of the preprocessing done by [[FirrtlStage]].
   */
-class AddDefaults extends Phase {
+class AddDefaults extends Phase with PreservesAll[Phase] {
 
   /** Append any missing default annotations to an annotation sequence */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/stage/phases/AddImplicitEmitter.scala
+++ b/src/main/scala/firrtl/stage/phases/AddImplicitEmitter.scala
@@ -4,12 +4,14 @@ package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, EmitAnnotation, EmitCircuitAnnotation}
 import firrtl.stage.{CompilerAnnotation, RunFirrtlTransformAnnotation}
-import firrtl.options.Phase
+import firrtl.options.{Phase, PreservesAll}
 
 /** [[firrtl.options.Phase Phase]] that adds a [[firrtl.EmitCircuitAnnotation EmitCircuitAnnotation]] derived from a
   * [[firrtl.stage.CompilerAnnotation CompilerAnnotation]] if one does not already exist.
   */
-class AddImplicitEmitter extends Phase {
+class AddImplicitEmitter extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites: Set[Class[Phase]] = Set(classOf[AddDefaults])
 
   def transform(annos: AnnotationSeq): AnnotationSeq = {
     val emitter = annos.collectFirst{ case a: EmitAnnotation => a }

--- a/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
+++ b/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
@@ -3,7 +3,7 @@
 package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, EmitAllModulesAnnotation}
-import firrtl.options.{Phase, Viewer}
+import firrtl.options.{Phase, PreservesAll, Viewer}
 import firrtl.stage.{FirrtlCircuitAnnotation, FirrtlOptions, OutputFileAnnotation}
 
 /** [[firrtl.options.Phase Phase]] that adds an [[OutputFileAnnotation]] if one does not already exist.
@@ -18,7 +18,9 @@ import firrtl.stage.{FirrtlCircuitAnnotation, FirrtlOptions, OutputFileAnnotatio
   * @note This [[firrtl.options.Phase Phase]] has a dependency on [[AddCircuit]]. Only a [[FirrtlCircuitAnnotation]]
   * will be used to implicitly set the [[OutputFileAnnotation]] (not other [[CircuitOption]] subclasses).
   */
-class AddImplicitOutputFile extends Phase {
+class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites: Set[Class[Phase]] = Set(classOf[AddCircuit])
 
   /** Add an [[OutputFileAnnotation]] to an [[AnnotationSeq]] */
   def transform(annotations: AnnotationSeq): AnnotationSeq =

--- a/src/main/scala/firrtl/stage/phases/Checks.scala
+++ b/src/main/scala/firrtl/stage/phases/Checks.scala
@@ -6,7 +6,7 @@ import firrtl.stage._
 
 import firrtl.{AnnotationSeq, EmitAllModulesAnnotation, EmitCircuitAnnotation}
 import firrtl.annotations.Annotation
-import firrtl.options.{OptionsException, Phase, StageUtils}
+import firrtl.options.{OptionsException, Phase, PreservesAll, StageUtils}
 
 /** [[firrtl.options.Phase Phase]] that strictly validates an [[AnnotationSeq]]. The checks applied are intended to be
   * extremeley strict. Nothing is inferred or assumed to take a default value (for default value resolution see
@@ -16,7 +16,9 @@ import firrtl.options.{OptionsException, Phase, StageUtils}
   * certain that other [[firrtl.options.Phase Phase]]s or views will succeed. See [[FirrtlStage]] for a list of
   * [[firrtl.options.Phase Phase]] that commonly run before this.
   */
-class Checks extends Phase {
+class Checks extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites: Set[Class[Phase]] = Set(classOf[AddDefaults], classOf[AddImplicitEmitter])
 
   /** Determine if annotations are sane
     *

--- a/src/main/scala/firrtl/stage/phases/Compiler.scala
+++ b/src/main/scala/firrtl/stage/phases/Compiler.scala
@@ -3,7 +3,7 @@
 package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, ChirrtlForm, CircuitState, Compiler => FirrtlCompiler, Transform, seqToAnnoSeq}
-import firrtl.options.{Phase, PhasePrerequisiteException, Translator}
+import firrtl.options.{Phase, PhasePrerequisiteException, PreservesAll, Translator}
 import firrtl.stage.{CircuitOption, CompilerAnnotation, FirrtlOptions, FirrtlCircuitAnnotation,
   RunFirrtlTransformAnnotation}
 
@@ -42,7 +42,14 @@ private [stage] case class Defaults(
   * FirrtlCircuitAnnotation(y). Note: A(b) ''may'' overwrite A(a) if this is a CompilerAnnotation.
   * FirrtlCircuitAnnotation(z) has no annotations, so it only gets the default A(a).
   */
-class Compiler extends Phase with Translator[AnnotationSeq, Seq[CompilerRun]] {
+class Compiler extends Phase with Translator[AnnotationSeq, Seq[CompilerRun]] with PreservesAll[Phase] {
+
+  override val prerequisites: Set[Class[Phase]] =
+    Set(classOf[AddDefaults],
+        classOf[AddImplicitEmitter],
+        classOf[Checks],
+        classOf[AddCircuit],
+        classOf[AddImplicitOutputFile])
 
   /** Convert an [[AnnotationSeq]] into a sequence of compiler runs. */
   protected def aToB(a: AnnotationSeq): Seq[CompilerRun] = {

--- a/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
+++ b/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
@@ -7,8 +7,8 @@ import firrtl.stage._
 import firrtl.{AnnotationSeq, EmitAllModulesAnnotation, EmitCircuitAnnotation, FirrtlExecutionResult, Parser}
 import firrtl.annotations.NoTargetAnnotation
 import firrtl.proto.FromProto
-import firrtl.options.{HasShellOptions, InputAnnotationFileAnnotation, OptionsException, Phase, ShellOption,
-  StageOptions, StageUtils}
+import firrtl.options.{HasShellOptions, InputAnnotationFileAnnotation, OptionsException, Phase, PreservesAll,
+  ShellOption, StageOptions, StageUtils}
 import firrtl.options.Viewer
 
 import scopt.OptionParser
@@ -120,7 +120,11 @@ object DriverCompatibility {
     * @param annos input annotations
     * @return output annotations
     */
-  class AddImplicitAnnotationFile extends Phase {
+  class AddImplicitAnnotationFile extends Phase with PreservesAll[Phase] {
+
+    override val prerequisites: Set[Class[Phase]] = Set(classOf[AddImplicitFirrtlFile])
+
+    override val dependents: Set[Class[Phase]] = Set(classOf[FirrtlStage])
 
     /** Try to add an [[InputAnnotationFileAnnotation]] implicitly specified by an [[AnnotationSeq]]. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = annotations
@@ -154,7 +158,9 @@ object DriverCompatibility {
     * @param annotations input annotations
     * @return
     */
-  class AddImplicitFirrtlFile extends Phase {
+  class AddImplicitFirrtlFile extends Phase with PreservesAll[Phase] {
+
+    override val dependents: Set[Class[Phase]] = Set(classOf[FirrtlStage])
 
     /** Try to add a [[FirrtlFileAnnotation]] implicitly specified by an [[AnnotationSeq]]. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {
@@ -181,7 +187,9 @@ object DriverCompatibility {
     */
   @deprecated("""AddImplicitEmitter should only be used to build Driver compatibility wrappers. Switch to Stage.""",
               "1.2")
-  class AddImplicitEmitter extends Phase {
+  class AddImplicitEmitter extends Phase with PreservesAll[Phase] {
+
+    override val dependents: Set[Class[Phase]] = Set(classOf[FirrtlStage])
 
     /** Add one [[EmitAnnotation]] foreach [[CompilerAnnotation]]. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {
@@ -203,7 +211,11 @@ object DriverCompatibility {
     */
   @deprecated("""AddImplicitOutputFile should only be used to build Driver compatibility wrappers. Switch to Stage.""",
               "1.2")
-  class AddImplicitOutputFile extends Phase {
+  class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
+
+    override val prerequisites: Set[Class[Phase]] = Set(classOf[AddImplicitFirrtlFile])
+
+    override val dependents: Set[Class[Phase]] = Set(classOf[FirrtlStage])
 
     /** Add an [[OutputFileAnnotation]] derived from a [[TopNameAnnotation]] if needed. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
+++ b/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
@@ -3,7 +3,7 @@
 package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, EmittedModuleAnnotation, EmittedCircuitAnnotation}
-import firrtl.options.{Phase, StageOptions, Viewer}
+import firrtl.options.{Phase, PreservesAll, StageOptions, Viewer}
 import firrtl.stage.FirrtlOptions
 
 import java.io.PrintWriter
@@ -24,7 +24,9 @@ import java.io.PrintWriter
   *
   * Any annotations written to files will be deleted.
   */
-class WriteEmitted extends Phase {
+class WriteEmitted extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites: Set[Class[Phase]] = Set(classOf[Compiler])
 
   /** Write any [[EmittedAnnotation]]s in an [[AnnotationSeq]] to files. Written [[EmittedAnnotation]]s are deleted. */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/test/scala/firrtlTests/options/PhaseManagerSpec.scala
+++ b/src/test/scala/firrtlTests/options/PhaseManagerSpec.scala
@@ -1,0 +1,338 @@
+// See LICENSE for license details.
+
+package firrtlTests.options
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import firrtl.AnnotationSeq
+import firrtl.options.{DependencyManagerException, Phase, PhaseManager}
+import firrtl.annotations.{Annotation, NoTargetAnnotation}
+
+import java.io.{File, PrintWriter}
+
+import sys.process._
+
+trait IdentityPhase extends Phase {
+  def transform(annotations: AnnotationSeq): AnnotationSeq = annotations
+}
+
+/** Default [[Phase]] that has no prerequisites and invalidates nothing */
+class A extends IdentityPhase {
+
+  override def invalidates(phase: Phase): Boolean = false
+}
+
+/** [[Phase]] that requires [[A]] and invalidates nothing */
+class B extends IdentityPhase {
+  override def prerequisites: Set[Class[Phase]] = Set(classOf[A])
+  override def invalidates(phase: Phase): Boolean = false
+}
+
+/** [[Phase]] that requires [[B]] and invalidates nothing */
+class C extends IdentityPhase {
+  override def prerequisites: Set[Class[Phase]] = Set(classOf[A])
+  override def invalidates(phase: Phase): Boolean = false
+}
+
+/** [[Phase]] that requires [[A]] and invalidates [[A]] */
+class D extends IdentityPhase {
+  override def prerequisites: Set[Class[Phase]] = Set(classOf[A])
+  override def invalidates(phase: Phase): Boolean = phase match {
+    case _: A => true
+    case _ => false
+  }
+}
+
+/** [[Phase]] that requires [[B]] and invalidates nothing */
+class E extends IdentityPhase {
+  override def prerequisites: Set[Class[Phase]] = Set(classOf[B])
+  override def invalidates(phase: Phase): Boolean = false
+}
+
+/** [[Phase]] that requires [[B]] and [[C]] and invalidates [[E]] */
+class F extends IdentityPhase {
+  override def prerequisites: Set[Class[Phase]] = Set(classOf[B], classOf[C])
+  override def invalidates(phase: Phase): Boolean = phase match {
+    case _: E => true
+    case _ => false
+  }
+}
+
+
+/** [[Phase]] that requires [[C]] and invalidates [[F]] */
+class G extends IdentityPhase {
+  override def prerequisites: Set[Class[Phase]] = Set(classOf[C])
+  override def invalidates(phase: Phase): Boolean = phase match {
+    case _: F => true
+    case _ => false
+  }
+}
+
+class CyclicA extends IdentityPhase {
+  override def prerequisites: Set[Class[Phase]] = Set(classOf[CyclicB])
+}
+
+class CyclicB extends IdentityPhase {
+  override def prerequisites: Set[Class[Phase]] = Set(classOf[CyclicA])
+}
+
+object CyclicInvalidateFixture {
+
+  class A extends IdentityPhase {
+    override def invalidates(phase: Phase): Boolean = false
+  }
+  class B extends IdentityPhase {
+    override def prerequisites: Set[Class[Phase]] = Set(classOf[A])
+    override def invalidates(phase: Phase): Boolean = false
+  }
+  class C extends IdentityPhase {
+    override def prerequisites: Set[Class[Phase]] = Set(classOf[A])
+    override def invalidates(phase: Phase): Boolean = phase match {
+      case _: B => true
+      case _ => false
+    }
+  }
+  class D extends IdentityPhase {
+    override def prerequisites: Set[Class[Phase]] = Set(classOf[B])
+    override def invalidates(phase: Phase): Boolean = phase match {
+      case _: C | _: E => true
+      case _ => false
+    }
+  }
+  class E extends IdentityPhase {
+    override def prerequisites: Set[Class[Phase]] = Set(classOf[B])
+    override def invalidates(phase: Phase): Boolean = false
+  }
+
+}
+
+object RepeatedAnalysisFixture {
+
+  trait InvalidatesAnalysis extends IdentityPhase {
+    override def invalidates(phase: Phase): Boolean = phase match {
+      case _: Analysis => true
+      case _ => false
+    }
+  }
+
+  class Analysis extends IdentityPhase {
+    override def invalidates(phase: Phase): Boolean = false
+  }
+  class A extends InvalidatesAnalysis {
+    override def prerequisites: Set[Class[Phase]] = Set(classOf[Analysis])
+  }
+  class B extends InvalidatesAnalysis {
+    override def prerequisites: Set[Class[Phase]] = Set(classOf[A], classOf[Analysis])
+  }
+  class C extends InvalidatesAnalysis {
+    override def prerequisites: Set[Class[Phase]] = Set(classOf[B], classOf[Analysis])
+  }
+
+}
+
+object InvertedAnalysisFixture {
+
+  class Analysis extends IdentityPhase {
+    override def invalidates(phase: Phase): Boolean = false
+  }
+  class A extends IdentityPhase {
+    override def prerequisites: Set[Class[Phase]] = Set(classOf[Analysis])
+    override def invalidates(phase: Phase): Boolean = phase match {
+      case _: Analysis => true
+      case _ => false
+    }
+  }
+  class B extends IdentityPhase {
+    override def prerequisites: Set[Class[Phase]] = Set(classOf[Analysis])
+    override def invalidates(phase: Phase): Boolean = phase match {
+      case _: Analysis | _: A => true
+      case _ => false
+    }
+  }
+  class C extends IdentityPhase {
+    override def prerequisites: Set[Class[Phase]] = Set(classOf[Analysis])
+    override def invalidates(phase: Phase): Boolean = phase match {
+      case _: Analysis | _: B => true
+      case _ => false
+    }
+  }
+
+}
+
+object DependentsFixture {
+
+  class First extends IdentityPhase {
+    override def invalidates(phase: Phase): Boolean = false
+  }
+
+  class Second extends IdentityPhase {
+    override val prerequisites: Set[Class[Phase]] = Set(classOf[First])
+    override def invalidates(phase: Phase): Boolean = false
+  }
+
+  /* This models a situation where a user has a custom Phase that they need to run before some other Phase. This is an
+   * abstract example of writing a Transform that cleans up combinational loops. This needs to run before combinational
+   * loop detection.
+   */
+  class Custom extends IdentityPhase {
+    override val prerequisites: Set[Class[Phase]] = Set(classOf[First])
+    override val dependents: Set[Class[Phase]] = Set(classOf[Second])
+    override def invalidates(phase: Phase): Boolean = false
+  }
+
+}
+
+class PhaseManagerSpec extends FlatSpec with Matchers {
+
+  def writeGraphviz(pm: PhaseManager, dir: String): Unit = {
+
+    /** Convert a Graphviz file to PNG using */
+    def maybeToPng(f: File): Unit = try {
+      s"dot -Tpng -O ${f}" !
+    } catch {
+      case _: java.io.IOException =>
+    }
+
+    val d = new File(dir)
+    d.mkdirs()
+
+    {
+      val f = new File(d + "/dependencyGraph.dot")
+      val w = new PrintWriter(f)
+      w.write(pm.dependenciesToGraphviz)
+      w.close
+      maybeToPng(f)
+    }
+
+    {
+      val f = new File(d + "/transformOrder.dot")
+      val w = new PrintWriter(new File(d + "/transformOrder.dot"))
+      try {
+        w.write(pm.transformOrderToGraphviz())
+        w.close
+        maybeToPng(f)
+      } catch {
+        case _: DependencyManagerException =>
+      }
+    }
+
+  }
+
+  implicit def f(a: Class[_ <: Phase]): Class[Phase] = a.asInstanceOf[Class[Phase]]
+
+  behavior of this.getClass.getName
+
+  it should "do nothing if all targets are reached" in {
+    val targets: Set[Class[Phase]] = Set(classOf[A], classOf[B], classOf[C], classOf[D])
+    val pm = new PhaseManager(targets, targets)
+
+    pm.flattenedTransformOrder should be (empty)
+  }
+
+  it should "handle a simple dependency" in {
+    val targets: Set[Class[Phase]] = Set(classOf[B])
+    val order: Seq[Class[Phase]] = Seq(classOf[A], classOf[B])
+    val pm = new PhaseManager(targets)
+
+    writeGraphviz(pm, "test_run_dir/SimpleDependency")
+
+    pm.flattenedTransformOrder.map(_.asClass) should be (order)
+  }
+
+  it should "handle a simple dependency with an invalidation" in {
+    val targets: Set[Class[Phase]] = Set(classOf[A], classOf[B], classOf[C], classOf[D])
+    val order: Seq[Class[Phase]] = Seq(classOf[A], classOf[D], classOf[A], classOf[B], classOf[C])
+    val pm = new PhaseManager(targets)
+
+    writeGraphviz(pm, "test_run_dir/OneInvalidate")
+
+    pm.flattenedTransformOrder.map(_.asClass) should be (order)
+  }
+
+  it should "handle a dependency with two invalidates optimally" in {
+    val targets: Set[Class[Phase]] = Set(classOf[A], classOf[B], classOf[C], classOf[E], classOf[F], classOf[G])
+    val pm = new PhaseManager(targets)
+
+    writeGraphviz(pm, "test_run_dir/TwoInvalidates")
+
+    pm.flattenedTransformOrder.size should be (targets.size)
+  }
+
+  it should "throw an exception for cyclic prerequisites" in {
+    val targets: Set[Class[Phase]] = Set(classOf[CyclicA], classOf[CyclicB])
+    val pm = new PhaseManager(targets)
+
+    intercept[DependencyManagerException]{ pm.flattenedTransformOrder }
+      .getMessage should startWith ("No transform ordering possible")
+  }
+
+  it should "handle invalidates that form a cycle" in {
+    val f = CyclicInvalidateFixture
+    val targets: Set[Class[Phase]] = Set(classOf[f.A], classOf[f.B], classOf[f.C], classOf[f.D], classOf[f.E])
+      .map(_.asInstanceOf[Class[Phase]])
+    val pm = new PhaseManager(targets)
+
+    writeGraphviz(pm, "test_run_dir/CyclicInvalidate")
+
+    info("only one phase was recomputed")
+    pm.flattenedTransformOrder.size should be (targets.size + 1)
+  }
+
+  it should "handle repeated recomputed analyses" in {
+    val f = RepeatedAnalysisFixture
+    val targets: Set[Class[Phase]] = Set(classOf[f.A], classOf[f.B], classOf[f.C])
+      .map(_.asInstanceOf[Class[Phase]])
+    val order: Seq[Class[Phase]] =
+      Seq( classOf[f.Analysis],
+           classOf[f.A],
+           classOf[f.Analysis],
+           classOf[f.B],
+           classOf[f.Analysis],
+           classOf[f.C])
+        .map(_.asInstanceOf[Class[Phase]])
+    val pm = new PhaseManager(targets)
+
+    writeGraphviz(pm, "test_run_dir/RepeatedAnalysis")
+
+    pm.flattenedTransformOrder.map(_.asClass) should be (order)
+  }
+
+  it should "handle inverted repeated recomputed analyses" in {
+    val f = InvertedAnalysisFixture
+    val targets: Set[Class[Phase]] = Set(classOf[f.A], classOf[f.B], classOf[f.C])
+      .map(_.asInstanceOf[Class[Phase]])
+    val order: Seq[Class[Phase]] =
+      Seq( classOf[f.Analysis],
+           classOf[f.C],
+           classOf[f.Analysis],
+           classOf[f.B],
+           classOf[f.Analysis],
+           classOf[f.A])
+        .map(_.asInstanceOf[Class[Phase]])
+    val pm = new PhaseManager(targets)
+
+    writeGraphviz(pm, "test_run_dir/InvertedRepeatedAnalysis")
+
+    pm.flattenedTransformOrder.map(_.asClass) should be (order)
+  }
+
+  /** This test shows how the dependents member can be used to run one transform before another. */
+  it should "handle a custom Phase with a dependent" in {
+    val f = DependentsFixture
+
+    info("without the custom transform it runs: First -> Second")
+    val pm = new PhaseManager(Set(classOf[f.Second]).map(_.asInstanceOf[Class[Phase]]))
+    val orderNoCustom: Seq[Class[Phase]] = Seq(classOf[f.First], classOf[f.Second])
+      .map(_.asInstanceOf[Class[Phase]])
+    pm.flattenedTransformOrder.map(_.asClass) should be (orderNoCustom)
+
+    info("with the custom transform it runs:    First -> Custom -> Second")
+    val pmCustom = new PhaseManager(Set(classOf[f.Custom], classOf[f.Second]).map(_.asInstanceOf[Class[Phase]]))
+    val orderCustom: Seq[Class[Phase]] = Seq(classOf[f.First], classOf[f.Custom], classOf[f.Second])
+      .map(_.asInstanceOf[Class[Phase]])
+
+    writeGraphviz(pmCustom, "test_run_dir/SingleDependent")
+
+    pmCustom.flattenedTransformOrder.map(_.asClass) should be (orderCustom)
+  }
+}


### PR DESCRIPTION
This implements a Dependency API for `TransformLike[A]`. This adds a `DependencyAPI` trait, an abstract class `DependencyManager`, and a concrete `PhaseManager`. The `DependencyAPI` defines three types of "dependencies" that, by implementing, allow a user to defer determination of a valid ordering to a `DependencyManager`. 

Dependencies are defined in terms of:
  - *prerequisites* are transforms that should run before me
  - *dependents* are transforms that should run after me (a means of prerequisite injection)
  - *invalidates* are transforms which I invalidate (e.g., a transform that runs at low form, but emits high form constructs and requires re-lowering)

The `DependencyManager` can then be used to, given a set of transforms you want to run and a set of all transforms that have been run, determine a linear ordering of transforms that satisfy your requirements. This uses uses the same algorithm proposed by @azidar in https://github.com/freechipsproject/firrtl/issues/446#issuecomment-300573107 with the exception of seeding the topological sort with information from a topological sort of the invalidates. This results in a more optimal solution that seems to minimize the number of repeated `Phase`s. Re-lowerings are handled by creating a new `DependencyManager` to solve the lowering sub-problem. 

This PR then adds dependencies to `firrtl.stage.phases` and modifies `FirrtlStage` to be implemented using a `PhaseManager` under the hood.

This includes a modification to `DiGraph` that allows for seeding the topological sort to get the necessary better linearization solution.

In preparation for using `DependencyManager` for FIRRTL transform scheduling, this makes `Transform` extend `TransformLike[CircuitState]`. 

META:
- Depends on #1005 
- Fixes #948 
- Related to #446 

TODO:
- [x] Switch to `Class[A]` instead of `A` for dependencies

## Examples

The examples below show examples of how different combinations of dependencies interact and are resolved. This uses built-in `DependencyManager` methods for generating graphviz output.

### Simple Dependency

![dependencygraph dot](https://user-images.githubusercontent.com/1018530/52882820-e0249680-3136-11e9-9e98-4c58db7b2ad5.png)
![phaseorder dot](https://user-images.githubusercontent.com/1018530/52882824-e286f080-3136-11e9-8a1e-d75cffcc7c9f.png)

### One Invalidate

![dependencygraph dot](https://user-images.githubusercontent.com/1018530/52882836-edda1c00-3136-11e9-9fe5-4b0ed9884679.png)
![phaseorder dot](https://user-images.githubusercontent.com/1018530/52882841-f16da300-3136-11e9-8cfc-cd6c50d9c723.png)

### Two Invalidates

There are many valid solutions here. However, many of the solutions result in repeated re-lowerings. The algorithm proposed seems to minimize this and choose a good solution.

![dependencygraph dot](https://user-images.githubusercontent.com/1018530/52882853-fe8a9200-3136-11e9-9721-a84e2e52107b.png)
![phaseorder dot](https://user-images.githubusercontent.com/1018530/52882859-021e1900-3137-11e9-9ba2-fc22d8ba296d.png)

### Repeated Analysis Phase

![dependencygraph dot](https://user-images.githubusercontent.com/1018530/52882868-0b0eea80-3137-11e9-8f4e-c6db5268af40.png)
![phaseorder dot](https://user-images.githubusercontent.com/1018530/52882873-0ea27180-3137-11e9-99ed-4f3e6822f5cc.png)

### Repeated Analysis with Invalidates

![dependencygraph dot](https://user-images.githubusercontent.com/1018530/52882892-21b54180-3137-11e9-90cb-7240996c2674.png)
![phaseorder dot](https://user-images.githubusercontent.com/1018530/52882898-2548c880-3137-11e9-84d1-398d8c2b00b8.png)

### Invalidation Creates a Cycle

![dependencygraph dot](https://user-images.githubusercontent.com/1018530/52882921-309bf400-3137-11e9-8f94-836b537b8b9c.png)
![phaseorder dot](https://user-images.githubusercontent.com/1018530/52882927-32fe4e00-3137-11e9-9989-260a336b0f87.png)

### Custom Transform Needing to Run *Before* Something Else

This is intended to model the @stevenmburns case of needing to run a custom transform *before* something else. Similarly, this is the same thing as what #446 is talking about. The major difference from the previous examples is that this defines the `dependents` for the custom transform.

```scala
class First extends IdentityPhase {
  override def invalidates(phase: Phase): Boolean = false
}

class Second extends IdentityPhase {
  override val prerequisites: Set[Class[Phase]] = Set(classOf[First])
  override def invalidates(phase: Phase): Boolean = false
}

class Custom extends IdentityPhase {
  override val prerequisites: Set[Class[Phase]] = Set(classOf[First])
  override val dependents: Set[Class[Phase]] = Set(classOf[Second])
  override def invalidates(phase: Phase): Boolean = false
}

implicit def f(a: Class[_ <: Phase]): Class[Phase] = a.asInstanceOf[Class[Phase]]
new PhaseManager(Set(classOf[Custom], classOf[Second]).map(_.asInstanceOf[Class[Phase]]))
  .flattenedPhaseOrder.map(_.asClass) should be (Set(classOf[First], classOf[Custom], classOf[Second]))
```

![dependencygraph dot](https://user-images.githubusercontent.com/1018530/53253063-5fadea80-368e-11e9-95bc-e2c8e0600585.png)
![phaseorder dot](https://user-images.githubusercontent.com/1018530/53253064-5fadea80-368e-11e9-9734-be80c743477c.png)

### FIRRTL Stage

This PR additionally swings `FirrtlStage` to use the Dependency API. This allows you to be very terse with the expression of what `FirrtlStage` needs to do:

```scala
  private val phases: Seq[Phase] = PhaseManager(Set(firrtl.stage.phases.WriteEmitted))
    .transformOrder
    .map(DeletedWrapper(_))
```

The dependency graph then looks like (and note that this is a much simpler use case than some of the examples above):

![firrtlstage-dependencies dot](https://user-images.githubusercontent.com/1018530/56429645-aafd0780-6291-11e9-8efc-6e3880021f0b.png)

And the determined phase ordering is as follows:

![firrtlstage-order dot](https://user-images.githubusercontent.com/1018530/56429651-af292500-6291-11e9-91e7-434c4c672432.png)

