### PR TITLE
Bugfix: GroupComponents

### DIFF
--- a/src/main/scala/firrtl/transforms/GroupComponents.scala
+++ b/src/main/scala/firrtl/transforms/GroupComponents.scala
@@ -264,6 +264,11 @@ class GroupComponents extends firrtl.Transform {
           val group = byNode(getWRef(c.loc).name)
           groupStatements(group) += Connect(c.info, c.loc, inGroupFixExps(group, topStmts)(c.expr))
           Block(topStmts)
+        case i: IsInvalid if byNode(getWRef(i.expr).name) != "" =>
+          // Sink is in group
+          val group = byNode(getWRef(i.expr).name)
+          groupStatements(group) += i
+          EmptyStmt
         // TODO Attach if all are in a group?
         case _: IsDeclaration | _: Connect | _: Attach =>
           // Sink is in Top


### PR DESCRIPTION
Bugfix for GroupComponents transform.

When grouping instances with invalid input ports, buggy behavior leaves the invalid statements in the parent module, instead of moving them to the new grouped module.

Includes test and bugfix.