### PR TITLE
Advertise FIRRTL grammar support in Atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ sbt assembly
 #### Other Tools
 * Firrtl syntax highlighting for Vim users: https://github.com/azidar/firrtl-syntax
 * Firrtl syntax highlighting for Sublime Text 3 users: https://github.com/codelec/highlight-firrtl
+* Firrtl syntax highlighting for Atom users: https://atom.io/packages/language-firrtl
 * Firrtl mode for Emacs users: https://github.com/ibm/firrtl-mode
 * Chisel3, an embedded hardware DSL that generates Firrtl: https://github.com/freechipsproject/chisel3
 * Treadle, a Firrtl Interpreter: https://github.com/freechipsproject/treadle


### PR DESCRIPTION
I have just published the adaptation of the sublime-text language support to Atom.
Let's advertise it in the README :)