### PR TITLE
Added mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,23 @@
+pull_request_rules:
+  - name: remove outdated reviews
+    conditions:
+      - base=master
+    actions:
+      dismiss_reviews:
+
+pull_request_rules:
+  - name: automatic squash-and-merge on CI success and review
+    conditions:
+      - status-success=continuous-integration/travis-ci/pr
+      - "#approved-reviews-by>=1"
+      - "#review-requested=0"
+      - "#changes-requested-reviews-by=0"
+      - "#commented-reviews-by=0"
+      - base=master
+      - label="Please Merge"
+      - label!="DO NOT MERGE"
+    actions:
+      merge:
+        method: squash
+        strict: smart
+        strict_method: merge


### PR DESCRIPTION
To start, this will allow mergify to do stuff only if the "Please Merge" label is present.

When merging, it will queue up the "Please Merge" PRs, and for each, merge when updating the PR to master, and the squash-and-merge when upstreaming the PR.

We can think about (1) rebasing onto master or (2) making mergify the default (not need the "Please Merge" label) for merging things that are approved.