### PR TITLE
Upgrade AsyncReset non-literal values check 

### DIFF
--- a/src/test/scala/firrtlTests/AsyncResetSpec.scala
+++ b/src/test/scala/firrtlTests/AsyncResetSpec.scala
@@ -90,6 +90,22 @@ class AsyncResetSpec extends FirrtlFlatSpec {
       )
     }
   }
+  "Late non-literals connections" should "NOT be allowed as reset values for AsyncReset" in {
+    an [passes.CheckHighForm.NonLiteralAsyncResetValueException] shouldBe thrownBy {
+      compileBody(s"""
+        |input clock : Clock
+        |input reset : AsyncReset
+        |input x : UInt<8>
+        |input y : UInt<8>
+        |output z : UInt<8>
+        |wire a : UInt<8> 
+        |reg r : UInt<8>, clock with : (reset => (reset, a))
+        |a <= y
+        |r <= x
+        |z <= r""".stripMargin
+      )
+    }
+  }
   
   "Hidden Non-literals" should "NOT be allowed as reset values for AsyncReset" in {
     an [passes.CheckHighForm.NonLiteralAsyncResetValueException] shouldBe thrownBy {

--- a/src/test/scala/firrtlTests/AsyncResetSpec.scala
+++ b/src/test/scala/firrtlTests/AsyncResetSpec.scala
@@ -110,6 +110,25 @@ class AsyncResetSpec extends FirrtlFlatSpec {
       )
     }
   }
+  "Wire connected to non-literal" should "NOT be allowed as reset values for AsyncReset" in {
+    an [passes.CheckHighForm.NonLiteralAsyncResetValueException] shouldBe thrownBy {
+      compileBody(s"""
+        |input clock : Clock
+        |input reset : AsyncReset
+        |input x : UInt<1>
+        |input y : UInt<1>
+        |input cond : UInt<1>
+        |output z : UInt<1>
+        |wire w : UInt<1>
+        |w <= UInt(1)
+        |when cond : 
+        |  w <= y
+        |reg r : UInt<1>, clock with : (reset => (reset, w))
+        |r <= x
+        |z <= r""".stripMargin
+      )
+    }
+  }
 
   "Complex literals" should "be allowed as reset values for AsyncReset" in {
     val result = compileBody(s"""


### PR DESCRIPTION
Upgrade AsyncReset non-literal values check with in-depth recursive  lookup of complex types

Fix #1044 