### PR TITLE
README.md Patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ To write a Firrtl transform, please start with the tutorial here: [src/main/scal
 To run these examples:
 ```
 sbt assembly
-./utils/bin/firrtl -td regress -tn rocket --custom-transforms tutorial.lesson1.AnalyzeCircuit
-./utils/bin/firrtl -td regress -tn rocket --custom-transforms tutorial.lesson2.AnalyzeCircuit
+./utils/bin/firrtl -td regress -i regress/RocketCore.fir --custom-transforms tutorial.lesson1.AnalyzeCircuit
+./utils/bin/firrtl -td regress -i regress/RocketCore.fir --custom-transforms tutorial.lesson2.AnalyzeCircuit
 ```
 
 #### Other Tools

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ sbt assembly
 
 ##### Prerequisites
  1. If not already installed, install [verilator](http://www.veripool.org/projects/verilator/wiki/Installing) (Requires at least v3.886)
- 2. If not already installed, install [sbt](http://www.scala-sbt.org/) (Requires at least v0.13.6)
+ 1. If not already installed, install [yosys](http://www.clifford.at/yosys/) (Requires at least v0.8)
+ 1. If not already installed, install [sbt](http://www.scala-sbt.org/) (Requires at least v0.13.6)
 
 ##### Installation
  1. Clone the repository:


### PR DESCRIPTION
Fixes #1112 

This is a very narrow fix that:
- Adds Yosys v0.8 as a prerequisite (without this `sbt test` will fail)
- Fixes the custom transform example section to work with the Stage/Phase refactor

We likely need to go much further and refactor/rewrite the README (like with the surgery of [Chisel#1106](https://github.com/freechipsproject/chisel3/pull/1106)), but this fixes existing identified problems.