### PR TITLE
Make sure directory exist before writing

### DIFF
--- a/src/test/scala/firrtlTests/stage/phases/AddCircuitSpec.scala
+++ b/src/test/scala/firrtlTests/stage/phases/AddCircuitSpec.scala
@@ -45,7 +45,9 @@ class AddCircuitSpec extends FlatSpec with Matchers {
   val (file, fileCircuit) = {
     val source = firrtlSource("foo")
     val fileName = "test_run_dir/AddCircuitSpec.fir"
-    val fw = new FileWriter(new File(fileName))
+    val srcFile = new File(fileName)
+    srcFile.getParentFile.mkdirs()
+    val fw = new FileWriter(srcFile)
     fw.write(source)
     fw.close()
     (fileName, Parser.parse(source))


### PR DESCRIPTION
If you run `AddCircuitSpec` test only before other testcases created the directory it needed (as below), it would throw `java.io.FileNotFoundException`.

https://github.com/freechipsproject/firrtl/blob/bdd6bf92e0a1a256856005f7acada3555cf28e79/src/test/scala/firrtlTests/stage/FirrtlMainSpec.scala#L120-L122

