### PR TITLE
Detect and error on registers with flip in type

### DIFF
--- a/src/test/scala/firrtlTests/CheckSpec.scala
+++ b/src/test/scala/firrtlTests/CheckSpec.scala
@@ -10,7 +10,7 @@ import firrtl.ir.Circuit
 import firrtl.passes.{Pass,ToWorkingIR,CheckHighForm,ResolveKinds,InferTypes,CheckTypes,PassException,InferWidths,CheckWidths,ResolveGenders,CheckGenders}
 
 class CheckSpec extends FlatSpec with Matchers {
-  "Connecting bundles of different types" should "throw an exception" in {
+  "Memories with flip in the data type" should "throw an exception" in {
     val passes = Seq(
       ToWorkingIR,
       CheckHighForm)
@@ -28,6 +28,26 @@ class CheckSpec extends FlatSpec with Matchers {
       }
     }
   }
+
+  "Registers with flip in the type" should "throw an exception" in {
+    val passes = Seq(
+      ToWorkingIR,
+      CheckHighForm)
+    val input =
+      """circuit Unit :
+        |  module Unit :
+        |    input clk : Clock
+        |    input in : UInt<32>
+        |    output out : UInt<32>
+        |    reg r : {a : UInt<32>, flip b : UInt<32>}, clk
+        |    out <= in""".stripMargin
+    intercept[CheckHighForm.RegWithFlipException] {
+      passes.foldLeft(Parser.parse(input.split("\n").toIterator)) {
+        (c: Circuit, p: Pass) => p.run(c)
+      }
+    }
+  }
+
   "Instance loops a -> b -> a" should "be detected" in {
     val passes = Seq(
       ToWorkingIR,


### PR DESCRIPTION
Thanks @edwardcwang for discovering that this doesn't error.

It's not in `CheckChirrtl` for now, but there are quite a few error checks that aren't duplicated in `CheckChirrtl`. I can add that too, but maybe syncing these up with an extra `CheckHighForm` after `ChirrtlToHighFirrtl` would be the right call? 