### PR TITLE
FIRRTL Bug - WVoid leaks from ExpandWhens

### DIFF
--- a/src/main/scala/firrtl/passes/ExpandWhens.scala
+++ b/src/main/scala/firrtl/passes/ExpandWhens.scala
@@ -48,6 +48,12 @@ object ExpandWhens extends Pass {
     Circuit(c.info, modulesx, c.main)
   }
 
+  /** Removes nodes in a module which have or depend on a void value which are never consumed
+    *
+    * @param m
+    * @param voidedNodes
+    * @return
+    */
   def removeVoidedNodes(m: Module, voidedNodes: Seq[DefNode]): DefModule = {
     val nodeNames = voidedNodes.map(_.name).toSet
     def removeNodes(s: Statement): Statement = s map removeNodes match {

--- a/src/main/scala/firrtl/passes/RemoveVoids.scala
+++ b/src/main/scala/firrtl/passes/RemoveVoids.scala
@@ -1,0 +1,5 @@
+package firrtl.passes
+
+class RemoveVoids {
+
+}

--- a/src/test/scala/firrtlTests/CheckInitializationSpec.scala
+++ b/src/test/scala/firrtlTests/CheckInitializationSpec.scala
@@ -24,7 +24,9 @@ class CheckInitializationSpec extends FirrtlFlatSpec {
      ExpandConnects,
      RemoveAccesses,
      ExpandWhens,
-     CheckInitialization)
+     CheckInitialization,
+     InferTypes
+  )
   "Missing assignment in consequence branch" should "trigger a PassException" in {
     val input =
       """circuit Test :
@@ -52,6 +54,21 @@ class CheckInitializationSpec extends FirrtlFlatSpec {
       passes.foldLeft(CircuitState(parse(input), UnknownForm)) {
         (c: CircuitState, p: Transform) => p.runTransform(c)
       }
+    }
+  }
+
+  "Assign after incomplete assignment" should "work" in {
+    val input =
+      """circuit Test :
+        |  module Test :
+        |    input p : UInt<1>
+        |    wire x : UInt<32>
+        |    when p :
+        |      x <= UInt(1)
+        |    x <= UInt(1)
+        |    """.stripMargin
+    passes.foldLeft(CircuitState(parse(input), UnknownForm)) {
+      (c: CircuitState, p: Transform) => p.runTransform(c)
     }
   }
   "Missing assignment to submodule port" should "trigger a PassException" in {


### PR DESCRIPTION
Interesting compiler bug found by @vighneshiyer (and the systolic array team).

When a partially unassigned wire is then assigned a value (thus theoretically overwriting the earlier partial assignment because of last connect semantics), the memoized nodes created by ExpandWhens (representing the partial assignment expression) are still generated. These nodes contain the WVoid expression, but are never read from. While this could be DCE'd away, DCE only runs on low FIRRTL. A later pass then trips up when it sees the WVoid expression.

Example of code that triggers the bug:
```
circuit Test :
    module Test :
        input p : UInt<1>
        wire x : UInt<32>
        when p :
            x <= UInt(1)
        x <= UInt(1)
```

Anyways, this PR includes the test case demonstrating the problem. @jackkoenig (and others) any thoughts on solutions?