### PR TITLE
Remove shadow type parameter

### DIFF
--- a/src/main/scala/firrtl/Visitor.scala
+++ b/src/main/scala/firrtl/Visitor.scala
@@ -3,7 +3,7 @@
 package firrtl
 
 import org.antlr.v4.runtime.ParserRuleContext
-import org.antlr.v4.runtime.tree.TerminalNode
+import org.antlr.v4.runtime.tree.{AbstractParseTreeVisitor, ParseTreeVisitor, TerminalNode}
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import firrtl.antlr._
@@ -14,7 +14,7 @@ import firrtl.ir._
 import Utils.throwInternalError
 
 
-class Visitor(infoMode: InfoMode) extends FIRRTLBaseVisitor[FirrtlNode] {
+class Visitor(infoMode: InfoMode) extends AbstractParseTreeVisitor[FirrtlNode] with ParseTreeVisitor[FirrtlNode] {
   // Strip file path
   private def stripPath(filename: String) = filename.drop(filename.lastIndexOf("/") + 1)
 
@@ -24,7 +24,7 @@ class Visitor(infoMode: InfoMode) extends FIRRTLBaseVisitor[FirrtlNode] {
     id forall legalChars
   }
 
-  def visit[FirrtlNode](ctx: CircuitContext): Circuit = visitCircuit(ctx)
+  def visit(ctx: CircuitContext): Circuit = visitCircuit(ctx)
 
   //  These regex have to change if grammar changes
   private val HexPattern = """\"*h([+\-]?[a-zA-Z0-9]+)\"*""".r
@@ -64,10 +64,10 @@ class Visitor(infoMode: InfoMode) extends FIRRTLBaseVisitor[FirrtlNode] {
     }
   }
 
-  private def visitCircuit[FirrtlNode](ctx: CircuitContext): Circuit =
+  private def visitCircuit(ctx: CircuitContext): Circuit =
     Circuit(visitInfo(Option(ctx.info), ctx), ctx.module.asScala.map(visitModule), ctx.id.getText)
 
-  private def visitModule[FirrtlNode](ctx: ModuleContext): DefModule = {
+  private def visitModule(ctx: ModuleContext): DefModule = {
     val info = visitInfo(Option(ctx.info), ctx)
     ctx.getChild(0).getText match {
       case "module" => Module(info, ctx.id.getText, ctx.port.asScala.map(visitPort),
@@ -82,11 +82,11 @@ class Visitor(infoMode: InfoMode) extends FIRRTLBaseVisitor[FirrtlNode] {
     }
   }
 
-  private def visitPort[FirrtlNode](ctx: PortContext): Port = {
+  private def visitPort(ctx: PortContext): Port = {
     Port(visitInfo(Option(ctx.info), ctx), ctx.id.getText, visitDir(ctx.dir), visitType(ctx.`type`))
   }
 
-  private def visitParameter[FirrtlNode](ctx: ParameterContext): Param = {
+  private def visitParameter(ctx: ParameterContext): Param = {
     val name = ctx.id.getText
     (ctx.intLit, ctx.StringLit, ctx.DoubleLit, ctx.RawString) match {
       case (int, null, null, null) => IntParam(name, string2BigInt(int.getText))
@@ -97,13 +97,13 @@ class Visitor(infoMode: InfoMode) extends FIRRTLBaseVisitor[FirrtlNode] {
     }
   }
 
-  private def visitDir[FirrtlNode](ctx: DirContext): Direction =
+  private def visitDir(ctx: DirContext): Direction =
     ctx.getText match {
       case "input" => Input
       case "output" => Output
     }
 
-  private def visitMdir[FirrtlNode](ctx: MdirContext): MPortDir =
+  private def visitMdir(ctx: MdirContext): MPortDir =
     ctx.getText match {
       case "infer" => MInfer
       case "read" => MRead
@@ -112,7 +112,7 @@ class Visitor(infoMode: InfoMode) extends FIRRTLBaseVisitor[FirrtlNode] {
     }
 
   // Match on a type instead of on strings?
-  private def visitType[FirrtlNode](ctx: TypeContext): Type = {
+  private def visitType(ctx: TypeContext): Type = {
     def getWidth(n: IntLitContext): Width = IntWidth(string2BigInt(n.getText))
     ctx.getChild(0) match {
       case term: TerminalNode =>
@@ -152,20 +152,20 @@ class Visitor(infoMode: InfoMode) extends FIRRTLBaseVisitor[FirrtlNode] {
     }
   }
 
-  private def visitField[FirrtlNode](ctx: FieldContext): Field = {
+  private def visitField(ctx: FieldContext): Field = {
     val flip = if (ctx.getChild(0).getText == "flip") Flip else Default
     Field(ctx.fieldId.getText, flip, visitType(ctx.`type`))
   }
 
-  private def visitBlock[FirrtlNode](ctx: ModuleBlockContext): Statement =
+  private def visitBlock(ctx: ModuleBlockContext): Statement =
     Block(ctx.simple_stmt().asScala.flatMap(x => Option(x.stmt).map(visitStmt)))
 
-  private def visitSuite[FirrtlNode](ctx: SuiteContext): Statement =
+  private def visitSuite(ctx: SuiteContext): Statement =
     Block(ctx.simple_stmt().asScala.flatMap(x => Option(x.stmt).map(visitStmt)))
 
 
   // Memories are fairly complicated to translate thus have a dedicated method
-  private def visitMem[FirrtlNode](ctx: StmtContext): Statement = {
+  private def visitMem(ctx: StmtContext): Statement = {
     val readers = mutable.ArrayBuffer.empty[String]
     val writers = mutable.ArrayBuffer.empty[String]
     val readwriters = mutable.ArrayBuffer.empty[String]
@@ -222,12 +222,12 @@ class Visitor(infoMode: InfoMode) extends FIRRTLBaseVisitor[FirrtlNode] {
   }
 
   // visitStringLit
-  private def visitStringLit[FirrtlNode](node: TerminalNode): StringLit = {
+  private def visitStringLit(node: TerminalNode): StringLit = {
     val raw = node.getText.tail.init // Remove surrounding double quotes
     ir.StringLit.unescape(raw)
   }
 
-  private def visitWhen[FirrtlNode](ctx: WhenContext): Conditionally = {
+  private def visitWhen(ctx: WhenContext): Conditionally = {
     val info = visitInfo(Option(ctx.info(0)), ctx)
 
     val alt: Statement =
@@ -242,7 +242,7 @@ class Visitor(infoMode: InfoMode) extends FIRRTLBaseVisitor[FirrtlNode] {
   }
 
   // visitStmt
-  private def visitStmt[FirrtlNode](ctx: StmtContext): Statement = {
+  private def visitStmt(ctx: StmtContext): Statement = {
     val ctx_exp = ctx.exp.asScala
     val info = visitInfo(Option(ctx.info), ctx)
     ctx.getChild(0) match {
@@ -289,7 +289,7 @@ class Visitor(infoMode: InfoMode) extends FIRRTLBaseVisitor[FirrtlNode] {
     }
   }
 
-  private def visitExp[FirrtlNode](ctx: ExpContext): Expression = {
+  private def visitExp(ctx: ExpContext): Expression = {
     val ctx_exp = ctx.exp.asScala
     ctx.getChild(0) match {
       case _: IdContext => Reference(ctx.getText, UnknownType)
@@ -348,7 +348,7 @@ class Visitor(infoMode: InfoMode) extends FIRRTLBaseVisitor[FirrtlNode] {
 
   // stripSuffix("(") is included because in ANTLR concrete syntax we have to include open parentheses,
   //  see grammar file for more details
-  private def visitPrimop[FirrtlNode](ctx: PrimopContext): PrimOp = fromString(ctx.getText.stripSuffix("("))
+  private def visitPrimop(ctx: PrimopContext): PrimOp = fromString(ctx.getText.stripSuffix("("))
 
   // visit Id and Keyword?
 }


### PR DESCRIPTION
This is not a fatal bug but an improvement.  How do I found that is explaining as below:

### **1. type parameter shadows warning**

I add `"-Yrangepos" ` and `"-Xlint"` to scala compiler option, and then I got the warning message:

```
src/main/scala/firrtl/Visitor.scala:27:13: type parameter FirrtlNode defined in method visit shadows class FirrtlNode defined in package ir. You may want to rename your type parameter, or possibly remove it.
[warn]   def visit[FirrtlNode](ctx: CircuitContext): Circuit = visitCircuit(ctx)
```

I found this answer what **type parameter shadows** means https://stackoverflow.com/questions/41899478/understanding-type-parameters-in-scala

In short, 

```scala
class Container[T](val t: T) {
    def isValueEqual(obj: T): Boolean = t.equals(obj)
}
```

Here, the `T` in` obj: T` is the same type as the `T` defined in `Container[T]`. Now consider this example:

```scala
class Container[T](val t: T) {
    def isValueEqual[T](obj: T): Boolean = t.equals(obj)
}
```

Notice that I defined a new type parameter at the method level as well (`isValueEqual[T]`). In this case, the `T` defined in the method will shadow the `T` defined on the class level. **This means that they might not be the same type!** You could call it like this:

```scala
val c = new Container("Hello")
println(c.isValueEqual(5)) // 5 is not of type String!
```
So I remove all `[FirrtlNode]` type parameter from method. Then I got fatal errors.

```
src/main/scala/firrtl/Visitor.scala:67:15: overriding method visitCircuit in class FIRRTLBaseVisitor of type (ctx: firrtl.antlr.FIRRTLParser.CircuitContext)firrtl.ir.FirrtlNode;
[error]  method visitCircuit has weaker access privileges; it should not be private
[error]   private def visitCircuit(ctx: CircuitContext): Circuit =
```

### 2. Can't assign weaker privilege in subclass

This answer the **why can't we assign weaker privilege in subclass** https://stackoverflow.com/questions/17510152/why-cant-we-assign-weaker-privilege-in-subclass

Is the method type parameter to address this issues? If so, I don't think that is a good solution.

### 3. In-depth

In `FIRRTLBaseVisitor.java`  , it just implement all methods (which in `FIRRTLVisitor` interface) return defalut result of calling `visitChildren`, and specify all methods to `public` . So subclass of ` FIRRTLBaseVisitor` can't override method from `public` to `private`

```java
public class FIRRTLBaseVisitor<T> extends AbstractParseTreeVisitor<T> implements FIRRTLVisitor<T> {
        /**
         * <p>The default implementation returns the result of calling
         * {@link #visitChildren} on {@code ctx}.</p>
         */
        @Override public T visitCircuit(FIRRTLParser.CircuitContext ctx) { return visitChildren(ctx); }
```

Thus, can we directly extends `AbstractParseTreeVisitor` and `FIRRTLVisitor` ?

I have a try as below and it reports the same error.

```scala
import org.antlr.v4.runtime.tree.AbstractParseTreeVisitor

class Visitor(infoMode: InfoMode) extends AbstractParseTreeVisitor[FirrtlNode] with FIRRTLVisitor[FirrtlNode] 
```

Move a step to `FIRRTLVisitor.java` , it just defined the method name and parameter. so we can directly extends `ParseTreeVisitor` 

```java
public interface FIRRTLVisitor<T> extends ParseTreeVisitor<T> {
        T visitCircuit(FIRRTLParser.CircuitContext ctx);
```

I have a try as below and it works.

```scala
import org.antlr.v4.runtime.tree.{AbstractParseTreeVisitor, ParseTreeVisitor}

class Visitor(infoMode: InfoMode) extends AbstractParseTreeVisitor[FirrtlNode] with ParseTreeVisitor[FirrtlNode]
```

### 4. Conclusion

`FIRRTLBaseVisitor`  and `FIRRTLVisitor`  are just defined the methods‘ signature (name, parameter type and return type) and the default implement for every AST nodes. They specify all method to `public`. 

We already know a) what AST nodes should we visit, and b) not use the default implement in `FIRRTLBaseVisitor`. So we can skip `FIRRTLBaseVisitor`  and `FIRRTLVisitor`  and extend `AbstractParseTreeVisitor` and `ParseTreeVisitor` directly.
