### PR TITLE
Remove deprecated ComponentName from CombinationalPath annotation

### DIFF
--- a/src/test/scala/firrtlTests/CheckCombLoopsSpec.scala
+++ b/src/test/scala/firrtlTests/CheckCombLoopsSpec.scala
@@ -298,10 +298,9 @@ class CheckCombLoopsSpec extends SimpleTransformSpec {
 
     val writer = new java.io.StringWriter
     val cs = compile(CircuitState(parse(input), ChirrtlForm), writer)
-    val mn = ModuleName("hasnoloops", CircuitName("hasnoloops"))
-    cs.annotations.collect {
-      case c @ CombinationalPath(ComponentName("b", `mn`), Seq(ComponentName("a", `mn`))) => c
-    }.nonEmpty should be (true)
+    val mt = ModuleTarget("hasnoloops", "hasnoloops")
+    val anno = CombinationalPath(mt.ref("b"), Seq(mt.ref("a")))
+    cs.annotations.contains(anno) should be (true)
   }
 }
 


### PR DESCRIPTION
Fixes #1103. I took the "directly change the annotation API" strategy, since a) there are already indirect deprecation warnings and b) it is used in limited places.

Has ucb-bar/chisel-testers2#45 as a related PR.