### PR TITLE
Add register init to RemoveWires dependencies

### DIFF
--- a/src/main/scala/firrtl/transforms/RemoveWires.scala
+++ b/src/main/scala/firrtl/transforms/RemoveWires.scala
@@ -90,11 +90,12 @@ class RemoveWires extends Transform {
           wireInfo(WRef(wire)) = wire.info
         case reg: DefRegister =>
           val resetDep = reg.reset.tpe match {
-            case AsyncResetType => reg.reset :: Nil
-            case _ => Nil
+            case AsyncResetType => Some(reg.reset)
+            case _ => None
           }
+          val initDep = Some(reg.init).filter(we(WRef(reg)) != we(_)) // Dependency exists IF reg doesn't init itself
           regInfo(we(WRef(reg))) = reg
-          netlist(we(WRef(reg))) = (reg.clock :: resetDep, reg.info)
+          netlist(we(WRef(reg))) = (Seq(reg.clock) ++ resetDep ++ initDep, reg.info)
         case decl: IsDeclaration => // Keep all declarations except for nodes and non-Analog wires
           decls += decl
         case con @ Connect(cinfo, lhs, rhs) => kind(lhs) match {

--- a/src/test/scala/firrtlTests/RemoveWiresSpec.scala
+++ b/src/test/scala/firrtlTests/RemoveWiresSpec.scala
@@ -182,4 +182,20 @@ class RemoveWiresSpec extends FirrtlFlatSpec {
     // Check declaration before use is maintained
     passes.CheckHighForm.execute(result)
   }
+
+  it should "order registers respecting initializations" in {
+    val result = compileBody(
+      s"""|input clock : Clock
+          |input foo : UInt<2>
+          |output bar : UInt<2>
+          |wire y_fault : UInt<2>
+          |reg y : UInt<2>, clock with :
+          |  reset => (UInt<1>("h0"), y_fault)
+          |y_fault <= foo
+          |bar <= y
+          |""".stripMargin)
+    // Check declaration before use is maintained
+    passes.CheckHighForm.execute(result)
+  }
+
 }


### PR DESCRIPTION
Adds a dependency to `RemoveWires` for registers that do not initialize themselves. (Oddly, adding a dependency for self-initializing registers causes `InfoSpec` to fail.)

Fixes #1077