### PR TITLE
Add serialization support for LoadMemoryFileType in LoadMemoryAnnotation

### DIFF
--- a/src/main/scala/firrtl/annotations/JsonProtocol.scala
+++ b/src/main/scala/firrtl/annotations/JsonProtocol.scala
@@ -45,7 +45,19 @@ object JsonProtocol {
       }},
     { case x: Transform => JString(x.getClass.getName) }
   ))
-
+  class LoadMemoryFileTypeSerializer extends CustomSerializer[MemoryLoadFileType.FileType](format => ( {
+    case JString(s) => s match {
+      case "h" => MemoryLoadFileType.Hex
+      case "b" => MemoryLoadFileType.Binary
+      case _ => throw new FIRRTLException(s"Unrecognized MemoryLoadFileType: $s")
+    }
+  }, {
+    case named: MemoryLoadFileType.FileType => named match {
+        case MemoryLoadFileType.Hex => JString("h")
+        case MemoryLoadFileType.Binary => JString("b")
+        case _ => throw new FIRRTLException(s"Unrecognized MemoryLoadFileType: $named")
+    }
+  }))
 
   class TargetSerializer extends CustomSerializer[Target](format => (
     { case JString(s) => Target.deserialize(s) },
@@ -78,7 +90,8 @@ object JsonProtocol {
       new TransformClassSerializer + new NamedSerializer + new CircuitNameSerializer +
       new ModuleNameSerializer + new ComponentNameSerializer + new TargetSerializer +
       new GenericTargetSerializer + new CircuitTargetSerializer + new ModuleTargetSerializer +
-      new InstanceTargetSerializer + new ReferenceTargetSerializer + new TransformSerializer
+      new InstanceTargetSerializer + new ReferenceTargetSerializer + new TransformSerializer  +
+      new LoadMemoryFileTypeSerializer
   }
 
   /** Serialize annotations to a String for emission */

--- a/src/main/scala/firrtl/annotations/JsonProtocol.scala
+++ b/src/main/scala/firrtl/annotations/JsonProtocol.scala
@@ -45,19 +45,10 @@ object JsonProtocol {
       }},
     { case x: Transform => JString(x.getClass.getName) }
   ))
-  class LoadMemoryFileTypeSerializer extends CustomSerializer[MemoryLoadFileType.FileType](format => ( {
-    case JString(s) => s match {
-      case "h" => MemoryLoadFileType.Hex
-      case "b" => MemoryLoadFileType.Binary
-      case _ => throw new FIRRTLException(s"Unrecognized MemoryLoadFileType: $s")
-    }
-  }, {
-    case named: MemoryLoadFileType.FileType => named match {
-        case MemoryLoadFileType.Hex => JString("h")
-        case MemoryLoadFileType.Binary => JString("b")
-        case _ => throw new FIRRTLException(s"Unrecognized MemoryLoadFileType: $named")
-    }
-  }))
+  class LoadMemoryFileTypeSerializer extends CustomSerializer[MemoryLoadFileType](format => (
+    { case JString(s) => MemoryLoadFileType.deserialize(s) },
+    { case named: MemoryLoadFileType => JString(named.serialize) }
+  ))
 
   class TargetSerializer extends CustomSerializer[Target](format => (
     { case JString(s) => Target.deserialize(s) },

--- a/src/main/scala/firrtl/annotations/LoadMemoryAnnotation.scala
+++ b/src/main/scala/firrtl/annotations/LoadMemoryAnnotation.scala
@@ -13,6 +13,9 @@ sealed abstract class MemoryLoadFileType(val value: String) {
 }
 
 object MemoryLoadFileType {
+  // purely for backwards compatibility with chisel3's ChiselLoadMemoryAnnotation
+  type FileType = MemoryLoadFileType
+
   case object Hex extends MemoryLoadFileType("h")
   case object Binary extends MemoryLoadFileType("b")
   def deserialize(s: String): MemoryLoadFileType = s match {

--- a/src/main/scala/firrtl/annotations/LoadMemoryAnnotation.scala
+++ b/src/main/scala/firrtl/annotations/LoadMemoryAnnotation.scala
@@ -4,13 +4,22 @@ package firrtl.annotations
 
 import java.io.File
 
-/** Enumeration of the two types of `readmem` statements available in Verilog.
-  */
-object MemoryLoadFileType extends Enumeration {
-  type FileType = Value
+import firrtl.FIRRTLException
 
-  val Hex:    Value = Value("h")
-  val Binary: Value = Value("b")
+/** Representation of the two types of `readmem` statements available in Verilog.
+  */
+sealed abstract class MemoryLoadFileType(val value: String) {
+  def serialize: String = value
+}
+
+object MemoryLoadFileType {
+  case object Hex extends MemoryLoadFileType("h")
+  case object Binary extends MemoryLoadFileType("b")
+  def deserialize(s: String): MemoryLoadFileType = s match {
+    case "h" => MemoryLoadFileType.Hex
+    case "b" => MemoryLoadFileType.Binary
+    case _ => throw new FIRRTLException(s"Unrecognized MemoryLoadFileType: $s")
+  }
 }
 
 /** Firrtl implementation for load memory
@@ -21,7 +30,7 @@ object MemoryLoadFileType extends Enumeration {
 case class LoadMemoryAnnotation(
   target: ComponentName,
   fileName: String,
-  hexOrBinary: MemoryLoadFileType.FileType = MemoryLoadFileType.Hex,
+  hexOrBinary: MemoryLoadFileType = MemoryLoadFileType.Hex,
   originalMemoryNameOpt: Option[String] = None
 ) extends SingleTargetAnnotation[Named] {
 

--- a/src/test/scala/firrtlTests/annotationTests/LoadMemoryAnnotationSpec.scala
+++ b/src/test/scala/firrtlTests/annotationTests/LoadMemoryAnnotationSpec.scala
@@ -2,7 +2,7 @@
 
 package firrtlTests.annotationTests
 
-import firrtl.annotations.{CircuitName, ComponentName, LoadMemoryAnnotation, ModuleName}
+import firrtl.annotations._
 import org.scalatest.{FreeSpec, Matchers}
 
 class LoadMemoryAnnotationSpec extends FreeSpec with Matchers {
@@ -25,5 +25,17 @@ class LoadMemoryAnnotationSpec extends FreeSpec with Matchers {
 
       lma.getFileName should be("./target/scala-2.12/test-classes/init_mem_subdata")
     }
+  }
+  "LoadMemoryAnnotation should be correctly parsed from a string" in {
+    val lma = new LoadMemoryAnnotation(
+      ComponentName("ram", ModuleName("ModuleMem", CircuitName("CircuitMem"))),
+      "CircuitMem.ModuleMem.ram.dat",
+      hexOrBinary = MemoryLoadFileType.Binary,
+      originalMemoryNameOpt = Some("memory")
+    )
+
+    val annoString = JsonProtocol.serializeTry(Seq(lma)).get
+    val loadedAnnos = JsonProtocol.deserializeTry(annoString).get
+    lma should equal(loadedAnnos.head)
   }
 }


### PR DESCRIPTION
Add custom LoadMemoryFileTypeSerializer.
Add test to verify LoadMemoryAnnotation can be correctly serialized/deserialized.

This resolves #1055.
