### PR TITLE
Emit legal Verilog literals for ExtModule IntParams > 32-bit

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -205,6 +205,9 @@ class VerilogEmitter extends SeqTransform with Emitter {
   /** Turn Params into Verilog Strings */
   def stringify(param: Param): String = param match {
     case IntParam(name, value) => s".$name($value)"
+      val blen = value.bitLength
+      val lit = if (value > 0) s"$blen'd$value" else s"-${blen+1}'sd${value.abs}"
+      s".$name($lit)"
     case DoubleParam(name, value) => s".$name($value)"
     case StringParam(name, value) => s".${name}(${value.verilogEscape})"
     case RawStringParam(name, value) => s".$name($value)"

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -204,9 +204,14 @@ class VerilogEmitter extends SeqTransform with Emitter {
   }
   /** Turn Params into Verilog Strings */
   def stringify(param: Param): String = param match {
-    case IntParam(name, value) => s".$name($value)"
-      val blen = value.bitLength
-      val lit = if (value > 0) s"$blen'd$value" else s"-${blen+1}'sd${value.abs}"
+    case IntParam(name, value) =>
+      val lit =
+        if (value.isValidInt) {
+          s"$value"
+        } else {
+          val blen = value.bitLength
+          if (value > 0) s"$blen'd$value" else s"-${blen+1}'sd${value.abs}"
+        }
       s".$name($lit)"
     case DoubleParam(name, value) => s".$name($value)"
     case StringParam(name, value) => s".${name}(${value.verilogEscape})"

--- a/src/test/resources/blackboxes/LargeParam.v
+++ b/src/test/resources/blackboxes/LargeParam.v
@@ -1,0 +1,7 @@
+// See LICENSE for license details.
+module LargeParam #(parameter DATA=0, WIDTH=1) (
+  output [WIDTH-1:0] out
+);
+  assign out = DATA;
+endmodule
+

--- a/src/test/resources/blackboxes/LargeParamTester.fir
+++ b/src/test/resources/blackboxes/LargeParamTester.fir
@@ -1,0 +1,43 @@
+; See LICENSE for license details.
+circuit LargeParamTester :
+  extmodule LargeParam :
+    output out : UInt<1>
+
+    defname = LargeParam
+    parameter WIDTH = 1
+    parameter DATA = 0
+
+  extmodule LargeParam_1 :
+    output out : UInt<128>
+
+    defname = LargeParam
+    parameter WIDTH = 128
+    parameter DATA = 9223372036854775807000
+
+  extmodule LargeParam_2 :
+    output out : SInt<128>
+
+    defname = LargeParam
+    parameter WIDTH = 128
+    parameter DATA = -9223372036854775807000
+
+  module LargeParamTester  :
+    input clock : Clock
+    input reset : UInt<1>
+
+    inst mod1 of LargeParam
+    inst mod2 of LargeParam_1
+    inst mod3 of LargeParam_2
+
+    when not(reset) :
+      when neq(mod1.out, UInt(0)) :
+        printf(clock, UInt(1), "Assertion failed\nTest Failed!\n")
+        stop(clock, UInt(1), 1)
+      when neq(mod2.out, UInt<128>(9223372036854775807000)) :
+        printf(clock, UInt(1), "Assertion failed\nTest Failed!\n")
+        stop(clock, UInt(1), 1)
+      when neq(mod3.out, SInt<128>(-9223372036854775807000)) :
+        printf(clock, UInt(1), "Assertion failed\nTest Failed!\n")
+        stop(clock, UInt(1), 1)
+      stop(clock, UInt(1), 0)
+

--- a/src/test/scala/firrtlTests/ExtModuleSpec.scala
+++ b/src/test/scala/firrtlTests/ExtModuleSpec.scala
@@ -11,3 +11,4 @@ class RenamedExtModuleExecutionTest extends ExecutionTest("RenamedExtModuleTeste
 class ParameterizedExtModuleExecutionTest extends ExecutionTest(
     "ParameterizedExtModuleTester", "/blackboxes", Seq("ParameterizedExtModule"))
 
+class LargeParamExecutionTest extends ExecutionTest("LargeParamTester", "/blackboxes", Seq("LargeParam"))


### PR DESCRIPTION
As the title states, we were emitting illegal literals which is a bit of a drag.