### PR TITLE
Add a data structure for memory conf reading and writing

### DIFF
--- a/src/main/scala/firrtl/passes/memlib/MemConf.scala
+++ b/src/main/scala/firrtl/passes/memlib/MemConf.scala
@@ -1,0 +1,61 @@
+// See LICENSE for license details.
+
+package firrtl.passes
+package memlib
+
+import scala.util.matching._
+
+sealed abstract class MemPort(val name: String) { override def toString = name }
+
+case object ReadPort extends MemPort("read")
+case object WritePort extends MemPort("write")
+case object MaskedWritePort extends MemPort("mwrite")
+case object ReadWritePort extends MemPort("rw")
+case object MaskedReadWritePort extends MemPort("mrw")
+
+object MemPort {
+
+  val all = Set(ReadPort, WritePort, MaskedWritePort, ReadWritePort, MaskedReadWritePort)
+
+  def apply(s: String): Option[MemPort] = MemPort.all.find(_.name == s)
+
+  def fromString(s: String): Seq[MemPort] = {
+    s.split(",").toSeq.map(MemPort.apply).map(_ match {
+      case Some(x) => x
+      case _ => throw new Exception(s"Error parsing MemPort string : ${s}")
+    })
+  }
+}
+
+case class MemConf(
+  name: String,
+  depth: Int,
+  width: Int,
+  ports: Seq[MemPort],
+  maskGranularity: Option[Int]
+) {
+
+  private def portsStr = ports.map(_.name).mkString(",")
+  private def maskGranStr = maskGranularity.map((p) => s"mask_gran $p").getOrElse("")
+
+  override def toString() = s"name ${name} depth ${depth} width ${width} ports ${portsStr} ${maskGranStr} "
+}
+
+object MemConf {
+
+  val regex = raw"\s*name\s+(\w+)\s+depth\s+(\d+)\s+width\s+(\d+)\s+ports\s+([^\s]+)\s+(?:mask_gran\s+(\d+))?\s*".r
+
+  def fromString(s: String): Seq[MemConf] = {
+    s.split("\n").toSeq.map(_ match {
+      case MemConf.regex(name, depth, width, ports, maskGran) => MemConf(name, depth.toInt, width.toInt, MemPort.fromString(ports), Option(maskGran).map(_.toInt))
+      case _ => throw new Exception(s"Error parsing MemConf string : ${s}")
+    })
+  }
+
+  def apply(name: String, depth: Int, width: Int, readPorts: Int, writePorts: Int, readWritePorts: Int, maskGranularity: Option[Int]): MemConf = {
+    val ports = Seq.fill(writePorts)(if (maskGranularity.isEmpty) WritePort else MaskedWritePort) ++
+                Seq.fill(readPorts)(ReadPort) ++
+                Seq.fill(readWritePorts)(if (maskGranularity.isEmpty) ReadWritePort else MaskedReadWritePort)
+    return new MemConf(name, depth, width, ports, maskGranularity)
+  }
+}

--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
@@ -50,15 +50,11 @@ class ConfWriter(filename: String) {
   val outputBuffer = new CharArrayWriter
   def append(m: DefAnnotatedMemory) = {
     // legacy
-    val maskGran = m.maskGran
-    val readers = List.fill(m.readers.length)("read")
-    val writers = List.fill(m.writers.length)(if (maskGran.isEmpty) "write" else "mwrite")
-    val readwriters = List.fill(m.readwriters.length)(if (maskGran.isEmpty) "rw" else "mrw")
-    val ports = (writers ++ readers ++ readwriters) mkString ","
-    val maskGranConf = maskGran match { case None => "" case Some(p) => s"mask_gran $p" }
-    val width = bitWidth(m.dataType)
-    val conf = s"name ${m.name} depth ${m.depth} width $width ports $ports $maskGranConf \n"
-    outputBuffer.append(conf)
+    // assert that we don't overflow going from BigInt to Int conversion
+    require(bitWidth(m.dataType) <= Int.MaxValue)
+    m.maskGran.foreach { case x => require(x <= Int.MaxValue) }
+    val conf = MemConf(m.name, m.depth, bitWidth(m.dataType).toInt, m.readers.length, m.writers.length, m.readwriters.length, m.maskGran.map(_.toInt))
+    outputBuffer.append(conf.toString + "\n")
   }
   def serialize() = {
     val outputFile = new PrintWriter(filename)

--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
@@ -54,7 +54,7 @@ class ConfWriter(filename: String) {
     require(bitWidth(m.dataType) <= Int.MaxValue)
     m.maskGran.foreach { case x => require(x <= Int.MaxValue) }
     val conf = MemConf(m.name, m.depth, bitWidth(m.dataType).toInt, m.readers.length, m.writers.length, m.readwriters.length, m.maskGran.map(_.toInt))
-    outputBuffer.append(conf.toString + "\n")
+    outputBuffer.append(conf.toString)
   }
   def serialize() = {
     val outputFile = new PrintWriter(filename)


### PR DESCRIPTION
This provides a data structure wrapper around the existing memory conf format which contains both reading and writing methods, making it easier to write code that needs to read the format. This should produce identical .conf files to the existing code, so it should be fully backward-compatible. From ucb-bar/barstools#35