### PR TITLE
Fix error reading empty MemConf strings

### DIFF
--- a/src/main/scala/firrtl/passes/memlib/MemConf.scala
+++ b/src/main/scala/firrtl/passes/memlib/MemConf.scala
@@ -51,9 +51,10 @@ object MemConf {
 
   def fromString(s: String): Seq[MemConf] = {
     s.split("\n").toSeq.map(_ match {
-      case MemConf.regex(name, depth, width, ports, maskGran) => MemConf(name, depth.toInt, width.toInt, MemPort.fromString(ports), Option(maskGran).map(_.toInt))
+      case MemConf.regex(name, depth, width, ports, maskGran) => Some(MemConf(name, depth.toInt, width.toInt, MemPort.fromString(ports), Option(maskGran).map(_.toInt)))
+      case "" => None
       case _ => throw new Exception(s"Error parsing MemConf string : ${s}")
-    })
+    }).flatten
   }
 
   def apply(name: String, depth: Int, width: Int, readPorts: Int, writePorts: Int, readWritePorts: Int, maskGranularity: Option[Int]): MemConf = {

--- a/src/test/scala/firrtlTests/ReplSeqMemTests.scala
+++ b/src/test/scala/firrtlTests/ReplSeqMemTests.scala
@@ -487,6 +487,28 @@ circuit CustomMemory :
     checkMemConf(confLoc, mems)
     (new java.io.File(confLoc)).delete()
   }
+
+  "ReplSeqMem" should "produce an empty conf file with no SeqMems" in {
+    val input = """
+circuit NoMemsHere :
+  module NoMemsHere :
+    input clock : Clock
+    input in : UInt<8>
+    output out : UInt<8>
+
+    out is invalid
+
+    out <= in
+"""
+    val mems = Set.empty[MemConf]
+    val confLoc = "ReplSeqMemTests.confTEMP"
+    val annos = Seq(ReplSeqMemAnnotation.parse("-c:CustomMemory:-o:"+confLoc),
+                    InferReadWriteAnnotation)
+    val res = compileAndEmit(CircuitState(parse(input), ChirrtlForm, annos))
+    // Check the emitted conf
+    checkMemConf(confLoc, mems)
+    (new java.io.File(confLoc)).delete()
+  }
 }
 
 // TODO: make more checks


### PR DESCRIPTION
This shouldn't affect anything currently being used, but the MemConf parser introduced in #1041 will error out on reading an empty MemConf. This PR fixes that and adds a unit test.