### PR TITLE
Change mergify to just require an approval

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,9 +10,6 @@ pull_request_rules:
     conditions:
       - status-success=continuous-integration/travis-ci/pr
       - "#approved-reviews-by>=1"
-      - "#review-requested=0"
-      - "#changes-requested-reviews-by=0"
-      - "#commented-reviews-by=0"
       - base=master
       - label="Please Merge"
       - label!="DO NOT MERGE"


### PR DESCRIPTION
Previously would require all requested reviewers must have approved a PR before merging.