### PR TITLE
DCE printf and stop statements with constant-0 enables

### DIFF
--- a/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
+++ b/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
@@ -212,6 +212,11 @@ class DeadCodeElimination extends Transform with ResolvedAnnotationPaths with Re
     var emptyBody = true
     renames.setModule(mod.name)
 
+    def deleteIfNotEnabled(stmt: Statement, en: Expression): Statement = en match {
+      case UIntLiteral(v, _) if v == BigInt(0) => EmptyStmt
+      case _ => stmt
+    }
+
     def onStmt(stmt: Statement): Statement = {
       val stmtx = stmt match {
         case inst: WDefInstance =>
@@ -230,6 +235,8 @@ class DeadCodeElimination extends Transform with ResolvedAnnotationPaths with Re
             EmptyStmt
           }
           else decl
+        case print: Print => deleteIfNotEnabled(print, print.en)
+        case stop: Stop => deleteIfNotEnabled(stop, stop.en)
         case con: Connect =>
           val node = getDeps(con.loc) match { case Seq(elt) => elt }
           if (deadNodes.contains(node)) EmptyStmt else con

--- a/src/test/scala/firrtlTests/DCETests.scala
+++ b/src/test/scala/firrtlTests/DCETests.scala
@@ -449,6 +449,23 @@ class DCETests extends FirrtlFlatSpec {
     // Check for register update
     verilog should include regex ("""(?m)if \(a\) begin\n\s*r <= x;\s*end""")
   }
+
+  "Emitted Verilog" should "not contain dead print or stop statements" in {
+    val input = parse(
+      """circuit test :
+        |  module test :
+        |    input clock : Clock
+        |    when UInt<1>(0) :
+        |      printf(clock, UInt<1>(1), "o hai")
+        |      stop(clock, UInt<1>(1), 1)""".stripMargin
+    )
+
+    val state = CircuitState(input, ChirrtlForm)
+    val result = (new VerilogCompiler).compileAndEmit(state, List.empty)
+    val verilog = result.getEmittedCircuit.value
+    verilog shouldNot include regex ("""fwrite""")
+    verilog shouldNot include regex ("""fatal""")
+  }
 }
 
 class DCECommandLineSpec extends FirrtlFlatSpec {


### PR DESCRIPTION
This gets rid of about 10% of the generated Verilog in the rocket-chip default config.