### PR TITLE
Switch FIRRTL to Dependency API

### DIFF
--- a/src/main/scala/firrtl/AddDescriptionNodes.scala
+++ b/src/main/scala/firrtl/AddDescriptionNodes.scala
@@ -71,6 +71,16 @@ class AddDescriptionNodes extends Transform {
   def inputForm = LowForm
   def outputForm = LowForm
 
+  override def prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.LowFormMinimumOptimized ++
+    Seq[Class[Transform]]( classOf[firrtl.transforms.BlackBoxSourceHelper],
+                           classOf[firrtl.transforms.ReplaceTruncatingArithmetic],
+                           classOf[firrtl.transforms.FlattenRegUpdate],
+                           classOf[firrtl.passes.VerilogModulusCleanup],
+                           classOf[firrtl.transforms.VerilogRename],
+                           classOf[firrtl.passes.VerilogPrep] )
+
+  override def dependents: Seq[Class[Transform]] = Seq.empty
+
   def onStmt(compMap: Map[String, Seq[String]])(stmt: Statement): Statement = {
     stmt.map(onStmt(compMap)) match {
       case d: IsDeclaration if compMap.contains(d.name) =>

--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -11,7 +11,8 @@ import firrtl.annotations._
 import firrtl.ir.Circuit
 import firrtl.Utils.throwInternalError
 import firrtl.annotations.transforms.{EliminateTargetPaths, ResolvePaths}
-import firrtl.options.{StageUtils, TransformLike}
+import firrtl.options.{DependencyAPI, StageUtils, TransformLike}
+import firrtl.stage.transforms.CatchCustomTransformExceptions
 
 /** Container of all annotations for a Firrtl compiler */
 class AnnotationSeq private (private[firrtl] val underlying: List[Annotation]) {
@@ -169,13 +170,20 @@ final case object UnknownForm extends CircuitForm(-1) {
 // scalastyle:on magic.number
 
 /** The basic unit of operating on a Firrtl AST */
-abstract class Transform extends TransformLike[CircuitState] {
+abstract class Transform extends TransformLike[CircuitState] with DependencyAPI[Transform] {
   /** A convenience function useful for debugging and error messages */
   def name: String = this.getClass.getSimpleName
+
   /** The [[firrtl.CircuitForm]] that this transform requires to operate on */
+  @deprecated(
+    "InputForm/OutputForm will be removed. Use DependencyAPI methods (prerequisites, dependents, invalidates)", "1.2")
   def inputForm: CircuitForm
+
   /** The [[firrtl.CircuitForm]] that this transform outputs */
+  @deprecated(
+    "InputForm/OutputForm will be removed. Use DependencyAPI methods (prerequisites, dependents, invalidates)", "1.2")
   def outputForm: CircuitForm
+
   /** Perform the transform, encode renaming with RenameMap, and can
     *   delete annotations
     * Called by [[runTransform]].
@@ -183,9 +191,29 @@ abstract class Transform extends TransformLike[CircuitState] {
     * @param state Input Firrtl AST
     * @return A transformed Firrtl AST
     */
-  protected def execute(state: CircuitState): CircuitState
+  def execute(state: CircuitState): CircuitState
 
   def transform(state: CircuitState): CircuitState = execute(state)
+
+  override def prerequisites: Seq[Class[Transform]] =
+    CompilerUtils.circuitFormToTransformSeq(inputForm).getOrElse(Seq.empty)
+
+  override def dependents: Seq[Class[Transform]] = outputForm match {
+    case UnknownForm => Seq.empty
+    case _ =>
+      (new mutable.LinkedHashSet[Class[Transform]]() ++ CompilerUtils.circuitFormToEmitterSeq(inputForm) ++
+         firrtl.stage.Forms.VerilogOptimized --
+         CompilerUtils.circuitFormToTransformSeq(outputForm).getOrElse(Seq.empty) --
+         prerequisites -
+         this.getClass.asInstanceOf[Class[Transform]])
+        .toSeq
+  }
+
+  override def invalidates(a: Transform): Boolean = {
+    val diff = CompilerUtils.circuitFormToTransformSeq(inputForm).getOrElse(Set.empty).toSet --
+      CompilerUtils.circuitFormToTransformSeq(outputForm).getOrElse(Seq.empty)
+    diff(a.getClass.asInstanceOf[Class[Transform]])
+  }
 
   /** Convenience method to get annotations relevant to this Transform
     *
@@ -275,6 +303,18 @@ abstract class Transform extends TransformLike[CircuitState] {
   }
 }
 
+private[firrtl] trait DeprecatedTransformObject { this: Transform =>
+
+  protected def underlying: Transform
+
+  @deprecated("Transform objects are now classes. Create an object or use the Dependency API", "1.2")
+  def execute(c: CircuitState): CircuitState = underlying.execute(c)
+
+  override def inputForm = underlying.inputForm
+  override def outputForm = underlying.outputForm
+
+}
+
 trait SeqTransformBased {
   def transforms: Seq[Transform]
   protected def runTransforms(state: CircuitState): CircuitState =
@@ -334,7 +374,7 @@ object CompilerUtils extends LazyLogging {
         case ChirrtlForm =>
           Seq(new ChirrtlToHighFirrtl) ++ getLoweringTransforms(HighForm, outputForm)
         case HighForm =>
-          Seq(new IRToWorkingIR, new ResolveAndCheck, new transforms.DedupModules,
+          Seq(new IRToWorkingIR, new ResolveAndCheck, new Dedup,
               new HighFirrtlToMiddleFirrtl) ++ getLoweringTransforms(MidForm, outputForm)
         case MidForm => Seq(new MiddleFirrtlToLowFirrtl) ++ getLoweringTransforms(LowForm, outputForm)
         case LowForm => throwInternalError("getLoweringTransforms - LowForm") // should be caught by if above
@@ -390,6 +430,30 @@ object CompilerUtils extends LazyLogging {
     }
   }
 
+  private[firrtl] def circuitFormToTransformSeq(a: CircuitForm): Option[Seq[Class[Transform]]] = a match {
+    case ChirrtlForm => Some(firrtl.stage.Forms.ChirrtlForm)
+    case HighForm    => Some(firrtl.stage.Forms.HighForm)
+    case MidForm     => Some(firrtl.stage.Forms.MidForm)
+    case LowForm     => Some(firrtl.stage.Forms.LowForm)
+    case UnknownForm => None
+  }
+
+  private[firrtl] def circuitFormToEmitterSeq(a: CircuitForm): Seq[Class[Transform]] = {
+    val lowEmitters = Seq( classOf[LowFirrtlEmitter],
+                           classOf[VerilogEmitter],
+                           classOf[MinimumVerilogEmitter],
+                           classOf[SystemVerilogEmitter] ).asInstanceOf[Seq[Class[Transform]]]
+    a match {
+      case ChirrtlForm => Seq( classOf[ChirrtlEmitter],
+                               classOf[HighFirrtlEmitter],
+                               classOf[MiddleFirrtlEmitter] ).asInstanceOf[Seq[Class[Transform]]] ++ lowEmitters
+      case HighForm    => Seq( classOf[HighFirrtlEmitter],
+                               classOf[MiddleFirrtlEmitter] ).asInstanceOf[Seq[Class[Transform]]] ++ lowEmitters
+      case MidForm     => lowEmitters :+ classOf[MiddleFirrtlEmitter].asInstanceOf[Class[Transform]]
+      case LowForm     => lowEmitters
+      case UnknownForm => Seq.empty
+    }
+  }
 }
 
 trait Compiler extends LazyLogging {
@@ -455,15 +519,6 @@ trait Compiler extends LazyLogging {
     compile(state.copy(annotations = emitAnno +: state.annotations), emitter +: customTransforms)
   }
 
-  private def isCustomTransform(xform: Transform): Boolean = {
-    def getTopPackage(pack: java.lang.Package): java.lang.Package =
-      Package.getPackage(pack.getName.split('.').head)
-    // We use the top package of the Driver to get the top firrtl package
-    Option(xform.getClass.getPackage).map { p =>
-      getTopPackage(p) != firrtl.Driver.getClass.getPackage
-    }.getOrElse(true)
-  }
-
   /** Perform compilation
     *
     * Emission will only be performed if [[EmitAnnotation]]s are present
@@ -482,7 +537,8 @@ trait Compiler extends LazyLogging {
           xform.runTransform(in)
         } catch {
           // Wrap exceptions from custom transforms so they are reported as such
-          case e: Exception if isCustomTransform(xform) => throw CustomTransformException(e)
+          case e: Exception if CatchCustomTransformExceptions.isCustomTransform(xform) =>
+            throw CustomTransformException(e)
         }
       }
     }

--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -11,7 +11,7 @@ import firrtl.annotations._
 import firrtl.ir.Circuit
 import firrtl.Utils.throwInternalError
 import firrtl.annotations.transforms.{EliminateTargetPaths, ResolvePaths}
-import firrtl.options.StageUtils
+import firrtl.options.{StageUtils, TransformLike}
 
 /** Container of all annotations for a Firrtl compiler */
 class AnnotationSeq private (private[firrtl] val underlying: List[Annotation]) {
@@ -169,7 +169,7 @@ final case object UnknownForm extends CircuitForm(-1) {
 // scalastyle:on magic.number
 
 /** The basic unit of operating on a Firrtl AST */
-abstract class Transform extends LazyLogging {
+abstract class Transform extends TransformLike[CircuitState] {
   /** A convenience function useful for debugging and error messages */
   def name: String = this.getClass.getSimpleName
   /** The [[firrtl.CircuitForm]] that this transform requires to operate on */
@@ -184,6 +184,8 @@ abstract class Transform extends LazyLogging {
     * @return A transformed Firrtl AST
     */
   protected def execute(state: CircuitState): CircuitState
+
+  def transform(state: CircuitState): CircuitState = execute(state)
 
   /** Convenience method to get annotations relevant to this Transform
     *

--- a/src/main/scala/firrtl/Driver.scala
+++ b/src/main/scala/firrtl/Driver.scala
@@ -13,7 +13,7 @@ import firrtl.transforms._
 import firrtl.Utils.throwInternalError
 import firrtl.stage.{FirrtlExecutionResultView, FirrtlStage}
 import firrtl.stage.phases.DriverCompatibility
-import firrtl.options.{StageUtils, Phase, Viewer}
+import firrtl.options.{Phase, PhaseManager, StageUtils, Viewer}
 import firrtl.options.phases.DeletedWrapper
 
 
@@ -211,13 +211,18 @@ object Driver {
 
     val annos = optionsManager.firrtlOptions.toAnnotations ++ optionsManager.commonOptions.toAnnotations
 
-    val phases: Seq[Phase] =
-      Seq( new DriverCompatibility.AddImplicitAnnotationFile,
-           new DriverCompatibility.AddImplicitFirrtlFile,
-           new DriverCompatibility.AddImplicitOutputFile,
-           new DriverCompatibility.AddImplicitEmitter,
-           new FirrtlStage )
+    val phases: Seq[Phase] = {
+      import DriverCompatibility._
+      new PhaseManager(
+        Seq( classOf[AddImplicitAnnotationFile],
+             classOf[AddImplicitFirrtlFile],
+             classOf[AddImplicitOutputFile],
+             classOf[AddImplicitEmitter],
+             classOf[FirrtlStage] )
+          .map(_.asInstanceOf[Class[Phase]]) )
+        .transformOrder
         .map(DeletedWrapper(_))
+    }
 
     val annosx = try {
       phases.foldLeft(annos)( (a, p) => p.transform(a) )

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -16,7 +16,7 @@ import firrtl.WrappedExpression._
 import Utils._
 import MemPortUtils.{memPortField, memType}
 import firrtl.options.{HasShellOptions, ShellOption, StageUtils, PhaseException}
-import firrtl.stage.RunFirrtlTransformAnnotation
+import firrtl.stage.{RunFirrtlTransformAnnotation, TransformManager}
 // Datastructures
 import scala.collection.mutable.ArrayBuffer
 
@@ -180,6 +180,11 @@ case class VRandom(width: BigInt) extends Expression {
 class VerilogEmitter extends SeqTransform with Emitter {
   def inputForm = LowForm
   def outputForm = LowForm
+
+  override def prerequisites = firrtl.stage.Forms.LowFormOptimized
+
+  override def dependents = Seq.empty
+
   val outputSuffix = ".v"
   val tab = "  "
   def AND(e1: WrappedExpression, e2: WrappedExpression): Expression = {
@@ -948,16 +953,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
     }
   }
 
-  /** Preamble for every emitted Verilog file */
-  def transforms = Seq(
-    new BlackBoxSourceHelper,
-    new ReplaceTruncatingArithmetic,
-    new FlattenRegUpdate,
-    new DeadCodeElimination,
-    passes.VerilogModulusCleanup,
-    new VerilogRename,
-    passes.VerilogPrep,
-    new AddDescriptionNodes)
+  def transforms = new TransformManager(firrtl.stage.Forms.VerilogOptimized, prerequisites).flattenedTransformOrder
 
   def emit(state: CircuitState, writer: Writer): Unit = {
     val circuit = runTransforms(state).circuit
@@ -1005,16 +1001,18 @@ class VerilogEmitter extends SeqTransform with Emitter {
 
 class MinimumVerilogEmitter extends VerilogEmitter with Emitter {
 
+  override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized
 
-  override def transforms = super.transforms.filter{
-    case _: DeadCodeElimination => false
-    case _ => true
-  }
+  override def transforms = new TransformManager(firrtl.stage.Forms.VerilogMinimumOptimized, prerequisites)
+    .flattenedTransformOrder
 
 }
 
 class SystemVerilogEmitter extends VerilogEmitter {
-  StageUtils.dramaticWarning("SystemVerilog Emitter is the same as the Verilog Emitter!")
-
   override val outputSuffix: String = ".sv"
+
+  override def execute(state: CircuitState): CircuitState = {
+    StageUtils.dramaticWarning("SystemVerilog Emitter is the same as the Verilog Emitter!")
+    super.execute(state)
+  }
 }

--- a/src/main/scala/firrtl/annotations/transforms/EliminateTargetPaths.scala
+++ b/src/main/scala/firrtl/annotations/transforms/EliminateTargetPaths.scala
@@ -131,7 +131,7 @@ class EliminateTargetPaths extends Transform {
     (cir.copy(modules = finalModuleList), renameMap)
   }
 
-  override protected def execute(state: CircuitState): CircuitState = {
+  override def execute(state: CircuitState): CircuitState = {
 
     val annotations = state.annotations.collect { case a: ResolvePaths => a }
 

--- a/src/main/scala/firrtl/options/DependencyManager.scala
+++ b/src/main/scala/firrtl/options/DependencyManager.scala
@@ -1,0 +1,363 @@
+// See LICENSE for license details.
+
+package firrtl.options
+
+import firrtl.AnnotationSeq
+import firrtl.graph.{DiGraph, CyclicException}
+
+import scala.collection.Set
+import scala.collection.immutable.{Set => ISet}
+import scala.collection.mutable.{ArrayBuffer, HashMap, LinkedHashMap, LinkedHashSet, Queue}
+
+/** An exception arising from an in a [[DependencyManager]] */
+case class DependencyManagerException(message: String, cause: Throwable = null) extends RuntimeException(message, cause)
+
+/** A [[firrtl.options.TransformLike TransformLike]] that resolves a linear ordering of dependencies based on
+  * requirements.
+  * @tparam A the type over which this transforms
+  * @tparam B the type of the [[firrtl.options.TransformLike TransformLike]]
+  */
+trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends TransformLike[A] with DependencyAPI[B] {
+
+  /** Requested [[firrtl.options.TransformLike TransformLike]]s that should be run. Internally, this will be converted to
+    * a set based on the ordering defined here.
+    */
+  def targets: Seq[Class[B]]
+  private lazy val _targets: LinkedHashSet[Class[B]] = targets
+    .foldLeft(new LinkedHashSet[Class[B]]()){ case (a, b) => a += b }
+
+  /** A sequence of [[firrtl.Transform]]s that have been run. Internally, this will be converted to an ordered set.
+    */
+  def currentState: Seq[Class[B]]
+  private lazy val _currentState: LinkedHashSet[Class[B]] = currentState
+    .foldLeft(new LinkedHashSet[Class[B]]()){ case (a, b) => a += b }
+
+  /** Existing transform objects that have already been constructed */
+  def knownObjects: Set[B]
+
+  /** A sequence of wrappers to apply to the resulting [[firrtl.options.TransformLike TransformLike]] sequence. This can
+    * be used to, e.g., add automated pre-processing and post-processing.
+    */
+  def wrappers: Seq[(B) => B] = Seq.empty
+
+  /** Store of conversions between classes and objects. Objects that do not exist in the map will be lazily constructed.
+    */
+  protected lazy val classToObject: LinkedHashMap[Class[B], B] = {
+    val init = LinkedHashMap[Class[B], B](knownObjects.map(x => x.getClass.asInstanceOf[Class[B]] -> x).toSeq: _*)
+    (_targets ++ _currentState)
+      .filter(!init.contains(_))
+      .map(x => init(x) = safeConstruct(x))
+    init
+  }
+
+  /** A method that will create a copy of this [[firrtl.options.DependencyManager DependencyManager]], but with different
+    * requirements. This is used to solve sub-problems arising from invalidations.
+    */
+  protected def copy(
+    targets: Seq[Class[B]],
+    currentState: Seq[Class[B]],
+    knownObjects: ISet[B] = classToObject.values.toSet): B
+
+  /** Implicit conversion from Class[B] to B */
+  private implicit def cToO(c: Class[B]): B = classToObject.getOrElseUpdate(c, safeConstruct(c))
+
+  /** Implicit conversion from B to Class[B] */
+  private implicit def oToC(b: B): Class[B] = b.getClass.asInstanceOf[Class[B]]
+
+  /** Modified breadth-first search that supports multiple starting nodes and a custom extractor that can be used to
+    * generate/filter the edges to explore. Additionally, this will include edges to previously discovered nodes.
+    */
+  private def bfs( start: LinkedHashSet[Class[B]],
+                   blacklist: LinkedHashSet[Class[B]],
+                   extractor: B => Set[Class[B]] ): LinkedHashMap[B, LinkedHashSet[B]] = {
+
+    val (queue, edges) = {
+      val a: Queue[Class[B]]                    = Queue(start.toSeq:_*)
+      val b: LinkedHashMap[B, LinkedHashSet[B]] = LinkedHashMap[B, LinkedHashSet[B]](
+        start.map((cToO(_) -> LinkedHashSet[B]())).toSeq:_*)
+      (a, b)
+    }
+
+    while (queue.nonEmpty) {
+      val u: Class[B] = queue.dequeue
+      for (v: Class[B] <- extractor(classToObject(u))) {
+        if (!blacklist.contains(v) && !edges.contains(v)) {
+          queue.enqueue(v)
+        }
+        if (!edges.contains(v)) {
+          val obj = cToO(v)
+          edges(obj) = LinkedHashSet.empty
+          classToObject += (v -> obj)
+        }
+        edges(classToObject(u)) = edges(classToObject(u)) + classToObject(v)
+      }
+    }
+
+    edges
+  }
+
+  /** Pull in all registered [[firrtl.options.TransformLike TransformLike]] once [[firrtl.options.TransformLike
+    * TransformLike]] registration is integrated
+    * @todo implement this
+    */
+  private lazy val registeredTransforms: Set[B] = Set.empty
+
+  /** A directed graph consisting of prerequisite edges */
+  private lazy val prerequisiteGraph: DiGraph[B] = {
+    val edges = bfs(
+      start = _targets -- _currentState,
+      blacklist = _currentState,
+      extractor = (p: B) => new LinkedHashSet[Class[B]]() ++ p.prerequisites -- _currentState)
+    DiGraph(edges)
+  }
+
+  /** A directed graph consisting of prerequisites derived from only those transforms which are supposed to run. This
+    * pulls in dependents for transforms which are not in the target set.
+    */
+  private lazy val dependentsGraph: DiGraph[B] = {
+    val v = new LinkedHashSet() ++ prerequisiteGraph.getVertices
+    DiGraph(new LinkedHashMap() ++ v.map(vv => vv -> ((new LinkedHashSet() ++ vv.dependents).map(cToO) & v))).reverse
+  }
+
+  /** A directed graph consisting of prerequisites derived from ALL targets. This is necessary for defining targets for
+    * [[DependencyManager]] sub-problems.
+    */
+  private lazy val otherDependents: DiGraph[B] = {
+    val edges = {
+      val x = new LinkedHashMap ++ _targets
+        .map(classToObject)
+        .map{ a => a -> prerequisiteGraph.getVertices.filter(a._dependents(_)) }
+      x
+        .values
+        .reduce(_ ++ _)
+        .foldLeft(x){ case (xx, y) => if (xx.contains(y)) { xx } else { xx ++ Map(y -> Set.empty[B]) } }
+    }
+    DiGraph(edges).reverse
+  }
+
+  /** A directed graph consisting of all prerequisites, including prerequisites derived from dependents */
+  lazy val dependencyGraph: DiGraph[B] = prerequisiteGraph + dependentsGraph
+
+  /** A directed graph consisting of invalidation edges */
+  lazy val invalidateGraph: DiGraph[B] = {
+    val v = dependencyGraph.getVertices
+    DiGraph(
+      bfs(
+        start = _targets -- _currentState,
+        blacklist = _currentState,
+        extractor = (p: B) => v.filter(p.invalidates).map(_.asClass).toSet))
+      .reverse
+  }
+
+  /** Wrap a possible [[CyclicException]] thrown by a thunk in a [[DependencyManagerException]] */
+  private def cyclePossible[A](a: String, diGraph: DiGraph[_])(thunk: => A): A = try { thunk } catch {
+    case e: CyclicException =>
+      throw new DependencyManagerException(
+        s"""|No transform ordering possible due to cyclic dependency in $a with cycles:
+            |${diGraph.findSCCs.filter(_.size > 1).mkString("    - ", "\n    - ", "")}""".stripMargin, e)
+  }
+
+  /** Wrap an [[IllegalAccessException]] due to attempted object construction in a [[DependencyManagerException]] */
+  private def safeConstruct[A](a: Class[A]): A = try { a.newInstance } catch {
+    case e: IllegalAccessException => throw new DependencyManagerException(
+      s"Failed to construct '$a'! (Did you try to construct an object?)", e)
+    case e: InstantiationException => throw new DependencyManagerException(
+      s"Failed to construct '$a'! (Did you try to construct an inner class or a class with parameters?)", e)
+  }
+
+  /** An ordering of [[firrtl.options.TransformLike TransformLike]]s that causes the requested [[DependencyManager.targets
+    * targets]] to be executed starting from the [[DependencyManager.currentState currentState]]. This ordering respects
+    * prerequisites, dependents, and invalidates of all constituent [[firrtl.options.TransformLike TransformLike]]s.
+    * This uses an algorithm that attempts to reduce the number of re-lowerings due to invalidations. Re-lowerings are
+    * implemented as new [[DependencyManager]]s.
+    * @throws DependencyManagerException if a cycle exists in either the [[DependencyManager.dependencyGraph
+    * dependencyGraph]] or the [[DependencyManager.invalidateGraph invalidateGraph]].
+    */
+  lazy val transformOrder: Seq[B] = {
+
+    /* Topologically sort the dependency graph using the invalidate graph topological sort as a seed. This has the effect of
+     * reducing (perhaps minimizing?) the number of work re-lowerings.
+     */
+    val sorted = {
+      val seed = cyclePossible("invalidates", invalidateGraph){ invalidateGraph.linearize }.reverse
+
+      cyclePossible("prerequisites/dependents", dependencyGraph) {
+        dependencyGraph
+          .seededLinearize(Some(seed))
+          .reverse
+          .dropWhile(b => _currentState.contains(b))
+      }
+    }
+
+    val (state, lowerers) = {
+      /* [todo] Seq is inefficient here, but Array has ClassTag problems. Use something else? */
+      val (s, l) = sorted.foldLeft((_currentState, Seq[B]())){ case ((state, out), in) =>
+        /* The prerequisites are both prerequisites AND dependents. */
+        val prereqs = new LinkedHashSet() ++ in.prerequisites ++
+          dependencyGraph.getEdges(in).toSeq.map(oToC) ++
+          otherDependents.getEdges(in).toSeq.map(oToC)
+        val missing = (prereqs -- state)
+        val preprocessing: Option[B] = {
+          if (missing.nonEmpty) { Some(this.copy(prereqs.toSeq, state.toSeq)) }
+          else                  { None                                     }
+        }
+        ((state ++ missing + in).map(cToO).filterNot(in.invalidates).map(oToC), out ++ preprocessing :+ in)
+      }
+      val missing = (_targets -- s)
+      val postprocessing: Option[B] = {
+        if (missing.nonEmpty) { Some(this.copy(_targets.toSeq, s.toSeq)) }
+        else                  { None                        }
+      }
+
+      (s ++ missing, l ++ postprocessing)
+    }
+
+    if (!_targets.subsetOf(state)) {
+      throw new DependencyManagerException(
+        s"The final state ($state) did not include the requested targets (${targets})!")
+    }
+    lowerers
+  }
+
+  /** A version of the [[DependencyManager.transformOrder transformOrder]] that flattens the transforms of any internal
+    * [[DependencyManager]]s.
+    */
+  lazy val flattenedTransformOrder: Seq[B] = transformOrder.flatMap {
+    case p: DependencyManager[A, B] => p.flattenedTransformOrder
+    case p => Some(p)
+  }
+
+  final override def transform(annotations: A): A = {
+
+    /* A local store of each wrapper to it's underlying class. */
+    val wrapperToClass = new HashMap[B, Class[B]]
+
+    /* The determined, flat order of transforms is wrapped with surrounding transforms while populating wrapperToClass so
+     * that each wrapped transform object can be dereferenced to its underlying class. Each wrapped transform is then
+     * applied while tracking the state of the underlying A. If the state ever disagrees with a prerequisite, then this
+     * throws an exception.
+     */
+    flattenedTransformOrder
+      .map{ t =>
+        val w = wrappers.foldLeft(t){ case (tx, wrapper) => wrapper(tx) }
+        wrapperToClass += (w -> t)
+        w
+      }.foldLeft((annotations, _currentState)){ case ((a, state), t) =>
+          if (!t.prerequisites.toSet.subsetOf(state)) {
+            throw new DependencyManagerException(
+              s"""|Tried to execute '$t' for which run-time prerequisites were not satisfied:
+                  |  state: ${state.mkString("\n    -", "\n    -", "")}
+                  |  prerequisites: ${prerequisites.mkString("\n    -", "\n    -", "")}""".stripMargin)
+          }
+          (t.transform(a), ((state + wrapperToClass(t)).map(cToO).filterNot(t.invalidates).map(oToC)))
+      }._1
+  }
+
+  /** This colormap uses Colorbrewer's 4-class OrRd color scheme */
+  protected val colormap = Seq("#fef0d9", "#fdcc8a", "#fc8d59", "#d7301f")
+
+  /** Get a name of some [[firrtl.options.TransformLike TransformLike]] */
+  private def transformName(transform: B, suffix: String = ""): String = s""""${transform.name}$suffix""""
+
+  /** Convert all prerequisites, dependents, and invalidates to a Graphviz representation.
+    * @param file the name of the output file
+    */
+  def dependenciesToGraphviz: String = {
+
+    def toGraphviz(digraph: DiGraph[B], attributes: String = "", tab: String = "    "): Option[String] = {
+      val edges =
+        digraph
+          .getEdgeMap
+          .collect{ case (v, edges) if edges.nonEmpty => (v -> edges) }
+          .map{ case (v, edges) =>
+            s"""${transformName(v)} -> ${edges.map(e => transformName(e)).mkString("{ ", " ", " }")}""" }
+
+      if (edges.isEmpty) { None } else {
+        Some(
+          s"""|  { $attributes
+              |${edges.mkString(tab, "\n" + tab, "")}
+              |  }""".stripMargin
+        )
+      }
+    }
+
+    val connections =
+      Seq( (prerequisiteGraph, "edge []"),
+           (dependentsGraph,   """edge [color="#de2d26"]"""),
+           (invalidateGraph,   "edge [minlen=2,style=dashed,constraint=false]") )
+        .flatMap{ case (a, b) => toGraphviz(a, b) }
+        .mkString("\n")
+
+    val nodes =
+      (prerequisiteGraph + dependentsGraph + invalidateGraph + otherDependents)
+        .getVertices
+        .map(v => s"""${transformName(v)} [label="${v.getClass.getSimpleName}"]""")
+
+    s"""|digraph DependencyManager {
+        |  graph [rankdir=BT]
+        |  node [fillcolor="${colormap(0)}",style=filled,shape=box]
+        |${nodes.mkString("  ", "\n" + "  ", "")}
+        |$connections
+        |}
+        |""".stripMargin
+  }
+
+  def transformOrderToGraphviz(colormap: Seq[String] = colormap): String = {
+
+    def rotate[A](a: Seq[A]): Seq[A] = a match {
+      case Nil => Nil
+      case car :: cdr => cdr :+ car
+      case car => car
+    }
+
+    val sorted = ArrayBuffer.empty[String]
+
+    def rec(pm: DependencyManager[A, B], cm: Seq[String], tab: String = "", id: Int = 0): (String, Int) = {
+      var offset = id
+
+      val targets = pm._targets.toSeq.map(_.getSimpleName).mkString(", ")
+      val state = pm._currentState.toSeq.map(_.getSimpleName).mkString(", ")
+
+      val header = s"""|${tab}subgraph cluster_$id {
+                       |$tab  label="targets: $targets\\nstate: $state"
+                       |$tab  labeljust=l
+                       |$tab  node [fillcolor="${cm.head}"]""".stripMargin
+
+      val body = pm.transformOrder.map{
+        case a: DependencyManager[A, B] =>
+          val (str, d) = rec(a, rotate(cm), tab + "  ", offset + 1)
+          offset = d
+          str
+        case a =>
+          val name = s"""${transformName(a, "_" + id)}"""
+          sorted += name
+          s"""$tab  $name [label="${a.getClass.getSimpleName}"]"""
+      }.mkString("\n")
+
+      (Seq(header, body, s"$tab}").mkString("\n"), offset)
+    }
+
+    s"""|digraph DependencyManagerTransformOrder {
+        |  graph [rankdir=TB]
+        |  node [style=filled,shape=box]
+        |${rec(this, colormap, "  ")._1}
+        |  ${sorted.mkString(" -> ")}
+        |}""".stripMargin
+  }
+
+}
+
+/** A [[Phase]] that will ensure that some other [[Phase]]s and their prerequisites are executed.
+  *
+  * This tries to determine a phase ordering such that an [[AnnotationSeq]] ''output'' is produced that has had all of
+  * the requested [[Phase]] target transforms run without having them be invalidated.
+  * @param targets the [[Phase]]s you want to run
+  */
+class PhaseManager(
+  val targets: Seq[Class[Phase]],
+  val currentState: Seq[Class[Phase]] = Seq.empty,
+  val knownObjects: Set[Phase] = Set.empty) extends Phase with DependencyManager[AnnotationSeq, Phase] {
+
+  protected def copy(a: Seq[Class[Phase]], b: Seq[Class[Phase]], c: ISet[Phase]) = new PhaseManager(a, b, c)
+
+}

--- a/src/main/scala/firrtl/options/Phase.scala
+++ b/src/main/scala/firrtl/options/Phase.scala
@@ -6,6 +6,7 @@ import firrtl.AnnotationSeq
 
 import logger.LazyLogging
 
+import scala.collection.mutable.LinkedHashSet
 
 /** A polymorphic mathematical transform
   * @tparam A the transformed type
@@ -23,15 +24,78 @@ trait TransformLike[A] extends LazyLogging {
 
 }
 
+/** Mixin that defines dependencies between [[firrtl.options.TransformLike TransformLike]]s (hereafter referred to as
+  * "transforms")
+  *
+  * This trait forms the basis of the Dependency API of the Chisel/FIRRTL Hardware Compiler Framework. Dependencies are
+  * defined in terms of prerequisistes, dependents, and invalidates. A prerequisite is a transform that must run before
+  * this transform. A dependent is a transform that must run ''after'' this transform. (This can be viewed as a means of
+  * injecting a prerequisite into some other transform.) Finally, invalidates define the set of transforms whose effects
+  * this transform undos/invalidates. (Invalidation then implies that a transform that is invalidated by this transform
+  * and needed by another transform will need to be re-run.)
+  *
+  * This Dependency API only defines dependencies. A concrete [[DependencyManager]] is expected to be used to statically
+  * resolve a linear ordering of transforms that satisfies dependency requirements.
+  * @tparam A some transform
+  * @define seqNote @note The use of a Seq here is to preserve input order. Internally, this will be converted to a private,
+  * ordered Set.
+  */
+trait DependencyAPI[A <: DependencyAPI[A]] { this: TransformLike[_] =>
+
+  /** All transform that must run before this transform
+    * $seqNote
+    */
+  def prerequisites: Seq[Class[A]] = Seq.empty
+  private[options] lazy val _prerequisites: LinkedHashSet[Class[A]] = new LinkedHashSet() ++ prerequisites.toSet
+
+  /** All transforms that must run ''after'' this transform
+    *
+    * ''This is a means of prerequisite injection into some other transform.'' Normally a transform will define its own
+    * prerequisites. Dependents exist for two main situations:
+    *
+    * First, they improve the composition of optional transforms. If some first transform is optional (e.g., an
+    * expensive validation check), you would like to be able to conditionally cause it to run. If it is listed as a
+    * prerequisite on some other, second transform then it must always run before that second transform. There's no way
+    * to turn it off. However, by listing the second transform as a dependent of the first transform, the first
+    * transform will only run (and be treated as a prerequisite of the second transform) if included in a list of target
+    * transforms that should be run.
+    *
+    * Second, an external library would like to inject some first transform before a second transform inside FIRRTL. In
+    * this situation, the second transform cannot have any knowledge of external libraries. The use of a dependent here
+    * allows for prerequisite injection into FIRRTL proper.
+    *
+    * @see [[firrtl.passes.CheckTypes]] for an example of an optional checking [[firrtl.Transform]]
+    * $seqNote
+    */
+  def dependents: Seq[Class[A]] = Seq.empty
+  private[options] lazy val _dependents: LinkedHashSet[Class[A]] = new LinkedHashSet() ++ dependents.toSet
+
+  /** A function that, given a transform will return true if this transform invalidates/undos the effects of the input
+    * transform
+    * @note Can a [[firrtl.options.Phase Phase]] ever invalidate itself?
+    */
+  def invalidates(a: A): Boolean = true
+
+  /** Helper method to return the underlying class */
+  final def asClass: Class[A] = this.getClass.asInstanceOf[Class[A]]
+
+  /** Implicit conversion that allows for terser specification of [[DependencyAPI.prerequisites prerequisites]] and
+    * [[DependencyAPI.dependents dependents]].
+    */
+  implicit def classHelper(a: Class[_ <: A]): Class[A] = a.asInstanceOf[Class[A]]
+
+}
+
 /** A mathematical transformation of an [[AnnotationSeq]].
   *
-  * A [[Phase]] forms one unit in the Chisel/FIRRTL Hardware Compiler Framework (HCF). The HCF is built from a sequence
-  * of [[Phase]]s applied to an [[AnnotationSeq]]. Note that a [[Phase]] may consist of multiple phases internally.
+  * A [[firrtl.options.Phase Phase]] forms one unit in the Chisel/FIRRTL Hardware Compiler Framework (HCF). The HCF is
+  * built from a sequence of [[firrtl.options.Phase Phase]]s applied to an [[AnnotationSeq]]. Note that a
+  * [[firrtl.options.Phase Phase]] may consist of multiple phases internally.
   */
-abstract class Phase extends TransformLike[AnnotationSeq] {
+trait Phase extends TransformLike[AnnotationSeq] with DependencyAPI[Phase] {
 
-  /** The name of this [[Phase]]. This will be used to generate debug/error messages or when deleting annotations. This
-    * will default to the `simpleName` of the class.
+  /** The name of this [[firrtl.options.Phase Phase]]. This will be used to generate debug/error messages or when deleting
+    * annotations. This will default to the `simpleName` of the class.
     * @return this phase's name
     * @note Override this with your own implementation for different naming behavior.
     */
@@ -39,15 +103,15 @@ abstract class Phase extends TransformLike[AnnotationSeq] {
 
 }
 
-/** A [[TransformLike]] that internally ''translates'' the input type to some other type, transforms the internal type,
-  * and converts back to the original type.
+/** A [[firrtl.options.TransformLike TransformLike]] that internally ''translates'' the input type to some other type,
+  * transforms the internal type, and converts back to the original type.
   *
-  * This is intended to be used to insert a [[TransformLike]] parameterized by type `B` into a sequence of
-  * [[TransformLike]]s parameterized by type `A`.
-  * @tparam A the type of the [[TransformLike]]
+  * This is intended to be used to insert a [[firrtl.options.TransformLike TransformLike]] parameterized by type `B`
+  * into a sequence of [[firrtl.options.TransformLike TransformLike]]s parameterized by type `A`.
+  * @tparam A the type of the [[firrtl.options.TransformLike TransformLike]]
   * @tparam B the internal type
   */
-trait Translator[A, B] { this: TransformLike[A] =>
+trait Translator[A, B] extends TransformLike[A] {
 
   /** A method converting type `A` into type `B`
     * @param an object of type `A`
@@ -69,6 +133,6 @@ trait Translator[A, B] { this: TransformLike[A] =>
 
   /** Convert the input object to the internal type, transform the internal type, and convert back to the original type
     */
-  final def transform(a: A): A = internalTransform(a)
+  override final def transform(a: A): A = bToA(internalTransform(aToB(a)))
 
 }

--- a/src/main/scala/firrtl/options/Phase.scala
+++ b/src/main/scala/firrtl/options/Phase.scala
@@ -86,6 +86,15 @@ trait DependencyAPI[A <: DependencyAPI[A]] { this: TransformLike[_] =>
 
 }
 
+/** A trait indicating that no invalidations occur, i.e., all previous transforms are preserved
+  * @tparam A some [[TransformLike]]
+  */
+trait PreservesAll[A <: DependencyAPI[A]] { this: DependencyAPI[A] =>
+
+  override def invalidates(a: A): Boolean = false
+
+}
+
 /** A mathematical transformation of an [[AnnotationSeq]].
   *
   * A [[firrtl.options.Phase Phase]] forms one unit in the Chisel/FIRRTL Hardware Compiler Framework (HCF). The HCF is

--- a/src/main/scala/firrtl/options/StageAnnotations.scala
+++ b/src/main/scala/firrtl/options/StageAnnotations.scala
@@ -86,7 +86,7 @@ object OutputAnnotationFileAnnotation extends HasShellOptions {
 }
 
 /** If this [[firrtl.annotations.Annotation Annotation]] exists in an [[firrtl.AnnotationSeq AnnotationSeq]], then a
-  * [[firrtl.options.phase.WriteOutputAnnotations WriteOutputAnnotations]] will include
+  * [[firrtl.options.phases.WriteOutputAnnotations WriteOutputAnnotations]] will include
   * [[firrtl.annotations.DeletedAnnotation DeletedAnnotation]]s when it writes to a file.
   *  - set with '--write-deleted'
   */

--- a/src/main/scala/firrtl/passes/CheckInitialization.scala
+++ b/src/main/scala/firrtl/passes/CheckInitialization.scala
@@ -6,6 +6,7 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.traversals.Foreachers._
+import firrtl.options.PreservesAll
 
 import annotation.tailrec
 
@@ -14,18 +15,18 @@ import annotation.tailrec
   * @note This pass looks for [[firrtl.WVoid]]s left behind by [[ExpandWhens]]
   * @note Assumes single connection (ie. no last connect semantics)
   */
-object CheckInitialization extends Pass {
-  private case class VoidExpr(stmt: Statement, voidDeps: Seq[Expression])
+class CheckInitialization extends Pass with PreservesAll[Transform] {
 
-  class RefNotInitializedException(info: Info, mname: String, name: String, trace: Seq[Statement]) extends PassException(
-      s"$info : [module $mname]  Reference $name is not fully initialized.\n" + 
-      trace.map(s => s"  ${get_info(s)} : ${s.serialize}").mkString("\n")
-    )
+  import CheckInitialization._
+
+  override def prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.Resolved
+
+  private case class VoidExpr(stmt: Statement, voidDeps: Seq[Expression])
 
   private def getTrace(expr: WrappedExpression, voidExprs: Map[WrappedExpression, VoidExpr]): Seq[Statement] = {
     @tailrec
     def rec(e: WrappedExpression, map: Map[WrappedExpression, VoidExpr], trace: Seq[Statement]): Seq[Statement] = {
-      val voidExpr = map(e) 
+      val voidExpr = map(e)
       val newTrace = voidExpr.stmt +: trace
       if (voidExpr.voidDeps.nonEmpty) rec(voidExpr.voidDeps.head, map, newTrace) else newTrace
     }
@@ -88,4 +89,15 @@ object CheckInitialization extends Pass {
     errors.trigger()
     c
   }
+}
+
+object CheckInitialization extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new CheckInitialization
+
+  class RefNotInitializedException(info: Info, mname: String, name: String, trace: Seq[Statement]) extends PassException(
+      s"$info : [module $mname]  Reference $name is not fully initialized.\n" +
+      trace.map(s => s"  ${get_info(s)} : ${s.serialize}").mkString("\n")
+    )
+
 }

--- a/src/main/scala/firrtl/passes/CheckWidths.scala
+++ b/src/main/scala/firrtl/passes/CheckWidths.scala
@@ -8,11 +8,14 @@ import firrtl.PrimOps._
 import firrtl.traversals.Foreachers._
 import firrtl.Utils._
 import firrtl.annotations.{CircuitTarget, ModuleTarget, Target, TargetToken}
+import firrtl.options.PreservesAll
 
-object CheckWidths extends Pass {
+object CheckWidths extends Pass with DeprecatedPassObject {
+
   /** The maximum allowed width for any circuit element */
   val MaxWidth = 1000000
   val DshlMaxWidth = ceilLog2(MaxWidth + 1)
+
   class UninferredWidth (info: Info, target: String) extends PassException(
     s"""|$info : Uninferred width for target below. (Did you forget to assign to it?)
         |$target""".stripMargin)
@@ -32,6 +35,17 @@ object CheckWidths extends Pass {
     s"$info: [target $mname] Parameter $n in tail operator is larger than input width $width.")
   class AttachWidthsNotEqual(info: Info, mname: String, eName: String, source: String) extends PassException(
     s"$info: [target $mname] Attach source $source and expression $eName must have identical widths.")
+
+  override protected lazy val underlying = new CheckWidths
+
+}
+
+class CheckWidths extends Pass with PreservesAll[Transform] {
+
+  import CheckWidths._
+
+  override def prerequisites: Seq[Class[Transform]] =
+    Seq[Class[Transform]]( classOf[passes.InferWidths] ) ++ firrtl.stage.Forms.WorkingIR
 
   def run(c: Circuit): Circuit = {
     val errors = new Errors()

--- a/src/main/scala/firrtl/passes/Checks.scala
+++ b/src/main/scala/firrtl/passes/Checks.scala
@@ -8,9 +8,9 @@ import firrtl.PrimOps._
 import firrtl.Utils._
 import firrtl.traversals.Foreachers._
 import firrtl.WrappedType._
+import firrtl.options.PreservesAll
 
-object CheckHighForm extends Pass {
-  type NameSet = collection.mutable.HashSet[String]
+object CheckHighForm extends Pass with DeprecatedPassObject {
 
   // Custom Exceptions
   class NotUniqueException(info: Info, mname: String, name: String) extends PassException(
@@ -57,6 +57,18 @@ object CheckHighForm extends Pass {
     s"$info: [module $mname] Primop $op lsb $lsb > $msb.")
   class NonLiteralAsyncResetValueException(info: Info, mname: String, reg: String, init: String) extends PassException(
     s"$info: [module $mname] AsyncReset Reg '$reg' reset to non-literal '$init'")
+
+  override protected lazy val underlying = new CheckHighForm
+
+}
+
+class CheckHighForm extends Pass with PreservesAll[Transform] {
+
+  import CheckHighForm._
+
+  override def prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.WorkingIR
+
+  type NameSet = collection.mutable.HashSet[String]
 
   def run(c: Circuit): Circuit = {
     val errors = new Errors()
@@ -219,9 +231,8 @@ object CheckHighForm extends Pass {
   }
 }
 
-object CheckTypes extends Pass {
+object CheckTypes extends Pass with DeprecatedPassObject {
 
-  // Custom Exceptions
   class SubfieldNotInBundle(info: Info, mname: String, name: String) extends PassException(
     s"$info: [module $mname ]  Subfield $name is not in bundle.")
   class SubfieldOnNonBundle(info: Info, mname: String, name: String) extends PassException(
@@ -285,6 +296,24 @@ object CheckTypes extends Pass {
   class IllegalUnknownType(info: Info, mname: String, exp: String) extends PassException(
     s"$info: [module $mname]  Uninferred type: $exp."
   )
+
+  override protected lazy val underlying = new CheckTypes
+
+}
+
+class CheckTypes extends Pass with PreservesAll[Transform] {
+
+  import CheckTypes._
+
+  override def prerequisites: Seq[Class[Transform]] =
+    Seq[Class[Transform]]( classOf[InferTypes] ) ++ firrtl.stage.Forms.WorkingIR
+
+  override val dependents: Seq[Class[Transform]] =
+    Seq[Class[Transform]]( classOf[passes.Uniquify],
+                           classOf[passes.ResolveGenders],
+                           classOf[passes.CheckGenders],
+                           classOf[passes.InferWidths],
+                           classOf[passes.CheckWidths] )
 
   //;---------------- Helper Functions --------------
   def ut: UIntType = UIntType(UnknownWidth)
@@ -475,7 +504,21 @@ object CheckTypes extends Pass {
   }
 }
 
-object CheckGenders extends Pass {
+object CheckGenders extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new CheckGenders
+
+}
+
+class CheckGenders extends Pass with PreservesAll[Transform] {
+
+  override def prerequisites: Seq[Class[Transform]] =
+    Seq[Class[Transform]]( classOf[passes.ResolveGenders] ) ++ firrtl.stage.Forms.WorkingIR
+
+  override val dependents: Seq[Class[Transform]] =
+    Seq[Class[Transform]]( classOf[passes.InferWidths],
+                           classOf[passes.CheckWidths] )
+
   type GenderMap = collection.mutable.HashMap[String, Gender]
 
   implicit def toStr(g: Gender): String = g match {

--- a/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
+++ b/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
@@ -5,9 +5,21 @@ package firrtl.passes
 import firrtl._
 import firrtl.ir._
 import firrtl.Mappers._
+import firrtl.options.PreservesAll
 
 
-object CommonSubexpressionElimination extends Pass {
+class CommonSubexpressionElimination extends Pass with PreservesAll[Transform] {
+
+  override val prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.LowForm ++
+    Seq[Class[Transform]]( classOf[firrtl.passes.RemoveValidIf],
+                           classOf[firrtl.transforms.ConstantPropagation],
+                           classOf[firrtl.passes.memlib.VerilogMemDelays],
+                           classOf[firrtl.passes.SplitExpressions],
+                           classOf[firrtl.transforms.CombineCats] )
+    .asInstanceOf[Seq[Class[Transform]]]
+
+  override val dependents: Seq[Class[Transform]] = Seq(classOf[SystemVerilogEmitter], classOf[VerilogEmitter])
+
   private def cse(s: Statement): Statement = {
     val expressions = collection.mutable.HashMap[MemoizedHash[Expression], String]()
     val nodes = collection.mutable.HashMap[String, Expression]()
@@ -44,4 +56,10 @@ object CommonSubexpressionElimination extends Pass {
     }
     Circuit(c.info, modulesx, c.main)
   }
+}
+
+object CommonSubexpressionElimination extends Pass with DeprecatedPassObject {
+
+  override lazy val underlying = new CommonSubexpressionElimination
+
 }

--- a/src/main/scala/firrtl/passes/ConvertFixedToSInt.scala
+++ b/src/main/scala/firrtl/passes/ConvertFixedToSInt.scala
@@ -8,10 +8,19 @@ import firrtl.ir._
 import firrtl._
 import firrtl.Mappers._
 import firrtl.Utils.{sub_type, module_type, field_type, max, throwInternalError}
+import firrtl.options.PreservesAll
 
 /** Replaces FixedType with SIntType, and correctly aligns all binary points
   */
-object ConvertFixedToSInt extends Pass {
+class ConvertFixedToSInt extends Pass with PreservesAll[Transform] {
+
+  override def prerequisites: Seq[Class[Transform]] =
+    Seq[Class[Transform]]( classOf[PullMuxes],
+                           classOf[ReplaceAccesses],
+                           classOf[ExpandConnects],
+                           classOf[RemoveAccesses],
+                           classOf[ExpandWhensAndCheck] ) ++ firrtl.stage.Forms.Deduped
+
   def alignArg(e: Expression, point: BigInt): Expression = e.tpe match {
     case FixedType(IntWidth(w), IntWidth(p)) => // assert(point >= p)
       if((point - p) > 0) {
@@ -83,29 +92,29 @@ object ConvertFixedToSInt extends Pass {
           types(name) = newType
           newStmt
         case WDefInstance(info, name, module, tpe) =>
-          val newType = moduleTypes(module) 
+          val newType = moduleTypes(module)
           types(name) = newType
           WDefInstance(info, name, module, newType)
-        case Connect(info, loc, exp) => 
+        case Connect(info, loc, exp) =>
           val point = calcPoint(Seq(loc))
           val newExp = alignArg(exp, point)
           Connect(info, loc, newExp) map updateExpType
-        case PartialConnect(info, loc, exp) => 
+        case PartialConnect(info, loc, exp) =>
           val point = calcPoint(Seq(loc))
           val newExp = alignArg(exp, point)
           PartialConnect(info, loc, newExp) map updateExpType
         // check Connect case, need to shl
         case s => (s map updateStmtType) map updateExpType
       }
- 
+
       m.ports.foreach(p => types(p.name) = p.tpe)
       m match {
         case Module(info, name, ports, body) => Module(info,name,ports,updateStmtType(body))
         case m:ExtModule => m
       }
     }
- 
-    val newModules = for(m <- c.modules) yield { 
+
+    val newModules = for(m <- c.modules) yield {
       val newPorts = m.ports.map(p => Port(p.info,p.name,p.direction,toSIntType(p.tpe)))
       m match {
          case Module(info, name, ports, body) => Module(info,name,newPorts,body)
@@ -113,8 +122,17 @@ object ConvertFixedToSInt extends Pass {
       }
     }
     newModules.foreach(m => moduleTypes(m.name) = module_type(m))
-    firrtl.passes.InferTypes.run(Circuit(c.info, newModules.map(onModule(_)), c.main ))
+
+    /* @todo This should be moved outside */
+    (new firrtl.passes.InferTypes).run(Circuit(c.info, newModules.map(onModule(_)), c.main ))
   }
 }
+
+object ConvertFixedToSInt extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new ConvertFixedToSInt
+
+}
+
 
 // vim: set ts=4 sw=4 et:

--- a/src/main/scala/firrtl/passes/ExpandWhens.scala
+++ b/src/main/scala/firrtl/passes/ExpandWhens.scala
@@ -8,6 +8,7 @@ import firrtl.Utils._
 import firrtl.Mappers._
 import firrtl.PrimOps._
 import firrtl.WrappedExpression._
+import firrtl.options.PreservesAll
 
 import annotation.tailrec
 import collection.mutable
@@ -23,7 +24,20 @@ import collection.mutable
   * @note Assumes bulk connects and isInvalids have been expanded
   * @note Assumes all references are declared
   */
-object ExpandWhens extends Pass {
+class ExpandWhens extends Pass with PreservesAll[Transform] {
+
+  override def prerequisites: Seq[Class[Transform]] =
+    Seq[Class[Transform]]( classOf[PullMuxes],
+                           classOf[ReplaceAccesses],
+                           classOf[ExpandConnects],
+                           classOf[RemoveAccesses],
+                           classOf[Uniquify] ) ++ firrtl.stage.Forms.Resolved
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case _: CheckInitialization | _: ResolveKinds | _: InferTypes => true
+    case _ => false
+  }
+
   /** Returns circuit with when and last connection semantics resolved */
   def run(c: Circuit): Circuit = {
     val modulesx = c.modules map {
@@ -286,4 +300,31 @@ object ExpandWhens extends Pass {
     DoPrim(And, Seq(e1, e2), Nil, BoolType)
   private def NOT(e: Expression) =
     DoPrim(Eq, Seq(e, zero), Nil, BoolType)
+}
+
+object ExpandWhens extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new ExpandWhens
+
+}
+
+class ExpandWhensAndCheck extends SeqTransform {
+
+  override def prerequisites: Seq[Class[Transform]] =
+    Seq[Class[Transform]]( classOf[PullMuxes],
+                           classOf[ReplaceAccesses],
+                           classOf[ExpandConnects],
+                           classOf[RemoveAccesses],
+                           classOf[Uniquify] ) ++ firrtl.stage.Forms.Deduped
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case _: ResolveKinds | _: InferTypes | _: ResolveGenders | _: InferWidths => true
+    case _ => false
+  }
+
+  override def inputForm = UnknownForm
+  override def outputForm = UnknownForm
+
+  override val transforms = Seq(new ExpandWhens, new CheckInitialization)
+
 }

--- a/src/main/scala/firrtl/passes/LowerTypes.scala
+++ b/src/main/scala/firrtl/passes/LowerTypes.scala
@@ -22,22 +22,20 @@ import firrtl.Mappers._
   *   wire foo_b : UInt<16>
   * }}}
   */
-object LowerTypes extends Transform {
+class LowerTypes extends Transform {
+
+  import LowerTypes._
+
   def inputForm = UnknownForm
   def outputForm = UnknownForm
 
-  /** Delimiter used in lowering names */
-  val delim = "_"
-  /** Expands a chain of referential [[firrtl.ir.Expression]]s into the equivalent lowered name
-    * @param e [[firrtl.ir.Expression]] made up of _only_ [[firrtl.WRef]], [[firrtl.WSubField]], and [[firrtl.WSubIndex]]
-    * @return Lowered name of e
-    */
-  def loweredName(e: Expression): String = e match {
-    case e: WRef => e.name
-    case e: WSubField => s"${loweredName(e.expr)}$delim${e.name}"
-    case e: WSubIndex => s"${loweredName(e.expr)}$delim${e.value}"
+  override val prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.MidForm
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case _: ResolveKinds | _: InferTypes | _: ResolveGenders | _: InferWidths => true
+    case _ => false
   }
-  def loweredName(s: Seq[String]): String = s mkString delim
+
   def renameExps(renames: RenameMap, n: String, t: Type, root: String): Seq[String] =
     renameExps(renames, WRef(n, t, ExpKind, UNKNOWNGENDER), root)
   def renameExps(renames: RenameMap, n: String, t: Type): Seq[String] =
@@ -148,7 +146,7 @@ object LowerTypes extends Transform {
         val exps = lowerTypesMemExp(memDataTypeMap, info, mname)(e)
         exps.size match {
           case 1 => exps.head
-          case _ => error("Error! lowerTypesExp called on MemKind " + 
+          case _ => error("Error! lowerTypesExp called on MemKind " +
                           "SubField that needs to be expanded!")(info, mname)
         }
       case _ => WRef(loweredName(e), e.tpe, kind(e), gender(e))
@@ -164,11 +162,11 @@ object LowerTypes extends Transform {
     s map lowerTypesStmt(memDataTypeMap, info, mname, renames) match {
       case s: DefWire => s.tpe match {
         case _: GroundType => s
-        case _ => 
+        case _ =>
           val exps = create_exps(s.name, s.tpe)
           val names = exps map loweredName
           renameExps(renames, s.name, s.tpe)
-          Block((exps zip names) map { case (e, n) => 
+          Block((exps zip names) map { case (e, n) =>
             DefWire(s.info, n, e.tpe)
           })
       }
@@ -190,7 +188,7 @@ object LowerTypes extends Transform {
         case t: BundleType =>
           val fieldsx = t.fields flatMap { f =>
             renameExps(renames, f.name, f.tpe, s"${sx.name}.")
-            create_exps(WRef(f.name, f.tpe, ExpKind, times(f.flip, MALE))) map { e => 
+            create_exps(WRef(f.name, f.tpe, ExpKind, times(f.flip, MALE))) map { e =>
               // Flip because inst genders are reversed from Module type
               Field(loweredName(e), swap(to_flip(gender(e))), e.tpe)
             }
@@ -286,3 +284,22 @@ object LowerTypes extends Transform {
   }
 }
 
+object LowerTypes extends Transform with DeprecatedTransformObject {
+
+  override protected lazy val underlying = new LowerTypes
+
+  /** Delimiter used in lowering names */
+  val delim = "_"
+
+  /** Expands a chain of referential [[firrtl.ir.Expression]]s into the equivalent lowered name
+    * @param e [[firrtl.ir.Expression]] made up of _only_ [[firrtl.WRef]], [[firrtl.WSubField]], and [[firrtl.WSubIndex]]
+    * @return Lowered name of e
+    */
+  def loweredName(e: Expression): String = e match {
+    case e: WRef => e.name
+    case e: WSubField => s"${loweredName(e.expr)}$delim${e.name}"
+    case e: WSubIndex => s"${loweredName(e.expr)}$delim${e.value}"
+  }
+  def loweredName(s: Seq[String]): String = s mkString delim
+
+}

--- a/src/main/scala/firrtl/passes/Passes.scala
+++ b/src/main/scala/firrtl/passes/Passes.scala
@@ -7,6 +7,7 @@ import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
 import firrtl.PrimOps._
+import firrtl.options.PreservesAll
 import firrtl.transforms.ConstantPropagation
 
 import scala.collection.mutable
@@ -30,6 +31,15 @@ trait Pass extends Transform {
   }
 }
 
+private[firrtl] trait DeprecatedPassObject { this: Pass =>
+
+  protected def underlying: Pass
+
+  @deprecated("Pass objects are now classes. Create an object or use the Dependency API", "1.2")
+  def run(c: Circuit): Circuit = underlying.run(c)
+
+}
+
 // Error handling
 class PassException(message: String) extends Exception(message)
 class PassExceptions(val exceptions: Seq[PassException]) extends Exception("\n" + exceptions.mkString("\n"))
@@ -45,8 +55,17 @@ class Errors {
   }
 }
 
+object ToWorkingIR extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new ToWorkingIR
+
+}
+
 // These should be distributed into separate files
-object ToWorkingIR extends Pass {
+class ToWorkingIR extends Pass with PreservesAll[Transform] {
+
+  override def prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.HighForm
+
   def toExp(e: Expression): Expression = e map toExp match {
     case ex: Reference => WRef(ex.name, ex.tpe, UnknownKind, UNKNOWNGENDER)
     case ex: SubField => WSubField(ex.expr, ex.name, ex.tpe, UNKNOWNGENDER)
@@ -64,8 +83,17 @@ object ToWorkingIR extends Pass {
     c copy (modules = c.modules map (_ map toStmt))
 }
 
-object PullMuxes extends Pass {
-   def run(c: Circuit): Circuit = {
+object PullMuxes extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new PullMuxes
+
+}
+
+class PullMuxes extends Pass with PreservesAll[Transform] {
+
+  override def prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.Deduped
+
+  def run(c: Circuit): Circuit = {
      def pull_muxes_e(e: Expression): Expression = e map pull_muxes_e match {
        case ex: WSubField => ex.expr match {
          case exx: Mux => Mux(exx.cond,
@@ -102,7 +130,12 @@ object PullMuxes extends Pass {
    }
 }
 
-object ExpandConnects extends Pass {
+class ExpandConnects extends Pass with PreservesAll[Transform] {
+
+  override def prerequisites: Seq[Class[Transform]] =
+    Seq[Class[Transform]]( classOf[PullMuxes],
+                           classOf[ReplaceAccesses] ) ++ firrtl.stage.Forms.Deduped
+
   def run(c: Circuit): Circuit = {
     def expand_connects(m: Module): Module = {
       val genders = collection.mutable.LinkedHashMap[String,Gender]()
@@ -176,10 +209,19 @@ object ExpandConnects extends Pass {
   }
 }
 
+object ExpandConnects extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new ExpandConnects
+
+}
+
 
 // Replace shr by amount >= arg width with 0 for UInts and MSB for SInts
 // TODO replace UInt with zero-width wire instead
-object Legalize extends Pass {
+class Legalize extends Pass with PreservesAll[Transform] {
+
+  override val prerequisites = firrtl.stage.Forms.MidForm :+ classOf[LowerTypes].asInstanceOf[Class[Transform]]
+
   private def legalizeShiftRight(e: DoPrim): Expression = {
     require(e.op == Shr)
     e.args.head match {
@@ -250,6 +292,12 @@ object Legalize extends Pass {
   }
 }
 
+object Legalize extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new Legalize
+
+}
+
 /** Makes changes to the Firrtl AST to make Verilog emission easier
   *
   * - For each instance, adds wires to connect to each port
@@ -260,7 +308,14 @@ object Legalize extends Pass {
   *
   * @note The result of this pass is NOT legal Firrtl
   */
-object VerilogPrep extends Pass {
+class VerilogPrep extends Pass {
+
+  override def prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.LowFormMinimumOptimized ++
+    Seq[Class[Transform]]( classOf[firrtl.transforms.BlackBoxSourceHelper],
+                           classOf[firrtl.transforms.ReplaceTruncatingArithmetic],
+                           classOf[firrtl.transforms.FlattenRegUpdate],
+                           classOf[VerilogModulusCleanup],
+                           classOf[firrtl.transforms.VerilogRename] )
 
   type AttachSourceMap = Map[WrappedExpression, Expression]
 
@@ -330,4 +385,10 @@ object VerilogPrep extends Pass {
     }
     c.copy(modules = modulesx)
   }
+}
+
+object VerilogPrep extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new VerilogPrep
+
 }

--- a/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
+++ b/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
@@ -8,12 +8,18 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
+import firrtl.options.PreservesAll
 
 case class MPort(name: String, clk: Expression)
 case class MPorts(readers: ArrayBuffer[MPort], writers: ArrayBuffer[MPort], readwriters: ArrayBuffer[MPort])
 case class DataRef(exp: Expression, male: String, female: String, mask: String, rdwrite: Boolean)
 
-object RemoveCHIRRTL extends Transform {
+class RemoveCHIRRTL extends Transform with PreservesAll[Transform] {
+
+  override def prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.ChirrtlForm ++
+    Seq[Class[Transform]]( classOf[passes.CInferTypes],
+                           classOf[passes.CInferMDir] )
+
   def inputForm: CircuitForm = UnknownForm
   def outputForm: CircuitForm = UnknownForm
   val ut = UnknownType

--- a/src/main/scala/firrtl/passes/RemoveValidIf.scala
+++ b/src/main/scala/firrtl/passes/RemoveValidIf.scala
@@ -2,27 +2,24 @@
 
 package firrtl
 package passes
+
+import firrtl.{SystemVerilogEmitter, VerilogEmitter}
 import firrtl.Mappers._
 import firrtl.ir._
 import Utils.throwInternalError
 
 /** Remove [[firrtl.ir.ValidIf ValidIf]] and replace [[firrtl.ir.IsInvalid IsInvalid]] with a connection to zero */
-object RemoveValidIf extends Pass {
+class RemoveValidIf extends Pass {
 
-  val UIntZero = Utils.zero
-  val SIntZero = SIntLiteral(BigInt(0), IntWidth(1))
-  val ClockZero = DoPrim(PrimOps.AsClock, Seq(UIntZero), Seq.empty, ClockType)
-  val FixedZero = FixedLiteral(BigInt(0), IntWidth(1), IntWidth(0))
+  import RemoveValidIf._
 
-  /** Returns an [[firrtl.ir.Expression Expression]] equal to zero for a given [[firrtl.ir.GroundType GroundType]]
-    * @note Accepts [[firrtl.ir.Type Type]] but dyanmically expects [[firrtl.ir.GroundType GroundType]]
-    */
-  def getGroundZero(tpe: Type): Expression = tpe match {
-    case _: UIntType => UIntZero
-    case _: SIntType => SIntZero
-    case ClockType => ClockZero
-    case _: FixedType => FixedZero
-    case other => throwInternalError(s"Unexpected type $other")
+  override val prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.LowForm
+
+  override val dependents: Seq[Class[Transform]] = Seq(classOf[SystemVerilogEmitter], classOf[VerilogEmitter])
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case _: Legalize | _: firrtl.transforms.ConstantPropagation => true
+    case _ => false
   }
 
   // Recursive. Removes ValidIfs
@@ -50,4 +47,26 @@ object RemoveValidIf extends Pass {
   }
 
   def run(c: Circuit): Circuit = Circuit(c.info, c.modules.map(onModule), c.main)
+}
+
+object RemoveValidIf extends Pass with DeprecatedPassObject {
+
+  override lazy val underlying = new RemoveValidIf
+
+  val UIntZero = Utils.zero
+  val SIntZero = SIntLiteral(BigInt(0), IntWidth(1))
+  val ClockZero = DoPrim(PrimOps.AsClock, Seq(UIntZero), Seq.empty, ClockType)
+  val FixedZero = FixedLiteral(BigInt(0), IntWidth(1), IntWidth(0))
+
+  /** Returns an [[firrtl.ir.Expression Expression]] equal to zero for a given [[firrtl.ir.GroundType GroundType]]
+    * @note Accepts [[firrtl.ir.Type Type]] but dyanmically expects [[firrtl.ir.GroundType GroundType]]
+    */
+  def getGroundZero(tpe: Type): Expression = tpe match {
+    case _: UIntType => UIntZero
+    case _: SIntType => SIntZero
+    case ClockType => ClockZero
+    case _: FixedType => FixedZero
+    case other => throwInternalError(s"Unexpected type $other")
+  }
+
 }

--- a/src/main/scala/firrtl/passes/ReplaceAccesses.scala
+++ b/src/main/scala/firrtl/passes/ReplaceAccesses.scala
@@ -2,22 +2,32 @@
 
 package firrtl.passes
 
+import firrtl.Transform
 import firrtl.ir._
 import firrtl.{WSubAccess, WSubIndex}
 import firrtl.Mappers._
-
+import firrtl.options.PreservesAll
 
 /** Replaces constant [[firrtl.WSubAccess]] with [[firrtl.WSubIndex]]
   * TODO Fold in to High Firrtl Const Prop
   */
-object ReplaceAccesses extends Pass {
+class ReplaceAccesses extends Pass with PreservesAll[Transform] {
+
+  override def prerequisites = firrtl.stage.Forms.Deduped :+ classOf[PullMuxes].asInstanceOf[Class[Transform]]
+
   def run(c: Circuit): Circuit = {
     def onStmt(s: Statement): Statement = s map onStmt map onExp
     def onExp(e: Expression): Expression = e match {
       case WSubAccess(ex, UIntLiteral(value, width), t, g) => WSubIndex(onExp(ex), value.toInt, t, g)
       case _ => e map onExp
     }
-  
+
     c copy (modules = c.modules map (_ map onStmt))
   }
+}
+
+object ReplaceAccesses extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new ReplaceAccesses
+
 }

--- a/src/main/scala/firrtl/passes/Resolves.scala
+++ b/src/main/scala/firrtl/passes/Resolves.scala
@@ -5,9 +5,21 @@ package firrtl.passes
 import firrtl._
 import firrtl.ir._
 import firrtl.Mappers._
+import firrtl.options.PreservesAll
 import Utils.throwInternalError
 
-object ResolveKinds extends Pass {
+
+object ResolveKinds extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new ResolveKinds
+
+}
+
+class ResolveKinds extends Pass with PreservesAll[Transform] {
+
+  override def prerequisites: Seq[Class[Transform]] =
+    Seq[Class[Transform]]( classOf[passes.CheckHighForm] ) ++ firrtl.stage.Forms.WorkingIR
+
   type KindMap = collection.mutable.LinkedHashMap[String, Kind]
 
   def find_port(kinds: KindMap)(p: Port): Port = {
@@ -22,7 +34,7 @@ object ResolveKinds extends Pass {
       case sx: WDefInstance => kinds(sx.name) = InstanceKind
       case sx: DefMemory => kinds(sx.name) = MemKind
       case _ =>
-    } 
+    }
     s map find_stmt(kinds)
   }
 
@@ -40,12 +52,25 @@ object ResolveKinds extends Pass {
        map find_stmt(kinds)
        map resolve_stmt(kinds))
   }
- 
+
   def run(c: Circuit): Circuit =
     c copy (modules = c.modules map resolve_kinds)
 }
 
-object ResolveGenders extends Pass {
+object ResolveGenders extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new ResolveGenders
+
+}
+
+class ResolveGenders extends Pass with PreservesAll[Transform] {
+
+  override def prerequisites: Seq[Class[Transform]] =
+    Seq[Class[Transform]]( classOf[passes.CheckHighForm],
+                           classOf[passes.ResolveKinds],
+                           classOf[passes.InferTypes],
+                           classOf[passes.Uniquify] ) ++ firrtl.stage.Forms.WorkingIR
+
   def resolve_e(g: Gender)(e: Expression): Expression = e match {
     case ex: WRef => ex copy (gender = g)
     case WSubField(exp, name, tpe, _) => WSubField(
@@ -59,7 +84,7 @@ object ResolveGenders extends Pass {
       WSubAccess(resolve_e(g)(exp), resolve_e(MALE)(index), tpe, g)
     case _ => e map resolve_e(g)
   }
-        
+
   def resolve_s(s: Statement): Statement = s match {
     //TODO(azidar): pretty sure don't need to do anything for Attach, but not positive...
     case IsInvalid(info, expr) =>
@@ -77,7 +102,17 @@ object ResolveGenders extends Pass {
     c copy (modules = c.modules map resolve_gender)
 }
 
-object CInferMDir extends Pass {
+object CInferMDir extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new CInferMDir
+
+}
+
+class CInferMDir extends Pass with PreservesAll[Transform] {
+
+  override def prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.ChirrtlForm ++
+    Seq[Class[Transform]]( classOf[CInferTypes] )
+
   type MPortDirMap = collection.mutable.LinkedHashMap[String, MPortDir]
 
   def infer_mdir_e(mports: MPortDirMap, dir: MPortDir)(e: Expression): Expression = e match {
@@ -111,7 +146,7 @@ object CInferMDir extends Pass {
     case e => e map infer_mdir_e(mports, dir)
   }
 
-  def infer_mdir_s(mports: MPortDirMap)(s: Statement): Statement = s match { 
+  def infer_mdir_s(mports: MPortDirMap)(s: Statement): Statement = s match {
     case sx: CDefMPort =>
        mports(sx.name) = sx.direction
        sx map infer_mdir_e(mports, MRead)
@@ -125,17 +160,17 @@ object CInferMDir extends Pass {
        sx
     case sx => sx map infer_mdir_s(mports) map infer_mdir_e(mports, MRead)
   }
-        
-  def set_mdir_s(mports: MPortDirMap)(s: Statement): Statement = s match { 
+
+  def set_mdir_s(mports: MPortDirMap)(s: Statement): Statement = s match {
     case sx: CDefMPort => sx copy (direction = mports(sx.name))
     case sx => sx map set_mdir_s(mports)
   }
-  
+
   def infer_mdir(m: DefModule): DefModule = {
     val mports = new MPortDirMap
     m map infer_mdir_s(mports) map set_mdir_s(mports)
   }
-     
+
   def run(c: Circuit): Circuit =
     c copy (modules = c.modules map infer_mdir)
 }

--- a/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
+++ b/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
@@ -23,7 +23,12 @@ import scala.collection.mutable
  *  This is technically incorrect firrtl, but allows the verilog emitter
  *  to emit correct verilog without needing to add temporary nodes
  */
-object VerilogModulusCleanup extends Pass {
+class VerilogModulusCleanup extends Pass {
+
+  override def prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.LowFormMinimumOptimized ++
+    Seq[Class[Transform]]( classOf[firrtl.transforms.BlackBoxSourceHelper],
+                           classOf[firrtl.transforms.ReplaceTruncatingArithmetic],
+                           classOf[firrtl.transforms.FlattenRegUpdate] )
 
   private def onModule(m: Module): Module = {
     val namespace = Namespace(m)
@@ -47,7 +52,7 @@ object VerilogModulusCleanup extends Pass {
 
       def removeRem(e: Expression): Expression = e match {
         case e: DoPrim => e.op match {
-          case Rem => 
+          case Rem =>
             val name = namespace.newTemp
             val newType = e mapType verilogRemWidth(e)
             v += DefNode(get_info(s), name, e mapType verilogRemWidth(e))
@@ -80,4 +85,10 @@ object VerilogModulusCleanup extends Pass {
     }
     Circuit(c.info, modules, c.main)
   }
+}
+
+object VerilogModulusCleanup extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new VerilogModulusCleanup
+
 }

--- a/src/main/scala/firrtl/passes/ZeroWidth.scala
+++ b/src/main/scala/firrtl/passes/ZeroWidth.scala
@@ -7,7 +7,22 @@ import firrtl.ir._
 import firrtl._
 import firrtl.Mappers._
 
-object ZeroWidth extends Transform {
+class ZeroWidth extends Transform {
+
+  override def prerequisites: Seq[Class[Transform]] =
+    Seq[Class[Transform]]( classOf[PullMuxes],
+                           classOf[ReplaceAccesses],
+                           classOf[ExpandConnects],
+                           classOf[RemoveAccesses],
+                           classOf[Uniquify],
+                           classOf[ExpandWhensAndCheck],
+                           classOf[ConvertFixedToSInt] ) ++ firrtl.stage.Forms.Deduped
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case _: InferTypes => true
+    case _             => false
+  }
+
   def inputForm: CircuitForm = UnknownForm
   def outputForm: CircuitForm = UnknownForm
 
@@ -173,10 +188,16 @@ object ZeroWidth extends Transform {
   def execute(state: CircuitState): CircuitState = {
     // run executeEmptyMemStmt first to remove zero-width memories
     // then run InferTypes to update widths for addr, en, clk, etc
-    val c = InferTypes.run(executeEmptyMemStmt(state).circuit)
+    val c = (new InferTypes).run(executeEmptyMemStmt(state).circuit)
     val renames = RenameMap()
     renames.setCircuit(c.main)
     val result = c.copy(modules = c.modules map onModule(renames))
     CircuitState(result, outputForm, state.annotations, Some(renames))
   }
+}
+
+object ZeroWidth extends Transform with DeprecatedTransformObject {
+
+  override protected lazy val underlying = new ZeroWidth
+
 }

--- a/src/main/scala/firrtl/passes/memlib/InferReadWrite.scala
+++ b/src/main/scala/firrtl/passes/memlib/InferReadWrite.scala
@@ -159,10 +159,10 @@ class InferReadWrite extends Transform with SeqTransformBased with HasShellOptio
 
   def transforms = Seq(
     InferReadWritePass,
-    CheckInitialization,
-    InferTypes,
-    ResolveKinds,
-    ResolveGenders
+    new CheckInitialization,
+    new InferTypes,
+    new ResolveKinds,
+    new ResolveGenders
   )
   def execute(state: CircuitState): CircuitState = {
     val runTransform = state.annotations.contains(InferReadWriteAnnotation)

--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
@@ -122,11 +122,11 @@ class ReplSeqMem extends Transform with HasShellOptions {
         new ReplaceMemMacros(outConfigFile),
         new WiringTransform,
         new SimpleMidTransform(RemoveEmpty),
-        new SimpleMidTransform(CheckInitialization),
-        new SimpleMidTransform(InferTypes),
-        Uniquify,
-        new SimpleMidTransform(ResolveKinds),
-        new SimpleMidTransform(ResolveGenders))
+        new SimpleMidTransform(new CheckInitialization),
+        new SimpleMidTransform(new InferTypes),
+        new Uniquify,
+        new SimpleMidTransform(new ResolveKinds),
+        new SimpleMidTransform(new ResolveGenders))
 
   def execute(state: CircuitState): CircuitState = {
     val annos = state.annotations.collect { case a: ReplSeqMemAnnotation => a }

--- a/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
+++ b/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
@@ -14,7 +14,18 @@ import MemPortUtils._
 import collection.mutable
 
 /** This pass generates delay reigsters for memories for verilog */
-object VerilogMemDelays extends Pass {
+class VerilogMemDelays extends Pass {
+
+  override val prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.LowForm :+
+    classOf[firrtl.passes.RemoveValidIf].asInstanceOf[Class[Transform]]
+
+  override val dependents: Seq[Class[Transform]] = Seq(classOf[VerilogEmitter], classOf[SystemVerilogEmitter])
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case _: firrtl.transforms.ConstantPropagation => true
+    case _ => false
+  }
+
   val ug = UNKNOWNGENDER
   type Netlist = collection.mutable.HashMap[String, Expression]
   implicit def expToString(e: Expression): String = e.serialize
@@ -94,7 +105,7 @@ object VerilogMemDelays extends Pass {
         Connect(NoInfo, memPortField(mem, writer, "addr"), addr),
         Connect(NoInfo, memPortField(mem, writer, "data"), data)
       )
- 
+
       stmts ++= ((sx.readers flatMap {reader =>
         // generate latency pipes for read ports (enable & addr)
         val clk = netlist(memPortField(sx, reader, "clk"))
@@ -158,4 +169,10 @@ object VerilogMemDelays extends Pass {
 
   def run(c: Circuit): Circuit =
     c copy (modules = c.modules map memDelayMod)
+}
+
+object VerilogMemDelays extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new VerilogMemDelays
+
 }

--- a/src/main/scala/firrtl/passes/wiring/WiringTransform.scala
+++ b/src/main/scala/firrtl/passes/wiring/WiringTransform.scala
@@ -43,7 +43,7 @@ class WiringTransform extends Transform {
   /** Defines the sequence of Transform that should be applied */
   private def transforms(w: Seq[WiringInfo]): Seq[Transform] = Seq(
     new Wiring(w),
-    ToWorkingIR
+    new ToWorkingIR
   )
   def execute(state: CircuitState): CircuitState = {
     val annos = state.annotations.collect {

--- a/src/main/scala/firrtl/stage/FirrtlStage.scala
+++ b/src/main/scala/firrtl/stage/FirrtlStage.scala
@@ -3,24 +3,20 @@
 package firrtl.stage
 
 import firrtl.{AnnotationSeq, CustomTransformException, FIRRTLException, Utils}
-import firrtl.options.{Stage, Phase, PhaseException, Shell, OptionsException, StageMain}
+import firrtl.options.{DependencyManagerException, Phase, PhaseException, PhaseManager, PreservesAll, Shell, Stage,
+  OptionsException, StageMain}
 import firrtl.options.phases.DeletedWrapper
 import firrtl.passes.{PassException, PassExceptions}
 
 import scala.util.control.ControlThrowable
 
 
-class FirrtlStage extends Stage {
+class FirrtlStage extends Stage with PreservesAll[Phase] {
+
   val shell: Shell = new Shell("firrtl") with FirrtlCli
 
-  private val phases: Seq[Phase] =
-    Seq( new firrtl.stage.phases.AddDefaults,
-         new firrtl.stage.phases.AddImplicitEmitter,
-         new firrtl.stage.phases.Checks,
-         new firrtl.stage.phases.AddCircuit,
-         new firrtl.stage.phases.AddImplicitOutputFile,
-         new firrtl.stage.phases.Compiler,
-         new firrtl.stage.phases.WriteEmitted )
+  val phases: Seq[Phase] = new PhaseManager(Seq(classOf[firrtl.stage.phases.WriteEmitted]))
+      .transformOrder
       .map(DeletedWrapper(_))
 
   def run(annotations: AnnotationSeq): AnnotationSeq = try {
@@ -29,7 +25,7 @@ class FirrtlStage extends Stage {
     /* Rethrow the exceptions which are expected or due to the runtime environment (out of memory, stack overflow, etc.).
      * Any UNEXPECTED exceptions should be treated as internal errors. */
     case p @ (_: ControlThrowable | _: PassException | _: PassExceptions | _: FIRRTLException | _: OptionsException
-                | _: PhaseException) => throw p
+                | _: PhaseException | _: DependencyManagerException) => throw p
     case CustomTransformException(cause) => throw cause
     case e: Exception => Utils.throwInternalError(exception = Some(e))
   }

--- a/src/main/scala/firrtl/stage/Forms.scala
+++ b/src/main/scala/firrtl/stage/Forms.scala
@@ -1,0 +1,87 @@
+// See LICENSE for license details.
+
+package firrtl.stage
+
+import firrtl._
+import firrtl.Transform
+
+/*
+ * - InferWidths should have InferTypes split out
+ * - ConvertFixedToSInt should have InferTypes split out
+ * - Move InferTypes out of ZeroWidth
+ */
+
+object Forms {
+
+  private implicit def classHelper(a: Class[_ <: Transform]): Class[Transform] = a.asInstanceOf[Class[Transform]]
+
+  val ChirrtlForm: Seq[Class[Transform]] = Seq.empty
+
+  val HighForm: Seq[Class[Transform]] = ChirrtlForm ++
+    Seq[Class[Transform]]( classOf[passes.CheckChirrtl],
+                           classOf[passes.CInferTypes],
+                           classOf[passes.CInferMDir],
+                           classOf[passes.RemoveCHIRRTL] )
+
+  val WorkingIR: Seq[Class[Transform]] = HighForm :+ classOf[passes.ToWorkingIR].asInstanceOf[Class[Transform]]
+
+  val Resolved: Seq[Class[Transform]] = WorkingIR ++
+    Seq[Class[Transform]]( classOf[passes.CheckHighForm],
+                           classOf[passes.ResolveKinds],
+                           classOf[passes.InferTypes],
+                           classOf[passes.CheckTypes],
+                           classOf[passes.Uniquify],
+                           classOf[passes.ResolveGenders],
+                           classOf[passes.CheckGenders],
+                           classOf[passes.InferWidths],
+                           classOf[passes.CheckWidths] )
+
+  val Deduped: Seq[Class[Transform]] = Resolved :+ classOf[firrtl.transforms.DedupModules].asInstanceOf[Class[Transform]]
+
+  val MidForm: Seq[Class[Transform]] = Deduped ++
+    Seq[Class[Transform]]( classOf[passes.PullMuxes],
+                           classOf[passes.ReplaceAccesses],
+                           classOf[passes.ExpandConnects],
+                           classOf[passes.RemoveAccesses],
+                           classOf[passes.ExpandWhensAndCheck],
+                           classOf[passes.ConvertFixedToSInt],
+                           classOf[passes.ZeroWidth] )
+
+  val LowForm: Seq[Class[Transform]] = MidForm ++
+    Seq[Class[Transform]]( classOf[passes.LowerTypes],
+                           classOf[passes.Legalize],
+                           classOf[firrtl.transforms.RemoveReset],
+                           classOf[firrtl.transforms.CheckCombLoops],
+                           classOf[firrtl.transforms.RemoveWires] )
+
+  val LowFormMinimumOptimized: Seq[Class[Transform]] = LowForm ++
+    Seq[Class[Transform]]( classOf[passes.RemoveValidIf],
+                           classOf[passes.memlib.VerilogMemDelays],
+                           classOf[passes.SplitExpressions] )
+
+  val LowFormOptimized: Seq[Class[Transform]] = LowFormMinimumOptimized ++
+    Seq[Class[Transform]]( classOf[firrtl.transforms.ConstantPropagation],
+                           classOf[passes.PadWidths],
+                           classOf[firrtl.transforms.CombineCats],
+                           classOf[passes.CommonSubexpressionElimination],
+                           classOf[firrtl.transforms.DeadCodeElimination] )
+
+  val VerilogMinimumOptimized: Seq[Class[Transform]] = LowFormMinimumOptimized ++
+    Seq[Class[Transform]]( classOf[firrtl.transforms.BlackBoxSourceHelper],
+                           classOf[firrtl.transforms.ReplaceTruncatingArithmetic],
+                           classOf[firrtl.transforms.FlattenRegUpdate],
+                           classOf[passes.VerilogModulusCleanup],
+                           classOf[firrtl.transforms.VerilogRename],
+                           classOf[passes.VerilogPrep],
+                           classOf[firrtl.AddDescriptionNodes] )
+
+  val VerilogOptimized: Seq[Class[Transform]] = LowFormOptimized ++
+    Seq[Class[Transform]]( classOf[firrtl.transforms.BlackBoxSourceHelper],
+                           classOf[firrtl.transforms.ReplaceTruncatingArithmetic],
+                           classOf[firrtl.transforms.FlattenRegUpdate],
+                           classOf[passes.VerilogModulusCleanup],
+                           classOf[firrtl.transforms.VerilogRename],
+                           classOf[passes.VerilogPrep],
+                           classOf[firrtl.AddDescriptionNodes] )
+
+}

--- a/src/main/scala/firrtl/stage/TransformManager.scala
+++ b/src/main/scala/firrtl/stage/TransformManager.scala
@@ -1,0 +1,22 @@
+// See LICENSE for license details.
+
+package firrtl.stage
+
+import firrtl.{CircuitForm, CircuitState, Transform, UnknownForm}
+import firrtl.options.DependencyManager
+
+class TransformManager(
+  val targets: Seq[Class[Transform]],
+  val currentState: Seq[Class[Transform]] = Seq.empty,
+  val knownObjects: Set[Transform] = Set.empty) extends Transform with DependencyManager[CircuitState, Transform] {
+
+  override def inputForm: CircuitForm = UnknownForm
+
+  override def outputForm: CircuitForm = UnknownForm
+
+  override def execute(state: CircuitState): CircuitState = transform(state)
+
+  override protected def copy(a: Seq[Class[Transform]], b: Seq[Class[Transform]], c: Set[Transform]) =
+    new TransformManager(a, b, c)
+
+}

--- a/src/main/scala/firrtl/stage/phases/AddCircuit.scala
+++ b/src/main/scala/firrtl/stage/phases/AddCircuit.scala
@@ -5,7 +5,7 @@ package firrtl.stage.phases
 import firrtl.stage._
 
 import firrtl.{AnnotationSeq, Parser}
-import firrtl.options.{Phase, PhasePrerequisiteException}
+import firrtl.options.{Phase, PhasePrerequisiteException, PreservesAll}
 
 /** [[firrtl.options.Phase Phase]] that expands [[FirrtlFileAnnotation]]/[[FirrtlSourceAnnotation]] into
   * [[FirrtlCircuitAnnotation]]s and deletes the originals. This is part of the preprocessing done on an input
@@ -25,7 +25,9 @@ import firrtl.options.{Phase, PhasePrerequisiteException}
   * an [[InfoModeAnnotation]].'''.
   * @define infoModeException firrtl.options.PhasePrerequisiteException if no [[InfoModeAnnotation]] is present
   */
-class AddCircuit extends Phase {
+class AddCircuit extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites: Seq[Class[Phase]] = Seq(classOf[AddDefaults], classOf[Checks])
 
   /** Extract the info mode from an [[AnnotationSeq]] or use the default info mode if no annotation exists
     * @param annotations some annotations

--- a/src/main/scala/firrtl/stage/phases/AddDefaults.scala
+++ b/src/main/scala/firrtl/stage/phases/AddDefaults.scala
@@ -3,14 +3,14 @@
 package firrtl.stage.phases
 
 import firrtl.AnnotationSeq
-import firrtl.options.{Phase, TargetDirAnnotation}
+import firrtl.options.{Phase, PreservesAll, TargetDirAnnotation}
 import firrtl.transforms.BlackBoxTargetDirAnno
 import firrtl.stage.{CompilerAnnotation, InfoModeAnnotation, FirrtlOptions}
 
 /** [[firrtl.options.Phase Phase]] that adds default [[FirrtlOption]] [[firrtl.annotations.Annotation Annotation]]s.
   * This is a part of the preprocessing done by [[FirrtlStage]].
   */
-class AddDefaults extends Phase {
+class AddDefaults extends Phase with PreservesAll[Phase] {
 
   /** Append any missing default annotations to an annotation sequence */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/stage/phases/AddImplicitEmitter.scala
+++ b/src/main/scala/firrtl/stage/phases/AddImplicitEmitter.scala
@@ -4,12 +4,14 @@ package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, EmitAnnotation, EmitCircuitAnnotation}
 import firrtl.stage.{CompilerAnnotation, RunFirrtlTransformAnnotation}
-import firrtl.options.Phase
+import firrtl.options.{Phase, PreservesAll}
 
 /** [[firrtl.options.Phase Phase]] that adds a [[firrtl.EmitCircuitAnnotation EmitCircuitAnnotation]] derived from a
   * [[firrtl.stage.CompilerAnnotation CompilerAnnotation]] if one does not already exist.
   */
-class AddImplicitEmitter extends Phase {
+class AddImplicitEmitter extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites: Seq[Class[Phase]] = Seq(classOf[AddDefaults])
 
   def transform(annos: AnnotationSeq): AnnotationSeq = {
     val emitter = annos.collectFirst{ case a: EmitAnnotation => a }

--- a/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
+++ b/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
@@ -3,22 +3,26 @@
 package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, EmitAllModulesAnnotation}
-import firrtl.options.{Phase, Viewer}
+import firrtl.options.{Phase, PreservesAll, Viewer}
 import firrtl.stage.{FirrtlOptions, OutputFileAnnotation}
 
 /** [[firrtl.options.Phase Phase]] that adds an [[OutputFileAnnotation]] if one does not already exist.
   *
   * To determine the [[OutputFileAnnotation]], the following precedence is used. Whichever happens first succeeds:
   *  - Do nothing if an [[OutputFileAnnotation]] or [[EmitAllModulesAnnotation]] exist
-  *  - Use the main in the first discovered [[FirrtlCircuitAnnotation]] (see note below)
+  *  - Use the main in the first discovered [[firrtl.stage.FirrtlCircuitAnnotation FirrtlCircuitAnnotation]] (see note
+  *    below)
   *  - Use "a"
   *
   * The file suffix may or may not be specified, but this may be arbitrarily changed by the [[Emitter]].
   *
-  * @note This [[firrtl.options.Phase Phase]] has a dependency on [[AddCircuit]]. Only a [[FirrtlCircuitAnnotation]]
-  * will be used to implicitly set the [[OutputFileAnnotation]] (not other [[CircuitOption]] subclasses).
+  * @note This [[firrtl.options.Phase Phase]] has a dependency on [[AddCircuit]]. Only a
+  * [[firrtl.stage.FirrtlCircuitAnnotation FirrtlCircuitAnnotation]] will be used to implicitly set the
+  * [[OutputFileAnnotation]] (not other [[CircuitOption]] subclasses).
   */
-class AddImplicitOutputFile extends Phase {
+class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites: Seq[Class[Phase]] = Seq(classOf[AddCircuit])
 
   /** Add an [[OutputFileAnnotation]] to an [[AnnotationSeq]] */
   def transform(annotations: AnnotationSeq): AnnotationSeq =

--- a/src/main/scala/firrtl/stage/phases/Checks.scala
+++ b/src/main/scala/firrtl/stage/phases/Checks.scala
@@ -6,7 +6,7 @@ import firrtl.stage._
 
 import firrtl.{AnnotationSeq, EmitAllModulesAnnotation, EmitCircuitAnnotation}
 import firrtl.annotations.Annotation
-import firrtl.options.{OptionsException, Phase}
+import firrtl.options.{OptionsException, Phase, PreservesAll}
 
 /** [[firrtl.options.Phase Phase]] that strictly validates an [[AnnotationSeq]]. The checks applied are intended to be
   * extremeley strict. Nothing is inferred or assumed to take a default value (for default value resolution see
@@ -16,11 +16,13 @@ import firrtl.options.{OptionsException, Phase}
   * certain that other [[firrtl.options.Phase Phase]]s or views will succeed. See [[FirrtlStage]] for a list of
   * [[firrtl.options.Phase Phase]] that commonly run before this.
   */
-class Checks extends Phase {
+class Checks extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites: Seq[Class[Phase]] = Seq(classOf[AddDefaults], classOf[AddImplicitEmitter])
 
   /** Determine if annotations are sane
     *
-    * @param annos a sequence of [[annotation.Annotation]]
+    * @param annos a sequence of [[firrtl.annotations.Annotation Annotation]]
     * @return true if all checks pass
     * @throws firrtl.options.OptionsException if any checks fail
     */

--- a/src/main/scala/firrtl/stage/phases/Compiler.scala
+++ b/src/main/scala/firrtl/stage/phases/Compiler.scala
@@ -3,9 +3,8 @@
 package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, ChirrtlForm, CircuitState, Compiler => FirrtlCompiler, Transform, seqToAnnoSeq}
-import firrtl.options.{Phase, PhasePrerequisiteException, Translator}
-import firrtl.stage.{CompilerAnnotation, FirrtlCircuitAnnotation,
-  RunFirrtlTransformAnnotation}
+import firrtl.options.{Phase, PhasePrerequisiteException, PreservesAll, Translator}
+import firrtl.stage.{CompilerAnnotation, FirrtlCircuitAnnotation, Forms, RunFirrtlTransformAnnotation}
 
 import scala.collection.mutable
 
@@ -23,13 +22,13 @@ private [stage] case class Defaults(
   compiler: Option[FirrtlCompiler] = None)
 
 /** Runs the FIRRTL compilers on an [[AnnotationSeq]]. If the input [[AnnotationSeq]] contains more than one circuit
-  * (i.e., more than one [[FirrtlCircuitAnnotation]]), then annotations will be broken up and each run will be executed
-  * in parallel.
+  * (i.e., more than one [[firrtl.stage.FirrtlCircuitAnnotation FirrtlCircuitAnnotation]]), then annotations will be
+  * broken up and each run will be executed in parallel.
   *
   * The [[AnnotationSeq]] will be chunked up into compiler runs using the following algorithm. All annotations that
-  * occur before the first [[FirrtlCircuitAnnotation]] are treated as global annotations that apply to all circuits.
-  * Annotations after a circuit are only associated with their closest preceeding circuit. E.g., for the following
-  * annotations (where A, B, and C are some annotations):
+  * occur before the first [[firrtl.stage.FirrtlCircuitAnnotation FirrtlCircuitAnnotation]] are treated as global
+  * annotations that apply to all circuits. Annotations after a circuit are only associated with their closest
+  * preceeding circuit. E.g., for the following annotations (where A, B, and C are some annotations):
   *
   *    A(a), FirrtlCircuitAnnotation(x), B, FirrtlCircuitAnnotation(y), A(b), C, FirrtlCircuitAnnotation(z)
   *
@@ -42,7 +41,14 @@ private [stage] case class Defaults(
   * FirrtlCircuitAnnotation(y). Note: A(b) ''may'' overwrite A(a) if this is a CompilerAnnotation.
   * FirrtlCircuitAnnotation(z) has no annotations, so it only gets the default A(a).
   */
-class Compiler extends Phase with Translator[AnnotationSeq, Seq[CompilerRun]] {
+class Compiler extends Phase with Translator[AnnotationSeq, Seq[CompilerRun]] with PreservesAll[Phase] {
+
+  override val prerequisites: Seq[Class[Phase]] =
+    Seq(classOf[AddDefaults],
+        classOf[AddImplicitEmitter],
+        classOf[Checks],
+        classOf[AddCircuit],
+        classOf[AddImplicitOutputFile]).asInstanceOf[Seq[Class[Phase]]]
 
   /** Convert an [[AnnotationSeq]] into a sequence of compiler runs. */
   protected def aToB(a: AnnotationSeq): Seq[CompilerRun] = {
@@ -85,15 +91,24 @@ class Compiler extends Phase with Translator[AnnotationSeq, Seq[CompilerRun]] {
     */
   protected def internalTransform(b: Seq[CompilerRun]): Seq[CompilerRun] = {
     def f(c: CompilerRun): CompilerRun = {
-      val statex = c
-        .compiler
-        .getOrElse { throw new PhasePrerequisiteException("No compiler specified!") }
-        .compile(c.stateIn, c.transforms.reverse)
-      c.copy(stateOut = Some(statex))
+      val targets = c.compiler match {
+        case Some(d) => compilerToTransforms(d) ++ c.transforms.map(_.getClass.asInstanceOf[Class[Transform]])
+        case None    => throw new PhasePrerequisiteException("No compiler specified!") }
+      val tm = new firrtl.stage.transforms.Compiler(targets)
+      c.copy(stateOut = Some(tm.transform(c.stateIn)))
     }
 
     if (b.size <= 1) { b.map(f)         }
     else             { b.par.map(f).seq }
+  }
+
+  private def compilerToTransforms(a: FirrtlCompiler): Seq[Class[Transform]] = a match {
+    case _: firrtl.NoneCompiler                                      => Forms.ChirrtlForm
+    case _: firrtl.HighFirrtlCompiler                                => Forms.HighForm
+    case _: firrtl.MiddleFirrtlCompiler                              => Forms.MidForm
+    case _: firrtl.LowFirrtlCompiler                                 => Forms.LowForm
+    case _: firrtl.VerilogCompiler | _: firrtl.SystemVerilogCompiler => Forms.LowFormOptimized
+    case _: firrtl.MinimumVerilogCompiler                            => Forms.LowFormMinimumOptimized
   }
 
 }

--- a/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
+++ b/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
@@ -3,7 +3,7 @@
 package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, EmittedModuleAnnotation, EmittedCircuitAnnotation}
-import firrtl.options.{Phase, StageOptions, Viewer}
+import firrtl.options.{Phase, PreservesAll, StageOptions, Viewer}
 import firrtl.stage.FirrtlOptions
 
 import java.io.PrintWriter
@@ -24,7 +24,9 @@ import java.io.PrintWriter
   *
   * Any annotations written to files will be deleted.
   */
-class WriteEmitted extends Phase {
+class WriteEmitted extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites: Seq[Class[Phase]] = Seq(classOf[Compiler])
 
   /** Write any [[EmittedAnnotation]]s in an [[AnnotationSeq]] to files. Written [[EmittedAnnotation]]s are deleted. */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/stage/transforms/CatchCustomTransformExceptions.scala
+++ b/src/main/scala/firrtl/stage/transforms/CatchCustomTransformExceptions.scala
@@ -1,0 +1,30 @@
+// See LICENSE for license details.
+
+package firrtl.stage.transforms
+
+import firrtl.{CircuitState, CustomTransformException, Transform}
+
+class CatchCustomTransformExceptions(val underlying: Transform) extends Transform with WrappedTransform {
+
+  override def execute(c: CircuitState): CircuitState = try {
+    underlying.execute(c)
+  } catch {
+    case e: Exception if CatchCustomTransformExceptions.isCustomTransform(trueUnderlying) => throw CustomTransformException(e)
+  }
+
+}
+
+object CatchCustomTransformExceptions {
+
+  private[firrtl] def isCustomTransform(xform: Transform): Boolean = {
+    def getTopPackage(pack: java.lang.Package): java.lang.Package =
+      Package.getPackage(pack.getName.split('.').head)
+    // We use the top package of the Driver to get the top firrtl package
+    Option(xform.getClass.getPackage).map { p =>
+      getTopPackage(p) != firrtl.Driver.getClass.getPackage
+    }.getOrElse(true)
+  }
+
+  def apply(a: Transform): CatchCustomTransformExceptions = new CatchCustomTransformExceptions(a)
+
+}

--- a/src/main/scala/firrtl/stage/transforms/Compiler.scala
+++ b/src/main/scala/firrtl/stage/transforms/Compiler.scala
@@ -1,0 +1,19 @@
+// See LICENSE for license details.
+
+package firrtl.stage.transforms
+
+import firrtl.{CircuitState, Transform}
+import firrtl.stage.TransformManager
+
+class Compiler(
+  targets: Seq[Class[Transform]],
+  currentState: Seq[Class[Transform]] = Seq.empty,
+  knownObjects: Set[Transform] = Set.empty) extends TransformManager(targets, currentState, knownObjects) {
+
+  override val wrappers = Seq(
+    (a: Transform) => CatchCustomTransformExceptions(a),
+    (a: Transform) => TrackTransforms(a),
+    (a: Transform) => UpdateAnnotations(a)
+  )
+
+}

--- a/src/main/scala/firrtl/stage/transforms/TrackTransforms.scala
+++ b/src/main/scala/firrtl/stage/transforms/TrackTransforms.scala
@@ -1,0 +1,69 @@
+// See LICENSE for license details.
+
+package firrtl.stage.transforms
+
+import firrtl.{AnnotationSeq, CircuitState, Transform}
+import firrtl.annotations.NoTargetAnnotation
+import firrtl.options.DependencyManagerException
+
+case class TransformHistoryAnnotation(history: Seq[Transform], state: Set[Transform]) extends NoTargetAnnotation {
+
+  def add(transform: Transform,
+          invalidates: (Transform) => Boolean = (a: Transform) => false): TransformHistoryAnnotation =
+    this.copy(
+      history = transform +: this.history,
+      state = (this.state + transform).filterNot(invalidates)
+    )
+
+}
+
+object TransformHistoryAnnotation {
+
+  def apply(transform: Transform): TransformHistoryAnnotation = TransformHistoryAnnotation(
+    history = Seq(transform),
+    state = Set(transform)
+  )
+
+}
+
+class TrackTransforms(val underlying: Transform) extends Transform with WrappedTransform {
+
+  private def updateState(annotations: AnnotationSeq): AnnotationSeq = {
+    var foundAnnotation = false
+    val annotationsx = annotations.map {
+      case x: TransformHistoryAnnotation =>
+        foundAnnotation = true
+        x.add(trueUnderlying)
+      case x => x
+    }
+    if (!foundAnnotation) {
+      TransformHistoryAnnotation(trueUnderlying) +: annotationsx
+    } else {
+      annotationsx
+    }
+  }
+
+  override def execute(c: CircuitState): CircuitState = {
+    val state = c.annotations
+      .collectFirst{ case TransformHistoryAnnotation(_, state) => state }
+      .getOrElse(Set.empty[Transform])
+      .map(_.getClass.asInstanceOf[Class[Transform]])
+
+    if (!trueUnderlying.prerequisites.toSet.subsetOf(state)) {
+      throw new DependencyManagerException(
+        s"""|Tried to execute Transform '$trueUnderlying' for which run-time prerequisites were not satisfied:
+            |  state: ${state.mkString("\n    -", "\n    -", "")}
+            |  prerequisites: ${trueUnderlying.prerequisites.mkString("\n    -", "\n    -", "")}""".stripMargin)
+    }
+
+    val out = underlying.execute(c)
+    out.copy(annotations = updateState(out.annotations))
+  }
+
+}
+
+object TrackTransforms {
+
+  def apply(a: Transform): Transform = new TrackTransforms(a)
+
+}

--- a/src/main/scala/firrtl/stage/transforms/UpdateAnnotations.scala
+++ b/src/main/scala/firrtl/stage/transforms/UpdateAnnotations.scala
@@ -1,0 +1,95 @@
+// See LICENSE for license details.
+
+package firrtl.stage.transforms
+
+import firrtl.{AnnotationSeq, CircuitState, RenameMap, Transform, Utils}
+import firrtl.annotations.{Annotation, DeletedAnnotation}
+import firrtl.options.Translator
+
+import scala.collection.mutable
+
+class UpdateAnnotations(val underlying: Transform) extends Transform with WrappedTransform
+    with Translator[CircuitState, (CircuitState, CircuitState)] {
+
+  override def execute(c: CircuitState): CircuitState = underlying.execute(c)
+
+  def aToB(a: CircuitState): (CircuitState, CircuitState) = (a, a)
+
+  def bToA(b: (CircuitState, CircuitState)): CircuitState = {
+    val (state, result) = (b._1, b._2)
+
+    val remappedAnnotations = propagateAnnotations(state.annotations, result.annotations, result.renames)
+
+    logger.info(s"Form: ${result.form}")
+
+    logger.debug(s"Annotations:")
+    remappedAnnotations.foreach( a => logger.debug(a.serialize) )
+
+    logger.trace(s"Circuit:\n${result.circuit.serialize}")
+    logger.info(s"======== Finished Transform $name ========\n")
+
+    CircuitState(result.circuit, result.form, remappedAnnotations, None)
+  }
+
+  def internalTransform(b: (CircuitState, CircuitState)): (CircuitState, CircuitState) = {
+    logger.info(s"======== Starting Transform $name ========")
+
+    /* @todo: prepare should likely be factored out of this */
+    val (timeMillis, result) = Utils.time { execute( trueUnderlying.prepare(b._2) ) }
+
+    logger.info(s"""----------------------------${"-" * name.size}---------\n""")
+    logger.info(f"Time: $timeMillis%.1f ms")
+
+    (b._1, result)
+  }
+
+  /** Propagate annotations and update their names.
+    *
+    * @param inAnno input AnnotationSeq
+    * @param resAnno result AnnotationSeq
+    * @param renameOpt result RenameMap
+    * @return the updated annotations
+    */
+  private[firrtl] def propagateAnnotations(
+      inAnno: AnnotationSeq,
+      resAnno: AnnotationSeq,
+      renameOpt: Option[RenameMap]): AnnotationSeq = {
+    val newAnnotations = {
+      val inSet = mutable.LinkedHashSet() ++ inAnno
+      val resSet = mutable.LinkedHashSet() ++ resAnno
+      val deleted = (inSet -- resSet).map {
+        case DeletedAnnotation(xFormName, delAnno) => DeletedAnnotation(s"$xFormName+$name", delAnno)
+        case anno => DeletedAnnotation(name, anno)
+      }
+      val created = resSet -- inSet
+      val unchanged = resSet & inSet
+      (deleted ++ created ++ unchanged)
+    }
+
+    // For each annotation, rename all annotations.
+    val renames = renameOpt.getOrElse(RenameMap())
+    val remapped2original = mutable.LinkedHashMap[Annotation, mutable.LinkedHashSet[Annotation]]()
+    val keysOfNote = mutable.LinkedHashSet[Annotation]()
+    val finalAnnotations = newAnnotations.flatMap { anno =>
+      val remappedAnnos = anno.update(renames)
+      remappedAnnos.foreach { remapped =>
+        val set = remapped2original.getOrElseUpdate(remapped, mutable.LinkedHashSet.empty[Annotation])
+        set += anno
+        if(set.size > 1) keysOfNote += remapped
+      }
+      remappedAnnos
+    }.toSeq
+    keysOfNote.foreach { key =>
+      logger.debug(s"""The following original annotations are renamed to the same new annotation.""")
+      logger.debug(s"""Original Annotations:\n  ${remapped2original(key).mkString("\n  ")}""")
+      logger.debug(s"""New Annotation:\n  $key""")
+    }
+    finalAnnotations
+  }
+}
+
+object UpdateAnnotations {
+
+  def apply(a: Transform): UpdateAnnotations = new UpdateAnnotations(a)
+
+}

--- a/src/main/scala/firrtl/stage/transforms/WrappedTransform.scala
+++ b/src/main/scala/firrtl/stage/transforms/WrappedTransform.scala
@@ -1,0 +1,33 @@
+// See LICENSE for license details.
+
+package firrtl.stage.transforms
+
+import firrtl.Transform
+
+/** A [[firrtl.Transform]] that "wraps" a second [[firrtl.Transform Transform]] to do some work before and after the
+  * second [[firrtl.Transform Transform]].
+  *
+  * This is intended to synergize with the [[firrtl.options.DependencyManager.wrappers]] method.
+  * @see [[firrtl.stage.transforms.CatchCustomTransformException]]
+  * @see [[firrtl.stage.transforms.TrackTransforms]]
+  * @see [[firrtl.stage.transforms.UpdateAnnotations]]
+  */
+trait WrappedTransform { this: Transform =>
+
+  /** The underlying [[firrtl.Transform]] */
+  val underlying: Transform
+
+  /** Return the original [[firrtl.Transform]] if this wrapper is wrapping other wrappers. */
+  lazy final val trueUnderlying: Transform = underlying match {
+    case a: WrappedTransform => a.trueUnderlying
+    case _ => underlying
+  }
+
+  override final val inputForm = underlying.inputForm
+  override final val outputForm = underlying.outputForm
+  override final val prerequisites = underlying.prerequisites
+  override final val dependents = underlying.dependents
+  override final def invalidates(b: Transform): Boolean = underlying.invalidates(b)
+  override final lazy val name = underlying.name
+
+}

--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -55,6 +55,10 @@ class BlackBoxSourceHelper extends firrtl.Transform {
   override def inputForm: CircuitForm = LowForm
   override def outputForm: CircuitForm = LowForm
 
+  override def prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.LowFormMinimumOptimized
+
+  override def dependents: Seq[Class[Transform]] = Seq.empty
+
   /** Collect BlackBoxHelperAnnos and and find the target dir if specified
     * @param annos a list of generic annotations for this transform
     * @return BlackBoxHelperAnnos and target directory

--- a/src/main/scala/firrtl/transforms/CheckCombLoops.scala
+++ b/src/main/scala/firrtl/transforms/CheckCombLoops.scala
@@ -13,7 +13,7 @@ import firrtl.annotations._
 import firrtl.Utils.throwInternalError
 import firrtl.graph.{MutableDiGraph,DiGraph}
 import firrtl.analyses.InstanceGraph
-import firrtl.options.{RegisteredTransform, ShellOption}
+import firrtl.options.{PreservesAll, RegisteredTransform, ShellOption}
 
 object CheckCombLoops {
   class CombLoopException(info: Info, mname: String, cycle: Seq[String]) extends PassException(
@@ -58,9 +58,14 @@ case class CombinationalPath(sink: ComponentName, sources: Seq[ComponentName]) e
   * @note The pass relies on ExtModulePathAnnotations to find loops through ExtModules
   * @note The pass will throw exceptions on "false paths"
   */
-class CheckCombLoops extends Transform with RegisteredTransform {
+class CheckCombLoops extends Transform with RegisteredTransform with PreservesAll[Transform] {
   def inputForm = LowForm
   def outputForm = LowForm
+
+  override val prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.MidForm ++
+    Seq[Class[Transform]]( classOf[passes.LowerTypes],
+                           classOf[passes.Legalize],
+                           classOf[firrtl.transforms.RemoveReset] )
 
   import CheckCombLoops._
 

--- a/src/main/scala/firrtl/transforms/CombineCats.scala
+++ b/src/main/scala/firrtl/transforms/CombineCats.scala
@@ -2,11 +2,13 @@
 package firrtl
 package transforms
 
+import firrtl.{SystemVerilogEmitter, VerilogEmitter}
 import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.PrimOps._
 import firrtl.WrappedExpression._
 import firrtl.annotations.NoTargetAnnotation
+import firrtl.options.PreservesAll
 
 import scala.collection.mutable
 
@@ -51,9 +53,18 @@ object CombineCats {
   * Use [[MaxCatLenAnnotation]] to limit the number of elements that can be concatenated.
   * The default maximum number of elements is 10.
   */
-class CombineCats extends Transform {
+class CombineCats extends Transform with PreservesAll[Transform] {
   def inputForm: LowForm.type = LowForm
   def outputForm: LowForm.type = LowForm
+
+  override val prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.LowForm ++
+    Seq[Class[Transform]]( classOf[passes.RemoveValidIf],
+                           classOf[firrtl.transforms.ConstantPropagation],
+                           classOf[firrtl.passes.memlib.VerilogMemDelays],
+                           classOf[firrtl.passes.SplitExpressions] )
+
+  override val dependents: Seq[Class[Transform]] = Seq(classOf[SystemVerilogEmitter], classOf[VerilogEmitter])
+
   val defaultMaxCatLen = 10
 
   def execute(state: CircuitState): CircuitState = {

--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -12,6 +12,7 @@ import firrtl.PrimOps._
 import firrtl.graph.DiGraph
 import firrtl.analyses.InstanceGraph
 import firrtl.annotations.TargetToken.Ref
+import firrtl.options.PreservesAll
 
 import annotation.tailrec
 import collection.mutable
@@ -90,10 +91,19 @@ object ConstantPropagation {
 
 }
 
-class ConstantPropagation extends Transform with ResolvedAnnotationPaths {
+class ConstantPropagation extends Transform with ResolvedAnnotationPaths with PreservesAll[Transform] {
   import ConstantPropagation._
   def inputForm = LowForm
   def outputForm = LowForm
+
+  override val prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.LowForm :+
+    classOf[passes.RemoveValidIf].asInstanceOf[Class[Transform]]
+
+  override val dependents: Seq[Class[Transform]] = Seq[Class[Transform]](
+    classOf[firrtl.passes.memlib.VerilogMemDelays],
+    classOf[firrtl.passes.SplitExpressions],
+    classOf[SystemVerilogEmitter],
+    classOf[VerilogEmitter] )
 
   override val annotationClasses: Traversable[Class[_]] = Seq(classOf[DontTouchAnnotation])
 

--- a/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
+++ b/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
@@ -10,7 +10,7 @@ import firrtl.analyses.InstanceGraph
 import firrtl.Mappers._
 import firrtl.Utils.{throwInternalError, kind}
 import firrtl.MemoizedHash._
-import firrtl.options.{RegisteredTransform, ShellOption}
+import firrtl.options.{PreservesAll, RegisteredTransform, ShellOption}
 
 import collection.mutable
 
@@ -29,9 +29,27 @@ import collection.mutable
   * circumstances of their instantiation in their parent module, they will still not be removed. To
   * remove such modules, use the [[NoDedupAnnotation]] to prevent deduplication.
   */
-class DeadCodeElimination extends Transform with ResolvedAnnotationPaths with RegisteredTransform {
+class DeadCodeElimination extends Transform with ResolvedAnnotationPaths with RegisteredTransform
+    with PreservesAll[Transform] {
   def inputForm = LowForm
   def outputForm = LowForm
+
+  override val prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.LowForm ++
+    Seq[Class[Transform]]( classOf[firrtl.passes.RemoveValidIf],
+                           classOf[firrtl.transforms.ConstantPropagation],
+                           classOf[firrtl.passes.memlib.VerilogMemDelays],
+                           classOf[firrtl.passes.SplitExpressions],
+                           classOf[firrtl.transforms.CombineCats],
+                           classOf[passes.CommonSubexpressionElimination] )
+
+  override val dependents: Seq[Class[Transform]] = Seq(
+    classOf[firrtl.transforms.BlackBoxSourceHelper],
+    classOf[firrtl.transforms.ReplaceTruncatingArithmetic],
+    classOf[firrtl.transforms.FlattenRegUpdate],
+    classOf[passes.VerilogModulusCleanup],
+    classOf[firrtl.transforms.VerilogRename],
+    classOf[passes.VerilogPrep],
+    classOf[firrtl.AddDescriptionNodes] )
 
   val options = Seq(
     new ShellOption[Unit](

--- a/src/main/scala/firrtl/transforms/Dedup.scala
+++ b/src/main/scala/firrtl/transforms/Dedup.scala
@@ -9,7 +9,7 @@ import firrtl.analyses.InstanceGraph
 import firrtl.annotations._
 import firrtl.passes.{InferTypes, MemPortUtils}
 import firrtl.Utils.throwInternalError
-import firrtl.options.{HasShellOptions, ShellOption}
+import firrtl.options.{HasShellOptions, PreservesAll, ShellOption}
 
 // Datastructures
 import scala.collection.mutable
@@ -39,9 +39,13 @@ case object NoCircuitDedupAnnotation extends NoTargetAnnotation with HasShellOpt
   * Specifically, the restriction of instance loops must have been checked, or else this pass can
   *  infinitely recurse
   */
-class DedupModules extends Transform {
+class DedupModules extends Transform with PreservesAll[Transform] {
   def inputForm: CircuitForm = HighForm
   def outputForm: CircuitForm = HighForm
+
+  override val prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.Resolved
+
+  override val dependents: Seq[Class[Transform]] = Seq.empty
 
   /** Deduplicate a Circuit
     * @param state Input Firrtl AST
@@ -85,7 +89,7 @@ class DedupModules extends Transform {
       }
     )
 
-    (InferTypes.run(c.copy(modules = dedupedModules)), renameMap)
+    ((new InferTypes).run(c.copy(modules = dedupedModules)), renameMap)
   }
 }
 

--- a/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
+++ b/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
@@ -108,6 +108,17 @@ class FlattenRegUpdate extends Transform {
   def inputForm = MidForm
   def outputForm = MidForm
 
+  override def prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.LowFormMinimumOptimized ++
+    Seq[Class[Transform]]( classOf[BlackBoxSourceHelper],
+                           classOf[ReplaceTruncatingArithmetic] )
+
+  override def dependents: Seq[Class[Transform]] = Seq.empty
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case _: DeadCodeElimination => true
+    case _ => false
+  }
+
   def execute(state: CircuitState): CircuitState = {
     val modulesx = state.circuit.modules.map {
       case mod: Module => FlattenRegUpdate.flattenReg(mod)

--- a/src/main/scala/firrtl/transforms/GroupComponents.scala
+++ b/src/main/scala/firrtl/transforms/GroupComponents.scala
@@ -61,7 +61,8 @@ class GroupComponents extends firrtl.Transform {
       case other => Seq(other)
     }
     val cs = state.copy(circuit = state.circuit.copy(modules = newModules))
-    val csx = ResolveKinds.execute(InferTypes.execute(cs))
+    /* @todo move ResolveKinds and InferTypes out */
+    val csx = (new ResolveKinds).execute((new InferTypes).execute(cs))
     csx
   }
 

--- a/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
+++ b/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
@@ -232,4 +232,14 @@ class RemoveKeywordCollisions(keywords: Set[String]) extends Transform {
 }
 
 /** Transform that removes collisions with Verilog keywords */
-class VerilogRename extends RemoveKeywordCollisions(v_keywords)
+class VerilogRename extends RemoveKeywordCollisions(v_keywords) {
+
+  override def prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.LowFormMinimumOptimized ++
+    Seq[Class[Transform]]( classOf[BlackBoxSourceHelper],
+                           classOf[ReplaceTruncatingArithmetic],
+                           classOf[FlattenRegUpdate],
+                           classOf[passes.VerilogModulusCleanup] )
+
+  override def dependents: Seq[Class[Transform]] = Seq.empty
+
+}

--- a/src/main/scala/firrtl/transforms/RemoveReset.scala
+++ b/src/main/scala/firrtl/transforms/RemoveReset.scala
@@ -5,6 +5,7 @@ package transforms
 
 import firrtl.ir._
 import firrtl.Mappers._
+import firrtl.options.PreservesAll
 
 import scala.collection.mutable
 
@@ -12,9 +13,13 @@ import scala.collection.mutable
   *
   * @note This pass must run after LowerTypes
   */
-class RemoveReset extends Transform {
-  def inputForm = MidForm
-  def outputForm = MidForm
+class RemoveReset extends Transform with PreservesAll[Transform] {
+  def inputForm = LowForm
+  def outputForm = LowForm
+
+  override val prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.MidForm ++
+    Seq[Class[Transform]]( classOf[passes.LowerTypes],
+                           classOf[passes.Legalize] )
 
   private case class Reset(cond: Expression, value: Expression)
 
@@ -41,4 +46,10 @@ class RemoveReset extends Transform {
     val c = state.circuit.map(onModule)
     state.copy(circuit = c)
   }
+}
+
+object RemoveReset extends Transform with DeprecatedTransformObject {
+
+  override protected lazy val underlying = new RemoveReset
+
 }

--- a/src/main/scala/firrtl/transforms/RemoveWires.scala
+++ b/src/main/scala/firrtl/transforms/RemoveWires.scala
@@ -9,6 +9,7 @@ import firrtl.Mappers._
 import firrtl.traversals.Foreachers._
 import firrtl.WrappedExpression._
 import firrtl.graph.{MutableDiGraph, CyclicException}
+import firrtl.options.PreservesAll
 
 import scala.collection.mutable
 import scala.util.{Try, Success, Failure}
@@ -19,9 +20,15 @@ import scala.util.{Try, Success, Failure}
   *  wires have multiple connections that may be impossible to order in a
   *  flow-foward way
   */
-class RemoveWires extends Transform {
+class RemoveWires extends Transform with PreservesAll[Transform] {
   def inputForm = LowForm
   def outputForm = LowForm
+
+  override val prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.MidForm ++
+    Seq[Class[Transform]]( classOf[passes.LowerTypes],
+                           classOf[passes.Legalize],
+                           classOf[transforms.RemoveReset],
+                           classOf[transforms.CheckCombLoops] )
 
   // Extract all expressions that are references to a Node, Wire, or Reg
   // Since we are operating on LowForm, they can only be WRefs
@@ -140,8 +147,9 @@ class RemoveWires extends Transform {
     }
   }
 
+  /* @todo move ResolveKinds outside */
   private val cleanup = Seq(
-    passes.ResolveKinds
+    new passes.ResolveKinds
   )
 
   def execute(state: CircuitState): CircuitState = {

--- a/src/main/scala/firrtl/transforms/ReplaceTruncatingArithmetic.scala
+++ b/src/main/scala/firrtl/transforms/ReplaceTruncatingArithmetic.scala
@@ -66,6 +66,11 @@ class ReplaceTruncatingArithmetic extends Transform {
   def inputForm = LowForm
   def outputForm = LowForm
 
+  override def prerequisites: Seq[Class[Transform]] = firrtl.stage.Forms.LowFormMinimumOptimized ++
+    Seq[Class[Transform]]( classOf[BlackBoxSourceHelper] )
+
+  override def dependents: Seq[Class[Transform]] = Seq.empty
+
   def execute(state: CircuitState): CircuitState = {
     val modulesx = state.circuit.modules.map(ReplaceTruncatingArithmetic.onMod(_))
     state.copy(circuit = state.circuit.copy(modules = modulesx))

--- a/src/main/scala/firrtl/transforms/TopWiring.scala
+++ b/src/main/scala/firrtl/transforms/TopWiring.scala
@@ -226,9 +226,9 @@ class TopWiringTransform extends Transform {
   /** Run passes to fix up the circuit of making the new connections  */
   private def fixupCircuit(circuit: Circuit): Circuit = {
     val passes = Seq(
-      InferTypes,
-      ResolveKinds,
-      ResolveGenders
+      new InferTypes,
+      new ResolveKinds,
+      new ResolveGenders
     )
     passes.foldLeft(circuit) { case (c: Circuit, p: Pass) => p.run(c) }
   }

--- a/src/test/scala/firrtlTests/AnnotationTests.scala
+++ b/src/test/scala/firrtlTests/AnnotationTests.scala
@@ -629,7 +629,7 @@ class JsonAnnotationTests extends AnnotationTests with BackendCompilationUtiliti
     override def inputForm: CircuitForm = UnknownForm
     override def outputForm: CircuitForm = UnknownForm
 
-    protected def execute(state: CircuitState): CircuitState = state
+    def execute(state: CircuitState): CircuitState = state
   }
 
   "annotation order" should "should be preserved" in {

--- a/src/test/scala/firrtlTests/CInferMDirSpec.scala
+++ b/src/test/scala/firrtlTests/CInferMDirSpec.scala
@@ -8,7 +8,7 @@ import firrtl.passes._
 import firrtl.transforms._
 import annotations._
 
-class CInferMDir extends LowTransformSpec {
+class CInferMDirSpec extends LowTransformSpec {
   object CInferMDirCheckPass extends Pass {
     // finds the memory and check its read port
     def checkStmt(s: Statement): Boolean = s match {

--- a/src/test/scala/firrtlTests/ChirrtlSpec.scala
+++ b/src/test/scala/firrtlTests/ChirrtlSpec.scala
@@ -12,10 +12,10 @@ import firrtl._
 
 class ChirrtlSpec extends FirrtlFlatSpec {
   def transforms = Seq(
-    CheckChirrtl,
-    CInferTypes,
-    CInferMDir,
-    RemoveCHIRRTL,
+    new CheckChirrtl,
+    new CInferTypes,
+    new CInferMDir,
+    new RemoveCHIRRTL,
     ToWorkingIR,
     CheckHighForm,
     ResolveKinds,
@@ -76,7 +76,7 @@ class ChirrtlSpec extends FirrtlFlatSpec {
   for ((description, input) <- CheckSpec.nonUniqueExamples) {
     it should s"be asserted for $description" in {
       assertThrows[CheckChirrtl.NotUniqueException] {
-        Seq(ToWorkingIR, CheckChirrtl).foldLeft(Parser.parse(input)){ case (c, tx) => tx.run(c) }
+        Seq(ToWorkingIR, new CheckChirrtl).foldLeft(Parser.parse(input)){ case (c, tx) => tx.run(c) }
       }
     }
   }

--- a/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
+++ b/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
@@ -1,0 +1,286 @@
+// See LICENSE for license details.
+
+package firrtlTests
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import firrtl.{ChirrtlToHighFirrtl, CircuitForm, CircuitState, HighFirrtlToMiddleFirrtl, IRToWorkingIR,
+  LowFirrtlOptimization, MiddleFirrtlToLowFirrtl, MinimumLowFirrtlOptimization, ResolveAndCheck, Transform}
+import firrtl.passes
+import firrtl.stage.{Forms, TransformManager}
+import firrtl.transforms.IdentityTransform
+
+object Orderings {
+  val ChirrtlToHighFirrtl = Seq(
+    classOf[passes.CheckChirrtl],
+    classOf[passes.CInferTypes],
+    classOf[passes.CInferMDir],
+    classOf[passes.RemoveCHIRRTL] )
+  val ResolveAndCheck = Seq(
+    classOf[passes.CheckHighForm],
+    classOf[passes.ResolveKinds],
+    classOf[passes.InferTypes],
+    classOf[passes.CheckTypes],
+    classOf[passes.Uniquify],
+    classOf[passes.ResolveKinds],
+    classOf[passes.InferTypes],
+    classOf[passes.ResolveGenders],
+    classOf[passes.CheckGenders],
+    classOf[passes.InferWidths],
+    classOf[passes.CheckWidths] )
+  val HighFirrtlToMiddleFirrtl = Seq(
+    classOf[passes.PullMuxes],
+    classOf[passes.ReplaceAccesses],
+    classOf[passes.ExpandConnects],
+    classOf[passes.RemoveAccesses],
+    classOf[passes.Uniquify],
+    classOf[passes.ResolveKinds],
+    classOf[passes.InferTypes],
+    classOf[passes.ExpandWhensAndCheck],
+    classOf[passes.ResolveKinds],
+    classOf[passes.InferTypes],
+    classOf[passes.ResolveGenders],
+    classOf[passes.InferWidths],
+    classOf[passes.ConvertFixedToSInt],
+    classOf[passes.ZeroWidth],
+    classOf[passes.InferTypes] )
+  val MiddleFirrtlToLowFirrtl = Seq(
+    classOf[passes.LowerTypes],
+    classOf[passes.ResolveKinds],
+    classOf[passes.InferTypes],
+    classOf[passes.ResolveGenders],
+    classOf[passes.InferWidths],
+    classOf[passes.Legalize],
+    classOf[firrtl.transforms.RemoveReset],
+    classOf[firrtl.transforms.CheckCombLoops],
+    classOf[firrtl.transforms.RemoveWires] )
+  val MinimumLowFirrtlOptimization = Seq(
+    classOf[passes.RemoveValidIf],
+    classOf[passes.Legalize],
+    classOf[passes.memlib.VerilogMemDelays],
+    classOf[passes.SplitExpressions] )
+  val LowFirrtlOptimization = Seq(
+    classOf[passes.RemoveValidIf],
+    classOf[passes.Legalize],
+    classOf[firrtl.transforms.ConstantPropagation],
+    classOf[passes.PadWidths],
+    classOf[passes.Legalize],
+    classOf[firrtl.transforms.ConstantPropagation],
+    classOf[passes.memlib.VerilogMemDelays],
+    classOf[firrtl.transforms.ConstantPropagation],
+    classOf[passes.SplitExpressions],
+    classOf[firrtl.transforms.CombineCats],
+    classOf[passes.CommonSubexpressionElimination],
+    classOf[firrtl.transforms.DeadCodeElimination] )
+  val VerilogMinimumOptimized = Seq(
+    classOf[firrtl.transforms.BlackBoxSourceHelper],
+    classOf[firrtl.transforms.ReplaceTruncatingArithmetic],
+    classOf[firrtl.transforms.FlattenRegUpdate],
+    classOf[passes.VerilogModulusCleanup],
+    classOf[firrtl.transforms.VerilogRename],
+    classOf[passes.VerilogPrep],
+    classOf[firrtl.AddDescriptionNodes] )
+  val VerilogOptimized = Seq(
+    classOf[firrtl.transforms.BlackBoxSourceHelper],
+    classOf[firrtl.transforms.ReplaceTruncatingArithmetic],
+    classOf[firrtl.transforms.FlattenRegUpdate],
+    classOf[firrtl.transforms.DeadCodeElimination],
+    classOf[passes.VerilogModulusCleanup],
+    classOf[firrtl.transforms.VerilogRename],
+    classOf[passes.VerilogPrep],
+    classOf[firrtl.AddDescriptionNodes] )
+}
+
+object Transforms {
+  class IdentityTransformDiff(val inputForm: CircuitForm, val outputForm: CircuitForm) extends Transform {
+    override def execute(state: CircuitState): CircuitState = state
+  }
+  class HighToHigh extends IdentityTransform(firrtl.HighForm)
+  class MidToMid extends IdentityTransform(firrtl.MidForm)
+  class MidToHigh extends IdentityTransformDiff(firrtl.MidForm, firrtl.HighForm)
+  class LowToLow extends IdentityTransform(firrtl.LowForm)
+  class LowToMid extends IdentityTransformDiff(firrtl.LowForm, firrtl.MidForm)
+  class LowToHigh extends IdentityTransformDiff(firrtl.LowForm, firrtl.HighForm)
+}
+
+class LoweringCompilersSpec extends FlatSpec with Matchers {
+
+  behavior of "ChirrtlToHighFirrtl"
+
+  it should "replicate the old order" in {
+    (new ChirrtlToHighFirrtl)
+      .transforms
+      .map(_.getClass.asInstanceOf[Class[Transform]]) should be (Orderings.ChirrtlToHighFirrtl)
+  }
+
+  behavior of "IRToWorkingIR"
+
+  it should "replicate the old order" in {
+    (new IRToWorkingIR)
+      .transforms
+      .map(_.getClass.asInstanceOf[Class[Transform]]) should be (Seq(classOf[passes.ToWorkingIR]))
+  }
+
+  behavior of "ResolveAndCheck"
+
+  it should "replicate the old order" in {
+    (new ResolveAndCheck)
+      .transforms
+      .map(_.getClass.asInstanceOf[Class[Transform]]) should be (Orderings.ResolveAndCheck)
+  }
+
+  behavior of "HighFirrtlToMiddleFirrtl"
+
+  it should "replicate the old order" in {
+    (new HighFirrtlToMiddleFirrtl)
+      .transforms
+      .map(_.getClass.asInstanceOf[Class[Transform]]) should be (Orderings.HighFirrtlToMiddleFirrtl)
+  }
+
+  behavior of "MiddleFirrtlToLowFirrtl"
+
+  it should "replicate the old order" in {
+    (new MiddleFirrtlToLowFirrtl)
+      .transforms
+      .map(_.getClass.asInstanceOf[Class[Transform]]) should be (Orderings.MiddleFirrtlToLowFirrtl)
+  }
+
+  behavior of "MinimumLowFirrtlOptimization"
+
+  it should "replicate the old order" in {
+    (new MinimumLowFirrtlOptimization)
+      .transforms
+      .map(_.getClass.asInstanceOf[Class[Transform]]) should be (Orderings.MinimumLowFirrtlOptimization)
+  }
+
+  behavior of "LowFirrtlOptimization"
+
+  it should "replicate the old order" in {
+    (new LowFirrtlOptimization)
+      .transforms
+      .map(_.getClass.asInstanceOf[Class[Transform]]) should be (Orderings.LowFirrtlOptimization)
+  }
+
+  behavior of "VerilogMinimumOptimized"
+
+  it should "replicate the old order" in {
+    (new TransformManager(Forms.VerilogMinimumOptimized, Forms.LowFormMinimumOptimized))
+      .flattenedTransformOrder
+      .map(_.getClass.asInstanceOf[Class[Transform]]) should be (Orderings.VerilogMinimumOptimized)
+  }
+
+  behavior of "VerilogOptimized"
+
+  it should "replicate the old order" in {
+    (new TransformManager(Forms.VerilogOptimized, Forms.LowFormOptimized))
+      .flattenedTransformOrder
+      .map(_.getClass.asInstanceOf[Class[Transform]]) should be (Orderings.VerilogOptimized)
+  }
+
+  behavior of "Chirrtl to Verilog"
+
+  it should "replicate the old order" in {
+    val oldOrder =
+      Orderings.ChirrtlToHighFirrtl ++
+        Some(classOf[passes.ToWorkingIR]) ++
+        Orderings.ResolveAndCheck ++
+        Some(classOf[firrtl.transforms.DedupModules]) ++
+        Orderings.HighFirrtlToMiddleFirrtl ++
+        Orderings.MiddleFirrtlToLowFirrtl ++
+        Orderings.LowFirrtlOptimization ++
+        Some(classOf[firrtl.VerilogEmitter])
+    (new TransformManager(Seq(classOf[firrtl.VerilogEmitter]).asInstanceOf[Seq[Class[Transform]]], Forms.ChirrtlForm))
+      .flattenedTransformOrder.map(_.getClass.asInstanceOf[Class[Transform]]) should be (oldOrder)
+  }
+
+  behavior of "Legacy Custom Transforms"
+
+  it should "work for High -> High" in {
+    val expected = Orderings.ChirrtlToHighFirrtl ++
+      Some(classOf[Transforms.HighToHigh]) ++
+      Some(classOf[passes.ToWorkingIR]) ++
+      Orderings.ResolveAndCheck ++
+      Some(classOf[firrtl.transforms.DedupModules]) ++
+      Orderings.HighFirrtlToMiddleFirrtl
+    (new TransformManager(Forms.MidForm :+ classOf[Transforms.HighToHigh].asInstanceOf[Class[Transform]]))
+      .flattenedTransformOrder
+      .map(_.getClass.asInstanceOf[Class[Transform]]) should be (expected)
+  }
+
+  it should "work for Mid -> Mid" in {
+    val expected = Orderings.ChirrtlToHighFirrtl ++
+      Some(classOf[passes.ToWorkingIR]) ++
+      Orderings.ResolveAndCheck ++
+      Some(classOf[firrtl.transforms.DedupModules]) ++
+      Orderings.HighFirrtlToMiddleFirrtl ++
+      Some(classOf[Transforms.MidToMid]) ++
+      Orderings.MiddleFirrtlToLowFirrtl
+    (new TransformManager(Forms.LowForm :+ classOf[Transforms.MidToMid].asInstanceOf[Class[Transform]]))
+      .flattenedTransformOrder
+      .map(_.getClass.asInstanceOf[Class[Transform]]) should be (expected)
+  }
+  it should "work for Mid -> High" in {
+    val expected = Orderings.ChirrtlToHighFirrtl ++
+      Some(classOf[passes.ToWorkingIR]) ++
+      Orderings.ResolveAndCheck ++
+      Some(classOf[firrtl.transforms.DedupModules]) ++
+      Orderings.HighFirrtlToMiddleFirrtl ++
+      Some(classOf[Transforms.MidToHigh]) ++
+      Some(classOf[passes.ToWorkingIR]) ++
+      Orderings.ResolveAndCheck ++
+      Some(classOf[firrtl.transforms.DedupModules]) ++
+      Orderings.HighFirrtlToMiddleFirrtl ++
+      Orderings.MiddleFirrtlToLowFirrtl
+    (new TransformManager(Forms.LowForm :+ classOf[Transforms.MidToHigh].asInstanceOf[Class[Transform]]))
+      .flattenedTransformOrder
+      .map(_.getClass.asInstanceOf[Class[Transform]]) should be (expected)
+  }
+
+  it should "work for Low -> Low" in {
+    val expected = Orderings.ChirrtlToHighFirrtl ++
+      Some(classOf[passes.ToWorkingIR]) ++
+      Orderings.ResolveAndCheck ++
+      Some(classOf[firrtl.transforms.DedupModules]) ++
+      Orderings.HighFirrtlToMiddleFirrtl ++
+      Orderings.MiddleFirrtlToLowFirrtl ++
+      Some(classOf[Transforms.LowToLow]) ++
+      Orderings.LowFirrtlOptimization
+    (new TransformManager(Forms.LowFormOptimized :+ classOf[Transforms.LowToLow].asInstanceOf[Class[Transform]]))
+      .flattenedTransformOrder
+      .map(_.getClass.asInstanceOf[Class[Transform]]) should be (expected)
+  }
+
+  it should "work for Low -> Mid" in {
+    val expected = Orderings.ChirrtlToHighFirrtl ++
+      Some(classOf[passes.ToWorkingIR]) ++
+      Orderings.ResolveAndCheck ++
+      Some(classOf[firrtl.transforms.DedupModules]) ++
+      Orderings.HighFirrtlToMiddleFirrtl ++
+      Orderings.MiddleFirrtlToLowFirrtl ++
+      Some(classOf[Transforms.LowToMid]) ++
+      Orderings.MiddleFirrtlToLowFirrtl ++
+      Orderings.LowFirrtlOptimization
+    (new TransformManager(Forms.LowFormOptimized :+ classOf[Transforms.LowToMid].asInstanceOf[Class[Transform]]))
+      .flattenedTransformOrder
+      .map(_.getClass.asInstanceOf[Class[Transform]]) should be (expected)
+  }
+
+  it should "work for Low -> High" in {
+    val expected = Orderings.ChirrtlToHighFirrtl ++
+      Some(classOf[passes.ToWorkingIR]) ++
+      Orderings.ResolveAndCheck ++
+      Some(classOf[firrtl.transforms.DedupModules]) ++
+      Orderings.HighFirrtlToMiddleFirrtl ++
+      Orderings.MiddleFirrtlToLowFirrtl ++
+      Some(classOf[Transforms.LowToHigh]) ++
+      Some(classOf[passes.ToWorkingIR]) ++
+      Orderings.ResolveAndCheck ++
+      Some(classOf[firrtl.transforms.DedupModules]) ++
+      Orderings.HighFirrtlToMiddleFirrtl ++
+      Orderings.MiddleFirrtlToLowFirrtl ++
+      Orderings.LowFirrtlOptimization
+    (new TransformManager(Forms.LowFormOptimized :+ classOf[Transforms.LowToHigh].asInstanceOf[Class[Transform]]))
+      .flattenedTransformOrder
+      .map(_.getClass.asInstanceOf[Class[Transform]]) should be (expected)
+  }
+}

--- a/src/test/scala/firrtlTests/fixed/RemoveFixedTypeSpec.scala
+++ b/src/test/scala/firrtlTests/fixed/RemoveFixedTypeSpec.scala
@@ -181,7 +181,7 @@ class RemoveFixedTypeSpec extends FirrtlFlatSpec {
     class CheckChirrtlTransform extends SeqTransform {
       def inputForm = ChirrtlForm
       def outputForm = ChirrtlForm
-      val transforms = Seq(passes.CheckChirrtl)
+      val transforms = Seq(new passes.CheckChirrtl)
     }
 
     val chirrtlTransform = new CheckChirrtlTransform
@@ -215,4 +215,3 @@ class RemoveFixedTypeSpec extends FirrtlFlatSpec {
     executeTest(input, check.split("\n") map normalized, passes)
   }
 }
-

--- a/src/test/scala/firrtlTests/stage/phases/CompilerSpec.scala
+++ b/src/test/scala/firrtlTests/stage/phases/CompilerSpec.scala
@@ -40,7 +40,7 @@ class CompilerSpec extends FlatSpec with Matchers {
 
     val expected = Seq(FirrtlCircuitAnnotation(circuitOut))
 
-    phase.transform(input).toSeq should be (expected)
+    phase.transform(input).collect{ case a: FirrtlCircuitAnnotation => a }.toSeq should be (expected)
   }
 
   it should "compile multiple FirrtlCircuitAnnotations" in new Fixture {

--- a/src/test/scala/firrtlTests/transforms/BlacklBoxSourceHelperSpec.scala
+++ b/src/test/scala/firrtlTests/transforms/BlacklBoxSourceHelperSpec.scala
@@ -101,11 +101,6 @@ class BlacklBoxSourceHelperTransformSpec extends LowTransformSpec {
     new java.io.File(s"test_run_dir/${BlackBoxSourceHelper.fileListName}").exists should be (true)
   }
 
-  "verilog compiler" should "have BlackBoxSourceHelper transform" in {
-    val verilogCompiler = new VerilogEmitter
-    verilogCompiler.transforms.map { x => x.getClass } should contain (classOf[BlackBoxSourceHelper])
-  }
-
   "verilog header files" should "be available but not mentioned in the file list" in {
     // Issue #917 - We don't want to list Verilog header files ("*.vh") in our file list.
     // We don't actually verify that the generated verilog code works,


### PR DESCRIPTION
This adds a Dependency API version of the FIRRTL compiler.

Roughly:

- Adds `TransformManager` for managing transforms (a `DependencyManager[Transform]`)
- Adds `firrtl.stage.transforms.Compiler` which replaces `firrtl.Compiler` and is, itself, a `Transform`
- Defines dependencies for all transforms and passes
- Adds compatibility logic for converting `inputForm`/`outputForm` to Dependency API
- New tests to ensure that the resulting transform orderings are sane