### PR TITLE
Use scalafix to remove unused import and deprecated procedure syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ sbt
 > test
 ```
 
+##### Use scalafix to remove unused import and deprecated procedure syntax
+ 1. Remove unused import:
+```
+sbt "firrtl/scalafix RemoveUnused"
+```
+ 2. Remove deprecated procedure syntax
+```
+sbt "firrtl/scalafix ProcedureSyntax"
+```
+
 ##### Using Firrtl as a commandline tool
 ```
 utils/bin/firrtl -i regress/rocket.fir -o regress/rocket.v -X verilog // Compiles rocket-chip to Verilog

--- a/build.sbt
+++ b/build.sbt
@@ -28,8 +28,12 @@ def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
   }
 }
 
+addCompilerPlugin(scalafixSemanticdb) // enable SemanticDB
+
 scalacOptions := scalacOptionsVersion(scalaVersion.value) ++ Seq(
-  "-deprecation"
+  "-deprecation",
+  "-Yrangepos",          // required by SemanticDB compiler plugin
+  "-Ywarn-unused-import" // required by `RemoveUnused` rule
 )
 
 def javacOptionsVersion(scalaVersion: String): Seq[String] = {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,4 +20,6 @@ addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.1")
 
 addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.3")
 
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.4")
+
 libraryDependencies += "com.github.os72" % "protoc-jar" % "3.5.1.1"

--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -5,14 +5,11 @@ package firrtl
 import logger._
 import java.io.Writer
 
-import firrtl.RenameMap.{CircularRenameException, IllegalRenameException}
 
 import scala.collection.mutable
 import firrtl.annotations._
-import firrtl.ir.{Circuit, Expression}
-import firrtl.Utils.{error, throwInternalError}
-import firrtl.annotations.TargetToken
-import firrtl.annotations.TargetToken.{Field, Index}
+import firrtl.ir.Circuit
+import firrtl.Utils.throwInternalError
 import firrtl.annotations.transforms.{EliminateTargetPaths, ResolvePaths}
 import firrtl.options.StageUtils
 

--- a/src/main/scala/firrtl/Driver.scala
+++ b/src/main/scala/firrtl/Driver.scala
@@ -3,17 +3,12 @@
 package firrtl
 
 import scala.collection._
-import scala.io.Source
-import scala.util.{Failure, Success, Try}
-import scala.util.control.ControlThrowable
+import scala.util.{Failure, Try}
 import java.io.{File, FileNotFoundException}
 import scala.sys.process.{BasicIO, ProcessLogger, stringSeqToProcess}
 import net.jcazevedo.moultingyaml._
-import logger.Logger
-import Parser.{IgnoreInfo, InfoMode}
 import annotations._
 import firrtl.annotations.AnnotationYamlProtocol._
-import firrtl.passes.{PassException, PassExceptions}
 import firrtl.transforms._
 import firrtl.Utils.throwInternalError
 import firrtl.stage.{FirrtlExecutionResultView, FirrtlStage}

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -2,13 +2,9 @@
 
 package firrtl
 
-import com.typesafe.scalalogging.LazyLogging
-import java.nio.file.{Paths, Files}
-import java.io.{Reader, Writer}
+import java.io.Writer
 
 import scala.collection.mutable
-import scala.sys.process._
-import scala.io.Source
 
 import firrtl.ir._
 import firrtl.passes._
@@ -21,9 +17,8 @@ import Utils._
 import MemPortUtils.{memPortField, memType}
 import firrtl.options.{HasShellOptions, ShellOption, StageUtils, PhaseException}
 import firrtl.stage.RunFirrtlTransformAnnotation
-import scopt.OptionParser
 // Datastructures
-import scala.collection.mutable.{ArrayBuffer, LinkedHashMap, HashSet}
+import scala.collection.mutable.ArrayBuffer
 
 case class EmitterException(message: String) extends PassException(message)
 

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -211,8 +211,8 @@ class VerilogEmitter extends SeqTransform with Emitter {
     case ClockType | AsyncResetType => ""
     case _ => throwInternalError(s"trying to write unsupported type in the Verilog Emitter: $tpe")
   }
-  def emit(x: Any)(implicit w: Writer) { emit(x, 0) }
-  def emit(x: Any, top: Int)(implicit w: Writer) {
+  def emit(x: Any)(implicit w: Writer): Unit = { emit(x, 0) }
+  def emit(x: Any, top: Int)(implicit w: Writer): Unit = {
     def cast(e: Expression): Any = e.tpe match {
       case (t: UIntType) => e
       case (t: SIntType) => Seq("$signed(",e,")")
@@ -500,7 +500,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
         declares += Seq(b, " ", tx, " ", n,";",info)
     }
 
-    def assign(e: Expression, value: Expression, info: Info) {
+    def assign(e: Expression, value: Expression, info: Info): Unit = {
       assigns += Seq("assign ", e, " = ", value, ";", info)
     }
 
@@ -593,7 +593,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
       }
     }
 
-    def initialize_mem(s: DefMemory) {
+    def initialize_mem(s: DefMemory): Unit = {
       if (s.depth > maxMemSize) {
         maxMemSize = s.depth
       }
@@ -813,7 +813,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
       }
     }
 
-    def emit_streams() {
+    def emit_streams(): Unit = {
       description match {
         case DocString(s) => build_comment(s.string).foreach(emit(_))
         case other =>

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -128,7 +128,6 @@ class MinimumLowFirrtlOptimization extends CoreTransform {
 
 
 import CompilerUtils.getLoweringTransforms
-import firrtl.transforms.BlackBoxSourceHelper
 
 /** Emits input circuit with no changes
   *

--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -6,12 +6,9 @@ import firrtl.ir._
 import firrtl.PrimOps._
 import firrtl.Mappers._
 import firrtl.WrappedExpression._
-import firrtl.WrappedType._
 
 import scala.collection.mutable
-import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet, LinkedHashMap, StringBuilder}
 import scala.util.matching.Regex
-import java.io.PrintWriter
 
 import firrtl.annotations.{ReferenceTarget, TargetToken}
 import _root_.logger.LazyLogging

--- a/src/main/scala/firrtl/annotations/Annotation.scala
+++ b/src/main/scala/firrtl/annotations/Annotation.scala
@@ -3,12 +3,8 @@
 package firrtl
 package annotations
 
-import net.jcazevedo.moultingyaml._
-import firrtl.annotations.AnnotationYamlProtocol._
-import firrtl.Utils.throwInternalError
 import firrtl.options.StageUtils
 
-import scala.collection.mutable
 
 case class AnnotationException(message: String) extends Exception(message)
 

--- a/src/main/scala/firrtl/annotations/AnnotationUtils.scala
+++ b/src/main/scala/firrtl/annotations/AnnotationUtils.scala
@@ -5,16 +5,11 @@ package annotations
 
 import java.io.File
 
-import org.json4s._
-import org.json4s.native.JsonMethods._
-import org.json4s.native.Serialization
-import org.json4s.native.Serialization.{read, write, writePretty}
 
 import net.jcazevedo.moultingyaml._
 import firrtl.annotations.AnnotationYamlProtocol._
 
 import firrtl.ir._
-import firrtl.Utils.error
 
 case class InvalidAnnotationFileException(file: File, cause: Throwable = null)
   extends FIRRTLException(s"$file, see cause below", cause)

--- a/src/main/scala/firrtl/annotations/JsonProtocol.scala
+++ b/src/main/scala/firrtl/annotations/JsonProtocol.scala
@@ -7,10 +7,8 @@ import scala.util.{Try, Failure}
 import org.json4s._
 import org.json4s.native.JsonMethods._
 import org.json4s.native.Serialization
-import org.json4s.native.Serialization.{read, write, writePretty}
+import org.json4s.native.Serialization.{read, writePretty}
 
-import firrtl.ir._
-import firrtl.Utils.error
 
 object JsonProtocol {
   class TransformClassSerializer extends CustomSerializer[Class[_ <: Transform]](format => (

--- a/src/main/scala/firrtl/annotations/analysis/DuplicationHelper.scala
+++ b/src/main/scala/firrtl/annotations/analysis/DuplicationHelper.scala
@@ -2,7 +2,6 @@
 
 package firrtl.annotations.analysis
 
-import firrtl.Namespace
 import firrtl.annotations._
 import firrtl.annotations.TargetToken.{Instance, OfModule, Ref}
 import firrtl.Utils.throwInternalError

--- a/src/main/scala/firrtl/options/Phase.scala
+++ b/src/main/scala/firrtl/options/Phase.scala
@@ -3,11 +3,9 @@
 package firrtl.options
 
 import firrtl.AnnotationSeq
-import firrtl.annotations.DeletedAnnotation
 
 import logger.LazyLogging
 
-import scala.collection.mutable
 
 /** A polymorphic mathematical transform
   * @tparam A the transformed type

--- a/src/main/scala/firrtl/options/StageUtils.scala
+++ b/src/main/scala/firrtl/options/StageUtils.scala
@@ -2,7 +2,6 @@
 
 package firrtl.options
 
-import java.io.File
 
 /** Utilities related to working with a [[Stage]] */
 object StageUtils {

--- a/src/main/scala/firrtl/options/phases/AddDefaults.scala
+++ b/src/main/scala/firrtl/options/phases/AddDefaults.scala
@@ -3,7 +3,7 @@
 package firrtl.options.phases
 
 import firrtl.AnnotationSeq
-import firrtl.options.{Phase, StageOption, TargetDirAnnotation}
+import firrtl.options.{Phase, TargetDirAnnotation}
 
 /** Add default annotations for a [[Stage]]
   *

--- a/src/main/scala/firrtl/package.scala
+++ b/src/main/scala/firrtl/package.scala
@@ -1,6 +1,5 @@
 // See LICENSE for license details.
 
-import firrtl.AnnotationSeq
 import firrtl.annotations.Annotation
 
 package object firrtl {

--- a/src/main/scala/firrtl/passes/CheckChirrtl.scala
+++ b/src/main/scala/firrtl/passes/CheckChirrtl.scala
@@ -2,7 +2,6 @@
 
 package firrtl.passes
 
-import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.traversals.Foreachers._

--- a/src/main/scala/firrtl/passes/CheckChirrtl.scala
+++ b/src/main/scala/firrtl/passes/CheckChirrtl.scala
@@ -106,7 +106,7 @@ object CheckChirrtl extends Pass {
       p.tpe.foreach(checkChirrtlW(p.info, mname))
     }
 
-    def checkChirrtlM(m: DefModule) {
+    def checkChirrtlM(m: DefModule): Unit = {
       val names = new NameSet
       m.foreach(checkChirrtlP(m.name, names))
       m.foreach(checkChirrtlS(m.info, m.name, names))

--- a/src/main/scala/firrtl/passes/CheckWidths.scala
+++ b/src/main/scala/firrtl/passes/CheckWidths.scala
@@ -116,7 +116,7 @@ object CheckWidths extends Pass {
 
     def check_width_p(minfo: Info, target: ModuleTarget)(p: Port): Unit = check_width_t(p.info, target)(p.tpe)
 
-    def check_width_m(circuit: CircuitTarget)(m: DefModule) {
+    def check_width_m(circuit: CircuitTarget)(m: DefModule): Unit = {
       m foreach check_width_p(m.info, circuit.module(m.name))
       m foreach check_width_s(m.info, circuit.module(m.name))
     }

--- a/src/main/scala/firrtl/passes/Checks.scala
+++ b/src/main/scala/firrtl/passes/Checks.scala
@@ -63,8 +63,8 @@ object CheckHighForm extends Pass {
     val moduleGraph = new ModuleGraph
     val moduleNames = (c.modules map (_.name)).toSet
 
-    def checkHighFormPrimop(info: Info, mname: String, e: DoPrim) {
-      def correctNum(ne: Option[Int], nc: Int) {
+    def checkHighFormPrimop(info: Info, mname: String, e: DoPrim): Unit = {
+      def correctNum(ne: Option[Int], nc: Int): Unit = {
         ne match {
           case Some(i) if e.args.length != i =>
             errors.append(new IncorrectNumArgsException(info, mname, e.op.toString, i))
@@ -99,7 +99,7 @@ object CheckHighForm extends Pass {
       }
     }
 
-    def checkFstring(info: Info, mname: String, s: StringLit, i: Int) {
+    def checkFstring(info: Info, mname: String, s: StringLit, i: Int): Unit = {
       val validFormats = "bdxc"
       val (percent, npercents) = s.string.foldLeft((false, 0)) {
         case ((percentx, n), b) if percentx && (validFormats contains b) =>
@@ -203,7 +203,7 @@ object CheckHighForm extends Pass {
       p.tpe foreach checkHighFormW(p.info, mname)
     }
 
-    def checkHighFormM(m: DefModule) {
+    def checkHighFormM(m: DefModule): Unit = {
       val names = new NameSet
       m foreach checkHighFormP(m.name, names)
       m foreach checkHighFormS(m.info, m.name, names)

--- a/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
+++ b/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
@@ -4,10 +4,8 @@ package firrtl.passes
 
 import firrtl._
 import firrtl.ir._
-import firrtl.Utils._
 import firrtl.Mappers._
 
-import annotation.tailrec
 
 object CommonSubexpressionElimination extends Pass {
   private def cse(s: Statement): Statement = {

--- a/src/main/scala/firrtl/passes/ConvertFixedToSInt.scala
+++ b/src/main/scala/firrtl/passes/ConvertFixedToSInt.scala
@@ -7,7 +7,7 @@ import firrtl.PrimOps._
 import firrtl.ir._
 import firrtl._
 import firrtl.Mappers._
-import firrtl.Utils.{sub_type, module_type, field_type, max, error, throwInternalError}
+import firrtl.Utils.{sub_type, module_type, field_type, max, throwInternalError}
 
 /** Replaces FixedType with SIntType, and correctly aligns all binary points
   */

--- a/src/main/scala/firrtl/passes/DeadCodeElimination.scala
+++ b/src/main/scala/firrtl/passes/DeadCodeElimination.scala
@@ -4,7 +4,6 @@ package firrtl.passes
 
 import firrtl._
 import firrtl.ir._
-import firrtl.Utils._
 import firrtl.Mappers._
 
 import annotation.tailrec

--- a/src/main/scala/firrtl/passes/ExpandWhens.scala
+++ b/src/main/scala/firrtl/passes/ExpandWhens.scala
@@ -11,7 +11,6 @@ import firrtl.WrappedExpression._
 
 import annotation.tailrec
 import collection.mutable
-import collection.immutable.ListSet
 
 /** Expand Whens
   *

--- a/src/main/scala/firrtl/passes/InferWidths.scala
+++ b/src/main/scala/firrtl/passes/InferWidths.scala
@@ -7,7 +7,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.collection.immutable.ListMap
 
 import firrtl._
-import firrtl.annotations.{Annotation, ReferenceTarget, TargetToken}
+import firrtl.annotations.{Annotation, ReferenceTarget}
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._

--- a/src/main/scala/firrtl/passes/Inline.scala
+++ b/src/main/scala/firrtl/passes/Inline.scala
@@ -9,7 +9,6 @@ import firrtl.annotations._
 import firrtl.analyses.InstanceGraph
 import firrtl.stage.RunFirrtlTransformAnnotation
 import firrtl.options.{RegisteredTransform, ShellOption}
-import scopt.OptionParser
 
 // Datastructures
 import scala.collection.mutable

--- a/src/main/scala/firrtl/passes/Passes.scala
+++ b/src/main/scala/firrtl/passes/Passes.scala
@@ -2,7 +2,6 @@
 
 package firrtl.passes
 
-import com.typesafe.scalalogging.LazyLogging
 import firrtl._
 import firrtl.ir._
 import firrtl.Utils._

--- a/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
+++ b/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
@@ -8,7 +8,6 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
-import firrtl.PrimOps.AsClock
 
 case class MPort(name: String, clk: Expression)
 case class MPorts(readers: ArrayBuffer[MPort], writers: ArrayBuffer[MPort], readwriters: ArrayBuffer[MPort])

--- a/src/main/scala/firrtl/passes/RemoveEmpty.scala
+++ b/src/main/scala/firrtl/passes/RemoveEmpty.scala
@@ -3,8 +3,6 @@
 package firrtl
 package passes
 
-import scala.collection.mutable
-import firrtl.Mappers._
 import firrtl.ir._
 
 object RemoveEmpty extends Pass {

--- a/src/main/scala/firrtl/passes/RemoveValidIf.scala
+++ b/src/main/scala/firrtl/passes/RemoveValidIf.scala
@@ -5,7 +5,6 @@ package passes
 import firrtl.Mappers._
 import firrtl.ir._
 import Utils.throwInternalError
-import WrappedExpression.weq
 
 /** Remove [[firrtl.ir.ValidIf ValidIf]] and replace [[firrtl.ir.IsInvalid IsInvalid]] with a connection to zero */
 object RemoveValidIf extends Pass {

--- a/src/main/scala/firrtl/passes/ReplaceAccesses.scala
+++ b/src/main/scala/firrtl/passes/ReplaceAccesses.scala
@@ -3,12 +3,8 @@
 package firrtl.passes
 
 import firrtl.ir._
-import firrtl.{WRef, WSubAccess, WSubIndex, WSubField}
+import firrtl.{WSubAccess, WSubIndex}
 import firrtl.Mappers._
-import firrtl.Utils._
-import firrtl.WrappedExpression._
-import firrtl.Namespace
-import scala.collection.mutable
 
 
 /** Replaces constant [[firrtl.WSubAccess]] with [[firrtl.WSubIndex]]

--- a/src/main/scala/firrtl/passes/Uniquify.scala
+++ b/src/main/scala/firrtl/passes/Uniquify.scala
@@ -2,7 +2,6 @@
 
 package firrtl.passes
 
-import com.typesafe.scalalogging.LazyLogging
 
 import scala.annotation.tailrec
 import firrtl._
@@ -11,7 +10,6 @@ import firrtl.Utils._
 import firrtl.Mappers._
 import MemPortUtils.memType
 
-import scala.collection.mutable
 
 /** Resolve name collisions that would occur in [[LowerTypes]]
   *

--- a/src/main/scala/firrtl/passes/clocklist/ClockList.scala
+++ b/src/main/scala/firrtl/passes/clocklist/ClockList.scala
@@ -6,14 +6,11 @@ package clocklist
 import firrtl._
 import firrtl.ir._
 import annotations._
-import Utils.error
-import java.io.{File, CharArrayWriter, PrintWriter, Writer}
+import java.io.{CharArrayWriter, Writer}
 import wiring.WiringUtils.{getChildrenMap, getLineage}
-import wiring.Lineage
 import ClockListUtils._
 import Utils._
 import memlib.AnalysisUtils._
-import memlib._
 
 /** Starting with a top module, determine the clock origins of each child instance.
  *  Write the result to writer.

--- a/src/main/scala/firrtl/passes/clocklist/ClockListTransform.scala
+++ b/src/main/scala/firrtl/passes/clocklist/ClockListTransform.scala
@@ -4,17 +4,12 @@ package firrtl.passes
 package clocklist
 
 import firrtl._
-import firrtl.ir._
 import annotations._
 import Utils.error
-import java.io.{File, CharArrayWriter, PrintWriter, Writer}
-import wiring.Lineage
-import ClockListUtils._
+import java.io.{PrintWriter, Writer}
 import Utils._
-import memlib.AnalysisUtils._
 import memlib._
 import firrtl.options.{RegisteredTransform, ShellOption}
-import scopt.OptionParser
 import firrtl.stage.RunFirrtlTransformAnnotation
 
 case class ClockListAnnotation(target: ModuleName, outputConfig: String) extends

--- a/src/main/scala/firrtl/passes/clocklist/ClockListUtils.scala
+++ b/src/main/scala/firrtl/passes/clocklist/ClockListUtils.scala
@@ -5,14 +5,9 @@ package clocklist
 
 import firrtl._
 import firrtl.ir._
-import annotations._
-import Utils.error
-import java.io.{File, CharArrayWriter, PrintWriter, Writer}
 import wiring.Lineage
-import ClockListUtils._
 import Utils._
 import memlib.AnalysisUtils._
-import memlib._
 
 object ClockListUtils {
   /** Returns a list of clock outputs from instances of external modules

--- a/src/main/scala/firrtl/passes/clocklist/RemoveAllButClocks.scala
+++ b/src/main/scala/firrtl/passes/clocklist/RemoveAllButClocks.scala
@@ -5,13 +5,7 @@ package clocklist
 
 import firrtl._
 import firrtl.ir._
-import annotations._
-import Utils.error
-import java.io.{File, CharArrayWriter, PrintWriter, Writer}
-import ClockListUtils._
 import Utils._
-import memlib.AnalysisUtils._
-import memlib._
 import Mappers._
 
 /** Remove all statements and ports (except instances/whens/blocks) whose

--- a/src/main/scala/firrtl/passes/memlib/DecorateMems.scala
+++ b/src/main/scala/firrtl/passes/memlib/DecorateMems.scala
@@ -3,7 +3,6 @@
 package firrtl
 package passes
 package memlib
-import ir._
 import annotations._
 import wiring._
 

--- a/src/main/scala/firrtl/passes/memlib/InferReadWrite.scala
+++ b/src/main/scala/firrtl/passes/memlib/InferReadWrite.scala
@@ -13,7 +13,6 @@ import MemPortUtils.memPortField
 import firrtl.passes.memlib.AnalysisUtils.{Connects, getConnects, getOrigin}
 import WrappedExpression.weq
 import annotations._
-import scopt.OptionParser
 import firrtl.stage.RunFirrtlTransformAnnotation
 
 

--- a/src/main/scala/firrtl/passes/memlib/MemConf.scala
+++ b/src/main/scala/firrtl/passes/memlib/MemConf.scala
@@ -3,7 +3,6 @@
 package firrtl.passes
 package memlib
 
-import scala.util.matching._
 
 sealed abstract class MemPort(val name: String) { override def toString = name }
 

--- a/src/main/scala/firrtl/passes/memlib/MemIR.scala
+++ b/src/main/scala/firrtl/passes/memlib/MemIR.scala
@@ -5,7 +5,6 @@ package memlib
 
 import firrtl._
 import firrtl.ir._
-import Utils.indent
 
 object DefAnnotatedMemory {
   def apply(m: DefMemory): DefAnnotatedMemory = {

--- a/src/main/scala/firrtl/passes/memlib/MemLibOptions.scala
+++ b/src/main/scala/firrtl/passes/memlib/MemLibOptions.scala
@@ -2,9 +2,7 @@
 
 package firrtl.passes.memlib
 
-import firrtl._
 import firrtl.options.{RegisteredLibrary, ShellOption}
-import scopt.OptionParser
 
 class MemLibOptions extends RegisteredLibrary {
   val name: String = "MemLib Options"

--- a/src/main/scala/firrtl/passes/memlib/MemTransformUtils.scala
+++ b/src/main/scala/firrtl/passes/memlib/MemTransformUtils.scala
@@ -5,9 +5,7 @@ package memlib
 
 import firrtl._
 import firrtl.ir._
-import firrtl.Utils._
 import firrtl.Mappers._
-import AnalysisUtils._
 import MemPortUtils.{MemPortMap}
 
 object MemTransformUtils {

--- a/src/main/scala/firrtl/passes/memlib/MemUtils.scala
+++ b/src/main/scala/firrtl/passes/memlib/MemUtils.scala
@@ -5,7 +5,6 @@ package firrtl.passes
 import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
-import firrtl.PrimOps._
 
 /** Given a mask, return a bitmask corresponding to the desired datatype.
  *  Requirements:

--- a/src/main/scala/firrtl/passes/memlib/RenameAnnotatedMemoryPorts.scala
+++ b/src/main/scala/firrtl/passes/memlib/RenameAnnotatedMemoryPorts.scala
@@ -5,9 +5,7 @@ package memlib
 
 import firrtl._
 import firrtl.ir._
-import firrtl.Utils._
 import firrtl.Mappers._
-import AnalysisUtils._
 import MemPortUtils._
 import MemTransformUtils._
 

--- a/src/main/scala/firrtl/passes/memlib/RenameAnnotatedMemoryPorts.scala
+++ b/src/main/scala/firrtl/passes/memlib/RenameAnnotatedMemoryPorts.scala
@@ -30,7 +30,7 @@ object RenameAnnotatedMemoryPorts extends Pass {
    *  E.g.:
    *    - ("m.read.addr") becomes (m.R0.addr)
    */
-  def getMemPortMap(m: DefAnnotatedMemory, memPortMap: MemPortMap) {
+  def getMemPortMap(m: DefAnnotatedMemory, memPortMap: MemPortMap): Unit = {
     val defaultFields = Seq("addr", "en", "clk")
     val rFields = defaultFields :+ "data"
     val wFields = rFields :+ "mask"

--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemMacros.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemMacros.scala
@@ -9,7 +9,6 @@ import firrtl.Utils._
 import firrtl.Mappers._
 import MemPortUtils.{MemPortMap, Modules}
 import MemTransformUtils._
-import AnalysisUtils._
 import firrtl.annotations._
 import wiring._
 

--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
@@ -4,14 +4,11 @@ package firrtl.passes
 package memlib
 
 import firrtl._
-import firrtl.ir._
 import firrtl.annotations._
 import firrtl.options.{HasShellOptions, ShellOption}
-import AnalysisUtils._
 import Utils.error
 import java.io.{File, CharArrayWriter, PrintWriter}
 import wiring._
-import scopt.OptionParser
 import firrtl.stage.RunFirrtlTransformAnnotation
 
 sealed trait PassOption

--- a/src/main/scala/firrtl/passes/memlib/YamlUtils.scala
+++ b/src/main/scala/firrtl/passes/memlib/YamlUtils.scala
@@ -5,7 +5,6 @@ package memlib
 import net.jcazevedo.moultingyaml._
 import java.io.{CharArrayWriter, File, PrintWriter}
 
-import firrtl.Utils.error
 
 object CustomYAMLProtocol extends DefaultYamlProtocol {
   // bottom depends on top
@@ -22,7 +21,6 @@ case class Config(pin: Pin, source: Source, top: Top)
 
 
 class YamlFileReader(file: String) {
-  import CustomYAMLProtocol._
   def parse[A](implicit reader: YamlReader[A]) : Seq[A] = {
     if (new File(file).exists) {
       val yamlString = scala.io.Source.fromFile(file).getLines.mkString("\n")
@@ -36,7 +34,6 @@ class YamlFileReader(file: String) {
 }
 
 class YamlFileWriter(file: String) {
-  import CustomYAMLProtocol._
   val outputBuffer = new CharArrayWriter
   val separator = "--- \n"
   def append(in: YamlValue) {

--- a/src/main/scala/firrtl/passes/memlib/YamlUtils.scala
+++ b/src/main/scala/firrtl/passes/memlib/YamlUtils.scala
@@ -36,10 +36,10 @@ class YamlFileReader(file: String) {
 class YamlFileWriter(file: String) {
   val outputBuffer = new CharArrayWriter
   val separator = "--- \n"
-  def append(in: YamlValue) {
+  def append(in: YamlValue): Unit = {
     outputBuffer append s"$separator${in.prettyPrint}"
   }
-  def dump() {
+  def dump(): Unit = {
     val outputFile = new PrintWriter(file)
     outputFile write outputBuffer.toString
     outputFile.close()

--- a/src/main/scala/firrtl/passes/wiring/Wiring.scala
+++ b/src/main/scala/firrtl/passes/wiring/Wiring.scala
@@ -5,8 +5,6 @@ package wiring
 
 import firrtl._
 import firrtl.ir._
-import firrtl.Utils._
-import firrtl.Mappers._
 import scala.collection.mutable
 import firrtl.annotations._
 import firrtl.annotations.AnnotationUtils._

--- a/src/main/scala/firrtl/passes/wiring/WiringTransform.scala
+++ b/src/main/scala/firrtl/passes/wiring/WiringTransform.scala
@@ -4,12 +4,9 @@ package firrtl.passes
 package wiring
 
 import firrtl._
-import firrtl.ir._
 import firrtl.Utils._
-import firrtl.Mappers._
 import scala.collection.mutable
 import firrtl.annotations._
-import WiringUtils._
 
 /** A class for all exceptions originating from firrtl.passes.wiring */
 case class WiringException(msg: String) extends PassException(msg)

--- a/src/main/scala/firrtl/passes/wiring/WiringUtils.scala
+++ b/src/main/scala/firrtl/passes/wiring/WiringUtils.scala
@@ -12,8 +12,6 @@ import scala.collection.mutable
 import firrtl.annotations._
 import firrtl.annotations.AnnotationUtils._
 import firrtl.analyses.InstanceGraph
-import firrtl.graph.DiGraph
-import WiringUtils._
 
 /** Declaration kind in lineage (e.g. input port, output port, wire)
   */

--- a/src/main/scala/firrtl/proto/ToProto.scala
+++ b/src/main/scala/firrtl/proto/ToProto.scala
@@ -3,7 +3,7 @@
 package firrtl
 package proto
 
-import java.io.{BufferedOutputStream, OutputStream}
+import java.io.OutputStream
 
 import FirrtlProtos._
 import Firrtl.Expression.PrimOp.Op

--- a/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
+++ b/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
@@ -7,7 +7,6 @@ import firrtl.ir.Circuit
 import firrtl.annotations.{Annotation, NoTargetAnnotation}
 import firrtl.options.{HasShellOptions, OptionsException, ShellOption}
 
-import scopt.OptionParser
 
 import java.io.FileNotFoundException
 import java.nio.file.NoSuchFileException

--- a/src/main/scala/firrtl/stage/FirrtlOptions.scala
+++ b/src/main/scala/firrtl/stage/FirrtlOptions.scala
@@ -2,7 +2,7 @@
 
 package firrtl.stage
 
-import firrtl.{Compiler, Transform}
+import firrtl.Compiler
 import firrtl.ir.Circuit
 
 /** Internal options used to control the FIRRTL compiler stage.

--- a/src/main/scala/firrtl/stage/FirrtlStage.scala
+++ b/src/main/scala/firrtl/stage/FirrtlStage.scala
@@ -9,7 +9,6 @@ import firrtl.passes.{PassException, PassExceptions}
 
 import scala.util.control.ControlThrowable
 
-import java.io.PrintWriter
 
 class FirrtlStage extends Stage {
   val shell: Shell = new Shell("firrtl") with FirrtlCli

--- a/src/main/scala/firrtl/stage/package.scala
+++ b/src/main/scala/firrtl/stage/package.scala
@@ -3,7 +3,7 @@
 package firrtl
 
 import firrtl.annotations.DeletedAnnotation
-import firrtl.options.{OptionsView, PhasePrerequisiteException, Viewer}
+import firrtl.options.{OptionsView, Viewer}
 import firrtl.stage.phases.WriteEmitted
 
 /** The [[stage]] package provides an implementation of the FIRRTL compiler using the [[firrtl.options]] package. This

--- a/src/main/scala/firrtl/stage/phases/AddCircuit.scala
+++ b/src/main/scala/firrtl/stage/phases/AddCircuit.scala
@@ -4,8 +4,8 @@ package firrtl.stage.phases
 
 import firrtl.stage._
 
-import firrtl.{AnnotationSeq, Parser, proto}
-import firrtl.options.{OptionsException, Phase, PhasePrerequisiteException}
+import firrtl.{AnnotationSeq, Parser}
+import firrtl.options.{Phase, PhasePrerequisiteException}
 
 /** [[firrtl.options.Phase Phase]] that expands [[FirrtlFileAnnotation]]/[[FirrtlSourceAnnotation]] into
   * [[FirrtlCircuitAnnotation]]s and deletes the originals. This is part of the preprocessing done on an input

--- a/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
+++ b/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
@@ -4,7 +4,7 @@ package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, EmitAllModulesAnnotation}
 import firrtl.options.{Phase, Viewer}
-import firrtl.stage.{FirrtlCircuitAnnotation, FirrtlOptions, OutputFileAnnotation}
+import firrtl.stage.{FirrtlOptions, OutputFileAnnotation}
 
 /** [[firrtl.options.Phase Phase]] that adds an [[OutputFileAnnotation]] if one does not already exist.
   *

--- a/src/main/scala/firrtl/stage/phases/Checks.scala
+++ b/src/main/scala/firrtl/stage/phases/Checks.scala
@@ -6,7 +6,7 @@ import firrtl.stage._
 
 import firrtl.{AnnotationSeq, EmitAllModulesAnnotation, EmitCircuitAnnotation}
 import firrtl.annotations.Annotation
-import firrtl.options.{OptionsException, Phase, StageUtils}
+import firrtl.options.{OptionsException, Phase}
 
 /** [[firrtl.options.Phase Phase]] that strictly validates an [[AnnotationSeq]]. The checks applied are intended to be
   * extremeley strict. Nothing is inferred or assumed to take a default value (for default value resolution see

--- a/src/main/scala/firrtl/stage/phases/Compiler.scala
+++ b/src/main/scala/firrtl/stage/phases/Compiler.scala
@@ -4,7 +4,7 @@ package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, ChirrtlForm, CircuitState, Compiler => FirrtlCompiler, Transform, seqToAnnoSeq}
 import firrtl.options.{Phase, PhasePrerequisiteException, Translator}
-import firrtl.stage.{CircuitOption, CompilerAnnotation, FirrtlOptions, FirrtlCircuitAnnotation,
+import firrtl.stage.{CompilerAnnotation, FirrtlCircuitAnnotation,
   RunFirrtlTransformAnnotation}
 
 import scala.collection.mutable

--- a/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
+++ b/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
@@ -7,7 +7,7 @@ import firrtl.stage._
 import firrtl.{AnnotationSeq, EmitAllModulesAnnotation, EmitCircuitAnnotation, FirrtlExecutionResult, Parser}
 import firrtl.annotations.NoTargetAnnotation
 import firrtl.proto.FromProto
-import firrtl.options.{HasShellOptions, InputAnnotationFileAnnotation, OptionsException, Phase, ShellOption,
+import firrtl.options.{InputAnnotationFileAnnotation, OptionsException, Phase,
   StageOptions, StageUtils}
 import firrtl.options.Viewer
 

--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -5,7 +5,6 @@ package firrtl.transforms
 import java.io.{File, FileNotFoundException, FileInputStream, FileOutputStream, PrintWriter}
 
 import firrtl._
-import firrtl.Utils.throwInternalError
 import firrtl.annotations._
 
 import scala.collection.immutable.ListSet

--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -143,7 +143,7 @@ object BlackBoxSourceHelper {
     * @param file the file to write it into
     * @throws BlackBoxNotFoundException if the requested resource does not exist
     */
-  def copyResourceToFile(name: String, file: File) {
+  def copyResourceToFile(name: String, file: File): Unit = {
     val in = getClass.getResourceAsStream(name)
     val out = new FileOutputStream(file)
     safeFile(name)(Iterator.continually(in.read).takeWhile(-1 != _).foreach(out.write))
@@ -152,7 +152,7 @@ object BlackBoxSourceHelper {
 
   val fileListName = "firrtl_black_box_resource_files.f"
 
-  def writeFileList(files: ListSet[File], targetDir: File) {
+  def writeFileList(files: ListSet[File], targetDir: File): Unit = {
     if (files.nonEmpty) {
       // We need the canonical path here, so verilator will create a path to the file that works from the targetDir,
       //  and, so we can compare the list of files automatically included, with an explicit list provided by the client
@@ -164,7 +164,7 @@ object BlackBoxSourceHelper {
     }
   }
 
-  def writeTextToFile(text: String, file: File) {
+  def writeTextToFile(text: String, file: File): Unit = {
     val out = new PrintWriter(file)
     out.write(text)
     out.close()

--- a/src/main/scala/firrtl/transforms/CheckCombLoops.scala
+++ b/src/main/scala/firrtl/transforms/CheckCombLoops.scala
@@ -3,11 +3,7 @@
 package firrtl.transforms
 
 import scala.collection.mutable
-import scala.collection.immutable.HashSet
-import scala.collection.immutable.HashMap
-import annotation.tailrec
 
-import Function.tupled
 
 import firrtl._
 import firrtl.ir._
@@ -18,7 +14,6 @@ import firrtl.Utils.throwInternalError
 import firrtl.graph.{MutableDiGraph,DiGraph}
 import firrtl.analyses.InstanceGraph
 import firrtl.options.{RegisteredTransform, ShellOption}
-import scopt.OptionParser
 
 object CheckCombLoops {
   class CombLoopException(info: Info, mname: String, cycle: Seq[String]) extends PassException(

--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -10,7 +10,6 @@ import firrtl.Utils._
 import firrtl.Mappers._
 import firrtl.PrimOps._
 import firrtl.graph.DiGraph
-import firrtl.WrappedExpression.weq
 import firrtl.analyses.InstanceGraph
 import firrtl.annotations.TargetToken.Ref
 

--- a/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
+++ b/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
@@ -8,14 +8,11 @@ import firrtl.annotations._
 import firrtl.graph._
 import firrtl.analyses.InstanceGraph
 import firrtl.Mappers._
-import firrtl.WrappedExpression._
-import firrtl.Utils.{throwInternalError, toWrappedExpression, kind}
+import firrtl.Utils.{throwInternalError, kind}
 import firrtl.MemoizedHash._
 import firrtl.options.{RegisteredTransform, ShellOption}
-import scopt.OptionParser
 
 import collection.mutable
-import java.io.{File, FileWriter}
 
 /** Dead Code Elimination (DCE)
   *

--- a/src/main/scala/firrtl/transforms/GroupComponents.scala
+++ b/src/main/scala/firrtl/transforms/GroupComponents.scala
@@ -4,9 +4,8 @@ import firrtl._
 import firrtl.Mappers._
 import firrtl.ir._
 import firrtl.annotations.{Annotation, ComponentName}
-import firrtl.passes.{InferTypes, LowerTypes, MemPortUtils, ResolveKinds}
-import firrtl.Utils.kind
-import firrtl.graph.{DiGraph, MutableDiGraph}
+import firrtl.passes.{InferTypes, LowerTypes, ResolveKinds}
+import firrtl.graph.MutableDiGraph
 
 import scala.collection.mutable
 

--- a/src/main/scala/firrtl/transforms/OptimizationAnnotations.scala
+++ b/src/main/scala/firrtl/transforms/OptimizationAnnotations.scala
@@ -4,7 +4,6 @@ package transforms
 
 import firrtl.annotations._
 import firrtl.passes.PassException
-import firrtl.transforms
 
 /** Indicate that DCE should not be run */
 case object NoDCEAnnotation extends NoTargetAnnotation

--- a/src/main/scala/firrtl/transforms/RemoveWires.scala
+++ b/src/main/scala/firrtl/transforms/RemoveWires.scala
@@ -8,7 +8,7 @@ import firrtl.Utils._
 import firrtl.Mappers._
 import firrtl.traversals.Foreachers._
 import firrtl.WrappedExpression._
-import firrtl.graph.{DiGraph, MutableDiGraph, CyclicException}
+import firrtl.graph.{MutableDiGraph, CyclicException}
 
 import scala.collection.mutable
 import scala.util.{Try, Success, Failure}

--- a/src/main/scala/firrtl/transforms/TopWiring.scala
+++ b/src/main/scala/firrtl/transforms/TopWiring.scala
@@ -11,10 +11,7 @@ import firrtl.passes.{Pass,
       }
 import firrtl.annotations._
 import firrtl.Mappers._
-import firrtl.graph._
 
-import java.io._
-import scala.io.Source
 import collection.mutable
 
 /** Annotation for optional output files, and what directory to put those files in (absolute path) **/

--- a/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
+++ b/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
@@ -7,7 +7,6 @@ import java.nio.file.Files
 import java.text.SimpleDateFormat
 import java.util.Calendar
 
-import firrtl.FirrtlExecutionOptions
 
 import scala.sys.process.{ProcessBuilder, ProcessLogger, _}
 

--- a/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
+++ b/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
@@ -25,7 +25,7 @@ trait BackendCompilationUtilities {
     * @param name the name of the resource
     * @param file the file to write it into
     */
-  def copyResourceToFile(name: String, file: File) {
+  def copyResourceToFile(name: String, file: File): Unit = {
     val in = getClass.getResourceAsStream(name)
     if (in == null) {
       throw new FileNotFoundException(s"Resource '$name'")

--- a/src/main/scala/logger/Logger.scala
+++ b/src/main/scala/logger/Logger.scala
@@ -4,11 +4,8 @@ package logger
 
 import java.io.{ByteArrayOutputStream, File, FileOutputStream, PrintStream}
 
-import firrtl.{ExecutionOptionsManager, HasFirrtlOptions, AnnotationSeq}
-import firrtl.stage.FirrtlOptions
-import firrtl.options.StageOptions
+import firrtl.{ExecutionOptionsManager, AnnotationSeq}
 import firrtl.options.Viewer.view
-import firrtl.stage.FirrtlOptionsView
 import logger.phases.{AddDefaults, Checks}
 
 import scala.util.DynamicVariable

--- a/src/main/scala/logger/LoggerAnnotations.scala
+++ b/src/main/scala/logger/LoggerAnnotations.scala
@@ -2,11 +2,9 @@
 
 package logger
 
-import firrtl.AnnotationSeq
 import firrtl.annotations.{Annotation, NoTargetAnnotation}
-import firrtl.options.{HasShellOptions, ShellOption, StageUtils}
+import firrtl.options.{HasShellOptions, ShellOption}
 
-import scopt.OptionParser
 
 /** An annotation associated with a Logger command line option */
 sealed trait LoggerOption { this: Annotation => }

--- a/src/main/scala/tutorial/lesson1-circuit-traversal/AnalyzeCircuit.scala
+++ b/src/main/scala/tutorial/lesson1-circuit-traversal/AnalyzeCircuit.scala
@@ -6,7 +6,7 @@ package lesson1
 // Compiler Infrastructure
 import firrtl.{Transform, LowForm, CircuitState, Utils}
 // Firrtl IR classes
-import firrtl.ir.{Circuit, DefModule, Statement, Expression, Mux}
+import firrtl.ir.{DefModule, Statement, Expression, Mux}
 // Map functions
 import firrtl.Mappers._
 // Scala's mutable collections

--- a/src/main/scala/tutorial/lesson2-working-ir/AnalyzeCircuit.scala
+++ b/src/main/scala/tutorial/lesson2-working-ir/AnalyzeCircuit.scala
@@ -6,7 +6,7 @@ package lesson2
 // Compiler Infrastructure
 import firrtl.{Transform, LowForm, CircuitState, Utils}
 // Firrtl IR classes
-import firrtl.ir.{Circuit, DefModule, Statement, DefInstance, Expression, Mux}
+import firrtl.ir.{DefModule, Statement, DefInstance, Expression, Mux}
 // Firrtl compiler's working IR classes (WIR)
 import firrtl.WDefInstance
 // Map functions


### PR DESCRIPTION
I add scalafix and then run 

```shell
sbt "firrtl/scalafix ProcedureSyntax"
```
and
```shell
sbt "firrtl/scalafix RemoveUnused"
```