### PR TITLE
Prevent Flatten from stripping all annotations

### DIFF
--- a/src/main/scala/firrtl/transforms/Flatten.scala
+++ b/src/main/scala/firrtl/transforms/Flatten.scala
@@ -104,7 +104,7 @@ class Flatten extends Transform {
    override def execute(state: CircuitState): CircuitState = {
      val annos = state.annotations.collect { case a @ FlattenAnnotation(_) => a }
      annos match {
-       case Nil => CircuitState(state.circuit, state.form)
+       case Nil => state
        case myAnnotations =>
          val c = state.circuit
          val (modNames, instNames) = collectAnns(state.circuit, myAnnotations)

--- a/src/test/scala/firrtlTests/FlattenTests.scala
+++ b/src/test/scala/firrtlTests/FlattenTests.scala
@@ -224,4 +224,14 @@ class FlattenTests extends LowTransformSpec {
           |    b <= a""".stripMargin
      execute(input, check, Seq(flatten("Inline1")))
   }
+  "The Flatten transform" should "do nothing if no flatten annotations are present" in{
+    val input =
+      """|circuit Foo:
+         |  module Foo:
+         |    input a: UInt<1>
+         |    output b: UInt<1>
+         |    b <= a
+         |""".stripMargin
+    execute(input, input, Seq.empty)
+  }
 }


### PR DESCRIPTION
Flatten was stripping annotations if it didn't find any flatten annotations. 

Fixes #1019.