### PR TITLE
Dependency API

### DIFF
--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -11,7 +11,7 @@ import firrtl.annotations._
 import firrtl.ir.Circuit
 import firrtl.Utils.throwInternalError
 import firrtl.annotations.transforms.{EliminateTargetPaths, ResolvePaths}
-import firrtl.options.StageUtils
+import firrtl.options.{StageUtils, TransformLike}
 
 /** Container of all annotations for a Firrtl compiler */
 class AnnotationSeq private (private[firrtl] val underlying: List[Annotation]) {
@@ -169,7 +169,7 @@ final case object UnknownForm extends CircuitForm(-1) {
 // scalastyle:on magic.number
 
 /** The basic unit of operating on a Firrtl AST */
-abstract class Transform extends LazyLogging {
+abstract class Transform extends TransformLike[CircuitState] {
   /** A convenience function useful for debugging and error messages */
   def name: String = this.getClass.getSimpleName
   /** The [[firrtl.CircuitForm]] that this transform requires to operate on */
@@ -184,6 +184,8 @@ abstract class Transform extends LazyLogging {
     * @return A transformed Firrtl AST
     */
   protected def execute(state: CircuitState): CircuitState
+
+  def transform(state: CircuitState): CircuitState = execute(state)
 
   /** Convenience method to get annotations relevant to this Transform
     *

--- a/src/main/scala/firrtl/options/DependencyManager.scala
+++ b/src/main/scala/firrtl/options/DependencyManager.scala
@@ -1,0 +1,363 @@
+// See LICENSE for license details.
+
+package firrtl.options
+
+import firrtl.AnnotationSeq
+import firrtl.graph.{DiGraph, CyclicException}
+
+import scala.collection.Set
+import scala.collection.immutable.{Set => ISet}
+import scala.collection.mutable.{ArrayBuffer, HashMap, LinkedHashMap, LinkedHashSet, Queue}
+
+/** An exception arising from an in a [[DependencyManager]] */
+case class DependencyManagerException(message: String, cause: Throwable = null) extends RuntimeException(message, cause)
+
+/** A [[firrtl.options.TransformLike TransformLike]] that resolves a linear ordering of dependencies based on
+  * requirements.
+  * @tparam A the type over which this transforms
+  * @tparam B the type of the [[firrtl.options.TransformLike TransformLike]]
+  */
+trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends TransformLike[A] with DependencyAPI[B] {
+
+  /** Requested [[firrtl.options.TransformLike TransformLike]]s that should be run. Internally, this will be converted to
+    * a set based on the ordering defined here.
+    */
+  def targets: Seq[Class[B]]
+  private lazy val _targets: LinkedHashSet[Class[B]] = targets
+    .foldLeft(new LinkedHashSet[Class[B]]()){ case (a, b) => a += b }
+
+  /** A sequence of [[firrtl.Transform]]s that have been run. Internally, this will be converted to an ordered set.
+    */
+  def currentState: Seq[Class[B]]
+  private lazy val _currentState: LinkedHashSet[Class[B]] = currentState
+    .foldLeft(new LinkedHashSet[Class[B]]()){ case (a, b) => a += b }
+
+  /** Existing transform objects that have already been constructed */
+  def knownObjects: Set[B]
+
+  /** A sequence of wrappers to apply to the resulting [[firrtl.options.TransformLike TransformLike]] sequence. This can
+    * be used to, e.g., add automated pre-processing and post-processing.
+    */
+  def wrappers: Seq[(B) => B] = Seq.empty
+
+  /** Store of conversions between classes and objects. Objects that do not exist in the map will be lazily constructed.
+    */
+  protected lazy val classToObject: LinkedHashMap[Class[B], B] = {
+    val init = LinkedHashMap[Class[B], B](knownObjects.map(x => x.getClass.asInstanceOf[Class[B]] -> x).toSeq: _*)
+    (_targets ++ _currentState)
+      .filter(!init.contains(_))
+      .map(x => init(x) = safeConstruct(x))
+    init
+  }
+
+  /** A method that will create a copy of this [[firrtl.options.DependencyManager DependencyManager]], but with different
+    * requirements. This is used to solve sub-problems arising from invalidations.
+    */
+  protected def copy(
+    targets: Seq[Class[B]],
+    currentState: Seq[Class[B]],
+    knownObjects: ISet[B] = classToObject.values.toSet): B
+
+  /** Implicit conversion from Class[B] to B */
+  private implicit def cToO(c: Class[B]): B = classToObject.getOrElseUpdate(c, safeConstruct(c))
+
+  /** Implicit conversion from B to Class[B] */
+  private implicit def oToC(b: B): Class[B] = b.getClass.asInstanceOf[Class[B]]
+
+  /** Modified breadth-first search that supports multiple starting nodes and a custom extractor that can be used to
+    * generate/filter the edges to explore. Additionally, this will include edges to previously discovered nodes.
+    */
+  private def bfs( start: LinkedHashSet[Class[B]],
+                   blacklist: LinkedHashSet[Class[B]],
+                   extractor: B => Set[Class[B]] ): LinkedHashMap[B, LinkedHashSet[B]] = {
+
+    val (queue, edges) = {
+      val a: Queue[Class[B]]                    = Queue(start.toSeq:_*)
+      val b: LinkedHashMap[B, LinkedHashSet[B]] = LinkedHashMap[B, LinkedHashSet[B]](
+        start.map((cToO(_) -> LinkedHashSet[B]())).toSeq:_*)
+      (a, b)
+    }
+
+    while (queue.nonEmpty) {
+      val u: Class[B] = queue.dequeue
+      for (v: Class[B] <- extractor(classToObject(u))) {
+        if (!blacklist.contains(v) && !edges.contains(v)) {
+          queue.enqueue(v)
+        }
+        if (!edges.contains(v)) {
+          val obj = cToO(v)
+          edges(obj) = LinkedHashSet.empty
+          classToObject += (v -> obj)
+        }
+        edges(classToObject(u)) = edges(classToObject(u)) + classToObject(v)
+      }
+    }
+
+    edges
+  }
+
+  /** Pull in all registered [[firrtl.options.TransformLike TransformLike]] once [[firrtl.options.TransformLike
+    * TransformLike]] registration is integrated
+    * @todo implement this
+    */
+  private lazy val registeredTransforms: Set[B] = Set.empty
+
+  /** A directed graph consisting of prerequisite edges */
+  private lazy val prerequisiteGraph: DiGraph[B] = {
+    val edges = bfs(
+      start = _targets -- _currentState,
+      blacklist = _currentState,
+      extractor = (p: B) => new LinkedHashSet[Class[B]]() ++ p.prerequisites -- _currentState)
+    DiGraph(edges)
+  }
+
+  /** A directed graph consisting of prerequisites derived from only those transforms which are supposed to run. This
+    * pulls in dependents for transforms which are not in the target set.
+    */
+  private lazy val dependentsGraph: DiGraph[B] = {
+    val v = new LinkedHashSet() ++ prerequisiteGraph.getVertices
+    DiGraph(new LinkedHashMap() ++ v.map(vv => vv -> ((new LinkedHashSet() ++ vv.dependents).map(cToO) & v))).reverse
+  }
+
+  /** A directed graph consisting of prerequisites derived from ALL targets. This is necessary for defining targets for
+    * [[DependencyManager]] sub-problems.
+    */
+  private lazy val otherDependents: DiGraph[B] = {
+    val edges = {
+      val x = new LinkedHashMap ++ _targets
+        .map(classToObject)
+        .map{ a => a -> prerequisiteGraph.getVertices.filter(a._dependents(_)) }
+      x
+        .values
+        .reduce(_ ++ _)
+        .foldLeft(x){ case (xx, y) => if (xx.contains(y)) { xx } else { xx ++ Map(y -> Set.empty[B]) } }
+    }
+    DiGraph(edges).reverse
+  }
+
+  /** A directed graph consisting of all prerequisites, including prerequisites derived from dependents */
+  lazy val dependencyGraph: DiGraph[B] = prerequisiteGraph + dependentsGraph
+
+  /** A directed graph consisting of invalidation edges */
+  lazy val invalidateGraph: DiGraph[B] = {
+    val v = dependencyGraph.getVertices
+    DiGraph(
+      bfs(
+        start = _targets -- _currentState,
+        blacklist = _currentState,
+        extractor = (p: B) => v.filter(p.invalidates).map(_.asClass).toSet))
+      .reverse
+  }
+
+  /** Wrap a possible [[CyclicException]] thrown by a thunk in a [[DependencyManagerException]] */
+  private def cyclePossible[A](a: String, diGraph: DiGraph[_])(thunk: => A): A = try { thunk } catch {
+    case e: CyclicException =>
+      throw new DependencyManagerException(
+        s"""|No transform ordering possible due to cyclic dependency in $a with cycles:
+            |${diGraph.findSCCs.filter(_.size > 1).mkString("    - ", "\n    - ", "")}""".stripMargin, e)
+  }
+
+  /** Wrap an [[IllegalAccessException]] due to attempted object construction in a [[DependencyManagerException]] */
+  private def safeConstruct[A](a: Class[A]): A = try { a.newInstance } catch {
+    case e: IllegalAccessException => throw new DependencyManagerException(
+      s"Failed to construct '$a'! (Did you try to construct an object?)", e)
+    case e: InstantiationException => throw new DependencyManagerException(
+      s"Failed to construct '$a'! (Did you try to construct an inner class or a class with parameters?)", e)
+  }
+
+  /** An ordering of [[firrtl.options.TransformLike TransformLike]]s that causes the requested [[DependencyManager.targets
+    * targets]] to be executed starting from the [[DependencyManager.currentState currentState]]. This ordering respects
+    * prerequisites, dependents, and invalidates of all constituent [[firrtl.options.TransformLike TransformLike]]s.
+    * This uses an algorithm that attempts to reduce the number of re-lowerings due to invalidations. Re-lowerings are
+    * implemented as new [[DependencyManager]]s.
+    * @throws DependencyManagerException if a cycle exists in either the [[DependencyManager.dependencyGraph
+    * dependencyGraph]] or the [[DependencyManager.invalidateGraph invalidateGraph]].
+    */
+  lazy val transformOrder: Seq[B] = {
+
+    /* Topologically sort the dependency graph using the invalidate graph topological sort as a seed. This has the effect of
+     * reducing (perhaps minimizing?) the number of work re-lowerings.
+     */
+    val sorted = {
+      val seed = cyclePossible("invalidates", invalidateGraph){ invalidateGraph.linearize }.reverse
+
+      cyclePossible("prerequisites/dependents", dependencyGraph) {
+        dependencyGraph
+          .seededLinearize(Some(seed))
+          .reverse
+          .dropWhile(b => _currentState.contains(b))
+      }
+    }
+
+    val (state, lowerers) = {
+      /* [todo] Seq is inefficient here, but Array has ClassTag problems. Use something else? */
+      val (s, l) = sorted.foldLeft((_currentState, Seq[B]())){ case ((state, out), in) =>
+        /* The prerequisites are both prerequisites AND dependents. */
+        val prereqs = new LinkedHashSet() ++ in.prerequisites ++
+          dependencyGraph.getEdges(in).toSeq.map(oToC) ++
+          otherDependents.getEdges(in).toSeq.map(oToC)
+        val missing = (prereqs -- state)
+        val preprocessing: Option[B] = {
+          if (missing.nonEmpty) { Some(this.copy(prereqs.toSeq, state.toSeq)) }
+          else                  { None                                     }
+        }
+        ((state ++ missing + in).map(cToO).filterNot(in.invalidates).map(oToC), out ++ preprocessing :+ in)
+      }
+      val missing = (_targets -- s)
+      val postprocessing: Option[B] = {
+        if (missing.nonEmpty) { Some(this.copy(_targets.toSeq, s.toSeq)) }
+        else                  { None                        }
+      }
+
+      (s ++ missing, l ++ postprocessing)
+    }
+
+    if (!_targets.subsetOf(state)) {
+      throw new DependencyManagerException(
+        s"The final state ($state) did not include the requested targets (${targets})!")
+    }
+    lowerers
+  }
+
+  /** A version of the [[DependencyManager.transformOrder transformOrder]] that flattens the transforms of any internal
+    * [[DependencyManager]]s.
+    */
+  lazy val flattenedTransformOrder: Seq[B] = transformOrder.flatMap {
+    case p: DependencyManager[A, B] => p.flattenedTransformOrder
+    case p => Some(p)
+  }
+
+  final override def transform(annotations: A): A = {
+
+    /* A local store of each wrapper to it's underlying class. */
+    val wrapperToClass = new HashMap[B, Class[B]]
+
+    /* The determined, flat order of transforms is wrapped with surrounding transforms while populating wrapperToClass so
+     * that each wrapped transform object can be dereferenced to its underlying class. Each wrapped transform is then
+     * applied while tracking the state of the underlying A. If the state ever disagrees with a prerequisite, then this
+     * throws an exception.
+     */
+    flattenedTransformOrder
+      .map{ t =>
+        val w = wrappers.foldLeft(t){ case (tx, wrapper) => wrapper(tx) }
+        wrapperToClass += (w -> t)
+        w
+      }.foldLeft((annotations, _currentState)){ case ((a, state), t) =>
+          if (!t.prerequisites.toSet.subsetOf(state)) {
+            throw new DependencyManagerException(
+              s"""|Tried to execute '$t' for which run-time prerequisites were not satisfied:
+                  |  state: ${state.mkString("\n    -", "\n    -", "")}
+                  |  prerequisites: ${prerequisites.mkString("\n    -", "\n    -", "")}""".stripMargin)
+          }
+          (t.transform(a), ((state + wrapperToClass(t)).map(cToO).filterNot(t.invalidates).map(oToC)))
+      }._1
+  }
+
+  /** This colormap uses Colorbrewer's 4-class OrRd color scheme */
+  protected val colormap = Seq("#fef0d9", "#fdcc8a", "#fc8d59", "#d7301f")
+
+  /** Get a name of some [[firrtl.options.TransformLike TransformLike]] */
+  private def transformName(transform: B, suffix: String = ""): String = s""""${transform.name}$suffix""""
+
+  /** Convert all prerequisites, dependents, and invalidates to a Graphviz representation.
+    * @param file the name of the output file
+    */
+  def dependenciesToGraphviz: String = {
+
+    def toGraphviz(digraph: DiGraph[B], attributes: String = "", tab: String = "    "): Option[String] = {
+      val edges =
+        digraph
+          .getEdgeMap
+          .collect{ case (v, edges) if edges.nonEmpty => (v -> edges) }
+          .map{ case (v, edges) =>
+            s"""${transformName(v)} -> ${edges.map(e => transformName(e)).mkString("{ ", " ", " }")}""" }
+
+      if (edges.isEmpty) { None } else {
+        Some(
+          s"""|  { $attributes
+              |${edges.mkString(tab, "\n" + tab, "")}
+              |  }""".stripMargin
+        )
+      }
+    }
+
+    val connections =
+      Seq( (prerequisiteGraph, "edge []"),
+           (dependentsGraph,   """edge [color="#de2d26"]"""),
+           (invalidateGraph,   "edge [minlen=2,style=dashed,constraint=false]") )
+        .flatMap{ case (a, b) => toGraphviz(a, b) }
+        .mkString("\n")
+
+    val nodes =
+      (prerequisiteGraph + dependentsGraph + invalidateGraph + otherDependents)
+        .getVertices
+        .map(v => s"""${transformName(v)} [label="${v.getClass.getSimpleName}"]""")
+
+    s"""|digraph DependencyManager {
+        |  graph [rankdir=BT]
+        |  node [fillcolor="${colormap(0)}",style=filled,shape=box]
+        |${nodes.mkString("  ", "\n" + "  ", "")}
+        |$connections
+        |}
+        |""".stripMargin
+  }
+
+  def transformOrderToGraphviz(colormap: Seq[String] = colormap): String = {
+
+    def rotate[A](a: Seq[A]): Seq[A] = a match {
+      case Nil => Nil
+      case car :: cdr => cdr :+ car
+      case car => car
+    }
+
+    val sorted = ArrayBuffer.empty[String]
+
+    def rec(pm: DependencyManager[A, B], cm: Seq[String], tab: String = "", id: Int = 0): (String, Int) = {
+      var offset = id
+
+      val targets = pm._targets.toSeq.map(_.getSimpleName).mkString(", ")
+      val state = pm._currentState.toSeq.map(_.getSimpleName).mkString(", ")
+
+      val header = s"""|${tab}subgraph cluster_$id {
+                       |$tab  label="targets: $targets\\nstate: $state"
+                       |$tab  labeljust=l
+                       |$tab  node [fillcolor="${cm.head}"]""".stripMargin
+
+      val body = pm.transformOrder.map{
+        case a: DependencyManager[A, B] =>
+          val (str, d) = rec(a, rotate(cm), tab + "  ", offset + 1)
+          offset = d
+          str
+        case a =>
+          val name = s"""${transformName(a, "_" + id)}"""
+          sorted += name
+          s"""$tab  $name [label="${a.getClass.getSimpleName}"]"""
+      }.mkString("\n")
+
+      (Seq(header, body, s"$tab}").mkString("\n"), offset)
+    }
+
+    s"""|digraph DependencyManagerTransformOrder {
+        |  graph [rankdir=TB]
+        |  node [style=filled,shape=box]
+        |${rec(this, colormap, "  ")._1}
+        |  ${sorted.mkString(" -> ")}
+        |}""".stripMargin
+  }
+
+}
+
+/** A [[Phase]] that will ensure that some other [[Phase]]s and their prerequisites are executed.
+  *
+  * This tries to determine a phase ordering such that an [[AnnotationSeq]] ''output'' is produced that has had all of
+  * the requested [[Phase]] target transforms run without having them be invalidated.
+  * @param targets the [[Phase]]s you want to run
+  */
+class PhaseManager(
+  val targets: Seq[Class[Phase]],
+  val currentState: Seq[Class[Phase]] = Seq.empty,
+  val knownObjects: Set[Phase] = Set.empty) extends Phase with DependencyManager[AnnotationSeq, Phase] {
+
+  protected def copy(a: Seq[Class[Phase]], b: Seq[Class[Phase]], c: ISet[Phase]) = new PhaseManager(a, b, c)
+
+}

--- a/src/main/scala/firrtl/options/Phase.scala
+++ b/src/main/scala/firrtl/options/Phase.scala
@@ -6,6 +6,7 @@ import firrtl.AnnotationSeq
 
 import logger.LazyLogging
 
+import scala.collection.mutable.LinkedHashSet
 
 /** A polymorphic mathematical transform
   * @tparam A the transformed type
@@ -23,15 +24,78 @@ trait TransformLike[A] extends LazyLogging {
 
 }
 
+/** Mixin that defines dependencies between [[firrtl.options.TransformLike TransformLike]]s (hereafter referred to as
+  * "transforms")
+  *
+  * This trait forms the basis of the Dependency API of the Chisel/FIRRTL Hardware Compiler Framework. Dependencies are
+  * defined in terms of prerequisistes, dependents, and invalidates. A prerequisite is a transform that must run before
+  * this transform. A dependent is a transform that must run ''after'' this transform. (This can be viewed as a means of
+  * injecting a prerequisite into some other transform.) Finally, invalidates define the set of transforms whose effects
+  * this transform undos/invalidates. (Invalidation then implies that a transform that is invalidated by this transform
+  * and needed by another transform will need to be re-run.)
+  *
+  * This Dependency API only defines dependencies. A concrete [[DependencyManager]] is expected to be used to statically
+  * resolve a linear ordering of transforms that satisfies dependency requirements.
+  * @tparam A some transform
+  * @define seqNote @note The use of a Seq here is to preserve input order. Internally, this will be converted to a private,
+  * ordered Set.
+  */
+trait DependencyAPI[A <: DependencyAPI[A]] { this: TransformLike[_] =>
+
+  /** All transform that must run before this transform
+    * $seqNote
+    */
+  def prerequisites: Seq[Class[A]] = Seq.empty
+  private[options] lazy val _prerequisites: LinkedHashSet[Class[A]] = new LinkedHashSet() ++ prerequisites.toSet
+
+  /** All transforms that must run ''after'' this transform
+    *
+    * ''This is a means of prerequisite injection into some other transform.'' Normally a transform will define its own
+    * prerequisites. Dependents exist for two main situations:
+    *
+    * First, they improve the composition of optional transforms. If some first transform is optional (e.g., an
+    * expensive validation check), you would like to be able to conditionally cause it to run. If it is listed as a
+    * prerequisite on some other, second transform then it must always run before that second transform. There's no way
+    * to turn it off. However, by listing the second transform as a dependent of the first transform, the first
+    * transform will only run (and be treated as a prerequisite of the second transform) if included in a list of target
+    * transforms that should be run.
+    *
+    * Second, an external library would like to inject some first transform before a second transform inside FIRRTL. In
+    * this situation, the second transform cannot have any knowledge of external libraries. The use of a dependent here
+    * allows for prerequisite injection into FIRRTL proper.
+    *
+    * @see [[firrtl.passes.CheckTypes]] for an example of an optional checking [[firrtl.Transform]]
+    * $seqNote
+    */
+  def dependents: Seq[Class[A]] = Seq.empty
+  private[options] lazy val _dependents: LinkedHashSet[Class[A]] = new LinkedHashSet() ++ dependents.toSet
+
+  /** A function that, given a transform will return true if this transform invalidates/undos the effects of the input
+    * transform
+    * @note Can a [[firrtl.options.Phase Phase]] ever invalidate itself?
+    */
+  def invalidates(a: A): Boolean = true
+
+  /** Helper method to return the underlying class */
+  final def asClass: Class[A] = this.getClass.asInstanceOf[Class[A]]
+
+  /** Implicit conversion that allows for terser specification of [[DependencyAPI.prerequisites prerequisites]] and
+    * [[DependencyAPI.dependents dependents]].
+    */
+  implicit def classHelper(a: Class[_ <: A]): Class[A] = a.asInstanceOf[Class[A]]
+
+}
+
 /** A mathematical transformation of an [[AnnotationSeq]].
   *
-  * A [[Phase]] forms one unit in the Chisel/FIRRTL Hardware Compiler Framework (HCF). The HCF is built from a sequence
-  * of [[Phase]]s applied to an [[AnnotationSeq]]. Note that a [[Phase]] may consist of multiple phases internally.
+  * A [[firrtl.options.Phase Phase]] forms one unit in the Chisel/FIRRTL Hardware Compiler Framework (HCF). The HCF is
+  * built from a sequence of [[firrtl.options.Phase Phase]]s applied to an [[AnnotationSeq]]. Note that a
+  * [[firrtl.options.Phase Phase]] may consist of multiple phases internally.
   */
-abstract class Phase extends TransformLike[AnnotationSeq] {
+trait Phase extends TransformLike[AnnotationSeq] with DependencyAPI[Phase] {
 
-  /** The name of this [[Phase]]. This will be used to generate debug/error messages or when deleting annotations. This
-    * will default to the `simpleName` of the class.
+  /** The name of this [[firrtl.options.Phase Phase]]. This will be used to generate debug/error messages or when deleting
+    * annotations. This will default to the `simpleName` of the class.
     * @return this phase's name
     * @note Override this with your own implementation for different naming behavior.
     */
@@ -39,15 +103,15 @@ abstract class Phase extends TransformLike[AnnotationSeq] {
 
 }
 
-/** A [[TransformLike]] that internally ''translates'' the input type to some other type, transforms the internal type,
-  * and converts back to the original type.
+/** A [[firrtl.options.TransformLike TransformLike]] that internally ''translates'' the input type to some other type,
+  * transforms the internal type, and converts back to the original type.
   *
-  * This is intended to be used to insert a [[TransformLike]] parameterized by type `B` into a sequence of
-  * [[TransformLike]]s parameterized by type `A`.
-  * @tparam A the type of the [[TransformLike]]
+  * This is intended to be used to insert a [[firrtl.options.TransformLike TransformLike]] parameterized by type `B`
+  * into a sequence of [[firrtl.options.TransformLike TransformLike]]s parameterized by type `A`.
+  * @tparam A the type of the [[firrtl.options.TransformLike TransformLike]]
   * @tparam B the internal type
   */
-trait Translator[A, B] { this: TransformLike[A] =>
+trait Translator[A, B] extends TransformLike[A] {
 
   /** A method converting type `A` into type `B`
     * @param an object of type `A`
@@ -69,6 +133,6 @@ trait Translator[A, B] { this: TransformLike[A] =>
 
   /** Convert the input object to the internal type, transform the internal type, and convert back to the original type
     */
-  final def transform(a: A): A = internalTransform(a)
+  override final def transform(a: A): A = bToA(internalTransform(aToB(a)))
 
 }

--- a/src/main/scala/firrtl/options/Phase.scala
+++ b/src/main/scala/firrtl/options/Phase.scala
@@ -86,6 +86,15 @@ trait DependencyAPI[A <: DependencyAPI[A]] { this: TransformLike[_] =>
 
 }
 
+/** A trait indicating that no invalidations occur, i.e., all previous transforms are preserved
+  * @tparam A some [[TransformLike]]
+  */
+trait PreservesAll[A <: DependencyAPI[A]] { this: DependencyAPI[A] =>
+
+  override def invalidates(a: A): Boolean = false
+
+}
+
 /** A mathematical transformation of an [[AnnotationSeq]].
   *
   * A [[firrtl.options.Phase Phase]] forms one unit in the Chisel/FIRRTL Hardware Compiler Framework (HCF). The HCF is


### PR DESCRIPTION
(Re-opening #1015 as Travis is not updating `$TRAVIS_BRANCH` after changing PR base branch...)

This implements a Dependency API for `TransformLike[A]` (hereafter referred to as **transforms**). This adds a `DependencyAPI` trait, an abstract class `DependencyManager`, and a concrete `PhaseManager`. The `DependencyAPI` defines three types of "dependencies" that, by implementing, allow a user to defer determination of a valid ordering to a `DependencyManager`. 

Dependencies of transform _Foo_ are then described using:

  - **prerequisites**: transforms that should run before Foo
  - **dependents**: transforms that should run after Foo (a means of prerequisite injection)
  - **invalidates**: transforms whose work/effects Foo destroys

Prerequisites and dependents are defined as a `Seq[Class[A]]` and internally converted to `LinkedHashSet[Class[A]]`. While a public API that exposes an immutable set is preferable, this is a compromise since no such set exists. Alternatives not used are: `scala.collection.Set`, `scala.collection.mutable.LinkedHashSet`, and `ListSet`.

A `DependencyManager` can then be used to, given a set of transforms you want to run and a set of all transforms that have been run, determine a linear ordering of transforms that satisfy your requirements. This uses a modification of the algorithm proposed by @azidar in https://github.com/freechipsproject/firrtl/issues/446#issuecomment-300573107:

1. A DAG of transforms with *invalidation edges* is constructed (an *invalidates graph*)
2. A DAG of transforms with *prerequisite and dependent edges* is constructed (a *dependents graph*)
3. A toplogical sort of the dependents graph, seeded with the reverse topological sort of the invalidates graph, gives a good ordering of transforms that minimizes re-lowerings
4. This ordering is examined, node by node, cleaning up any mismatches between transforms by solving `DependencyManager` sub-problems

This PR adds the `seededLinearize` method to `DiGraph` that allows for a topological sort seeded with some starting nodes. This is required to implement the above algorithm.

Finally, in preparation for using `DependencyManager` for FIRRTL transform scheduling, this makes `Transform` extend `TransformLike[CircuitState]`. 

META:
- Depends on #1005 
- Fixes #948 
- Related to #446 

## Examples

The examples below show examples of how different combinations of dependencies interact and are resolved. This uses built-in `DependencyManager` methods for generating graphviz output. All examples below are taken from the included `PhaseManagerSpec`. 

The top graph shows dependencies with prerequisites as black arrows, dependents as red arrows, and invalidates with dashed lines. The bottom graph shows the resulting linear ordering (if one exists). Each `DependencyManager` sub-problem is shown as a cluster with it's "target transforms" and the "state" showing current transforms that have run.

### Simple Dependency

Here, `B` depends on `A` and we request to run `B`.

![dependencyGraph dot](https://user-images.githubusercontent.com/1018530/60222563-c5340280-984b-11e9-8095-71fd04960e6d.png)
![transformOrder dot](https://user-images.githubusercontent.com/1018530/60222564-c5cc9900-984b-11e9-97a5-15ddab0ae67a.png)

### Simple Invalidate

Here, you have a pretty basic graph with one invalidate: `D` invalidates `A`, but also requires `A`. To get everything to run, you have to solve a sub-problem that reruns `A`.

![dependencyGraph dot](https://user-images.githubusercontent.com/1018530/60222739-70dd5280-984c-11e9-9422-67ea8b0c9118.png)
![transformOrder dot](https://user-images.githubusercontent.com/1018530/60222740-70dd5280-984c-11e9-861e-f5afbdbcb7e4.png)

### Single Dependent (Prerequisite Injection)

This is intended to model the @stevenmburns case of needing to run a custom transform *before* something else. Here, `Second` depends on `First`, but we want to run the custom transform `Custom` which should be inserted between them. By making `Second` a dependent of `Custom` you get the ordering you want.

![dependencyGraph dot](https://user-images.githubusercontent.com/1018530/60224112-1ee9fc00-984f-11e9-9b57-df0be7438276.png)
![transformOrder dot](https://user-images.githubusercontent.com/1018530/60224114-1ee9fc00-984f-11e9-8db3-9b74ccc77b52.png)

### Two Invalidates

In this graph, there are only two invalidations. However, this teases out problems with sub-optimal linearizations (corresponding to different possible topological sorts of the dependents graph). 

![dependencyGraph dot](https://user-images.githubusercontent.com/1018530/60222631-0af0cb00-984c-11e9-9155-b1df270f2f1b.png)
![transformOrder dot](https://user-images.githubusercontent.com/1018530/60222632-0af0cb00-984c-11e9-8644-ba199d34607a.png)

Here is the resulting linearization without seeding using the invalidation graph.

![transformOrder dot](https://user-images.githubusercontent.com/1018530/60224359-1645f580-9850-11e9-969a-582714ef358e.png)

### Complicated Example

The graph sum of the dependents and invalidates graphs form a cycle. This is a test with multiple valid orderings where choosing a bad one will result in a lot of re-lowering.

![dependencyGraph dot](https://user-images.githubusercontent.com/1018530/60222651-1fcd5e80-984c-11e9-9de9-d0102efd2a8c.png)
![transformOrder dot](https://user-images.githubusercontent.com/1018530/60222653-2065f500-984c-11e9-8b07-be066abf7d83.png)

Similar to the above "Two Invalidates", you wind up with a valid, but worse solution without the seeded topological sort.

![transformOrder dot](https://user-images.githubusercontent.com/1018530/60224818-1a731280-9852-11e9-8db3-21147070e3ee.png)

### Chained Invalidation

In this graph, you start with a simple initial graph with some weird properties where your invalidations start invalidating other needed transforms. This graph has these odd properties:

- `A` invalidates `B`
- `B` invalidates `C`
- `C` invalidates `D`
- `E` depends on `[A, B, C, D]`
- You start in state `[B, C, D]` wanting to run `[A, E]`

This tests that "chained invalidation" is getting properly handled.

![dependencyGraph dot](https://user-images.githubusercontent.com/1018530/60222642-16dc8d00-984c-11e9-8fdf-368197a81a24.png)
![transformOrder dot](https://user-images.githubusercontent.com/1018530/60222643-17752380-984c-11e9-844f-cacf11d614aa.png)

### Cyclic Prerequisite

A cycle in the prerequisistes will throw an exception.

![dependencyGraph dot](https://user-images.githubusercontent.com/1018530/60225246-f4e70880-9853-11e9-9ae0-36c045a64607.png)

### Cyclic Invalidates

A cycle in the invalidates will throw an exception.

![dependencyGraph dot](https://user-images.githubusercontent.com/1018530/60225007-f106b680-9852-11e9-98e7-d2336bb9de57.png)

### Repeated Analyses

This covers an intended use case where some "analysis" phase is repeatedly invalidated by some "consumer" phases. Concretely an analysis phase would be a phase that produces information that a consumer phase wants to use. However, each consumer phase makes modifications which require the analysis phase to be re-run (e.g., an analysis phase that constructs an `InstanceGraph` and consumer phases that rename modules).

![dependencyGraph dot](https://user-images.githubusercontent.com/1018530/60225046-172c5680-9853-11e9-876b-80188e542582.png)
![transformOrder dot](https://user-images.githubusercontent.com/1018530/60225047-172c5680-9853-11e9-82f2-7459275f8c64.png)

### Inverted Repeated Analyses

This is equivalent to the repeated analyses above, but the consumer phases invalidate each other.

![dependencyGraph dot](https://user-images.githubusercontent.com/1018530/60225053-1c89a100-9853-11e9-8e95-119c58ba6d7a.png)
![transformOrder dot](https://user-images.githubusercontent.com/1018530/60225054-1c89a100-9853-11e9-99fe-5ce94b8158ad.png)

### Deterministic Order

This relatively big example asserts that a deterministic order is preserved for all graphs constructed inside a `DependencyManager`.

![dependencyGraph dot](https://user-images.githubusercontent.com/1018530/60225029-0845a400-9853-11e9-8628-6919e6cce468.png)
![transformOrder dot](https://user-images.githubusercontent.com/1018530/60225030-08de3a80-9853-11e9-921b-1e8791ecced1.png)
