### PR TITLE
Move everything to Dependency API

### DIFF
--- a/src/main/scala/firrtl/AddDescriptionNodes.scala
+++ b/src/main/scala/firrtl/AddDescriptionNodes.scala
@@ -71,6 +71,16 @@ class AddDescriptionNodes extends Transform {
   def inputForm = LowForm
   def outputForm = LowForm
 
+  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
+    Seq( classOf[firrtl.transforms.BlackBoxSourceHelper],
+         classOf[firrtl.transforms.ReplaceTruncatingArithmetic],
+         classOf[firrtl.transforms.FlattenRegUpdate],
+         classOf[firrtl.passes.VerilogModulusCleanup],
+         classOf[firrtl.transforms.VerilogRename],
+         classOf[firrtl.passes.VerilogPrep] )
+
+  override val dependents = Seq.empty
+
   def onStmt(compMap: Map[String, Seq[String]])(stmt: Statement): Statement = {
     stmt.map(onStmt(compMap)) match {
       case d: IsDeclaration if compMap.contains(d.name) =>

--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -11,7 +11,8 @@ import firrtl.annotations._
 import firrtl.ir.Circuit
 import firrtl.Utils.throwInternalError
 import firrtl.annotations.transforms.{EliminateTargetPaths, ResolvePaths}
-import firrtl.options.{StageUtils, TransformLike}
+import firrtl.options.{DependencyAPI, StageUtils, TransformLike}
+import firrtl.stage.transforms.CatchCustomTransformExceptions
 
 /** Container of all annotations for a Firrtl compiler */
 class AnnotationSeq private (private[firrtl] val underlying: List[Annotation]) {
@@ -169,13 +170,20 @@ final case object UnknownForm extends CircuitForm(-1) {
 // scalastyle:on magic.number
 
 /** The basic unit of operating on a Firrtl AST */
-abstract class Transform extends TransformLike[CircuitState] {
+abstract class Transform extends TransformLike[CircuitState] with DependencyAPI[Transform] {
   /** A convenience function useful for debugging and error messages */
   def name: String = this.getClass.getSimpleName
+
   /** The [[firrtl.CircuitForm]] that this transform requires to operate on */
+  @deprecated(
+    "InputForm/OutputForm will be removed. Use DependencyAPI methods (prerequisites, dependents, invalidates)", "1.2")
   def inputForm: CircuitForm
+
   /** The [[firrtl.CircuitForm]] that this transform outputs */
+  @deprecated(
+    "InputForm/OutputForm will be removed. Use DependencyAPI methods (prerequisites, dependents, invalidates)", "1.2")
   def outputForm: CircuitForm
+
   /** Perform the transform, encode renaming with RenameMap, and can
     *   delete annotations
     * Called by [[runTransform]].
@@ -183,9 +191,29 @@ abstract class Transform extends TransformLike[CircuitState] {
     * @param state Input Firrtl AST
     * @return A transformed Firrtl AST
     */
-  protected def execute(state: CircuitState): CircuitState
+  def execute(state: CircuitState): CircuitState
 
   def transform(state: CircuitState): CircuitState = execute(state)
+
+  override def prerequisites = CompilerUtils.circuitFormToTransformSeq(inputForm).getOrElse(Seq.empty)
+
+  override def dependents = outputForm match {
+    case UnknownForm => Seq.empty
+    case _ =>
+      (new mutable.LinkedHashSet[Class[_ <: Transform]]() ++
+         CompilerUtils.circuitFormToEmitterSeq(inputForm) ++
+         firrtl.stage.Forms.VerilogOptimized --
+         CompilerUtils.circuitFormToTransformSeq(outputForm).getOrElse(Set.empty) --
+         prerequisites -
+         this.getClass)
+        .toSeq
+  }
+
+  override def invalidates(a: Transform): Boolean = {
+    val diff = CompilerUtils.circuitFormToTransformSeq(inputForm).getOrElse(Set.empty).toSet --
+      CompilerUtils.circuitFormToTransformSeq(outputForm).getOrElse(Seq.empty)
+    diff(a.getClass)
+  }
 
   /** Convenience method to get annotations relevant to this Transform
     *
@@ -275,6 +303,18 @@ abstract class Transform extends TransformLike[CircuitState] {
   }
 }
 
+private[firrtl] trait DeprecatedTransformObject { this: Transform =>
+
+  protected def underlying: Transform
+
+  @deprecated("Transform objects are now classes. Create an object or use the Dependency API", "1.2")
+  def execute(c: CircuitState): CircuitState = underlying.execute(c)
+
+  override def inputForm = underlying.inputForm
+  override def outputForm = underlying.outputForm
+
+}
+
 trait SeqTransformBased {
   def transforms: Seq[Transform]
   protected def runTransforms(state: CircuitState): CircuitState =
@@ -334,7 +374,7 @@ object CompilerUtils extends LazyLogging {
         case ChirrtlForm =>
           Seq(new ChirrtlToHighFirrtl) ++ getLoweringTransforms(HighForm, outputForm)
         case HighForm =>
-          Seq(new IRToWorkingIR, new ResolveAndCheck, new transforms.DedupModules,
+          Seq(new IRToWorkingIR, new ResolveAndCheck, new Dedup,
               new HighFirrtlToMiddleFirrtl) ++ getLoweringTransforms(MidForm, outputForm)
         case MidForm => Seq(new MiddleFirrtlToLowFirrtl) ++ getLoweringTransforms(LowForm, outputForm)
         case LowForm => throwInternalError("getLoweringTransforms - LowForm") // should be caught by if above
@@ -390,6 +430,30 @@ object CompilerUtils extends LazyLogging {
     }
   }
 
+  private[firrtl] def circuitFormToTransformSeq(a: CircuitForm): Option[Seq[Class[_ <: Transform]]] = a match {
+    case ChirrtlForm => Some(firrtl.stage.Forms.ChirrtlForm)
+    case HighForm    => Some(firrtl.stage.Forms.HighForm)
+    case MidForm     => Some(firrtl.stage.Forms.MidForm)
+    case LowForm     => Some(firrtl.stage.Forms.LowForm)
+    case UnknownForm => None
+  }
+
+  private[firrtl] def circuitFormToEmitterSeq(a: CircuitForm): Seq[Class[_ <: Transform]] = {
+    val lowEmitters = Seq( classOf[LowFirrtlEmitter],
+                           classOf[VerilogEmitter],
+                           classOf[MinimumVerilogEmitter],
+                           classOf[SystemVerilogEmitter] )
+    a match {
+      case ChirrtlForm => Seq( classOf[ChirrtlEmitter],
+                               classOf[HighFirrtlEmitter],
+                               classOf[MiddleFirrtlEmitter] ) ++ lowEmitters
+      case HighForm    => Seq( classOf[HighFirrtlEmitter],
+                               classOf[MiddleFirrtlEmitter] ) ++ lowEmitters
+      case MidForm     => lowEmitters :+ classOf[MiddleFirrtlEmitter]
+      case LowForm     => lowEmitters
+      case UnknownForm => Seq.empty
+    }
+  }
 }
 
 trait Compiler extends LazyLogging {
@@ -455,15 +519,6 @@ trait Compiler extends LazyLogging {
     compile(state.copy(annotations = emitAnno +: state.annotations), emitter +: customTransforms)
   }
 
-  private def isCustomTransform(xform: Transform): Boolean = {
-    def getTopPackage(pack: java.lang.Package): java.lang.Package =
-      Package.getPackage(pack.getName.split('.').head)
-    // We use the top package of the Driver to get the top firrtl package
-    Option(xform.getClass.getPackage).map { p =>
-      getTopPackage(p) != firrtl.Driver.getClass.getPackage
-    }.getOrElse(true)
-  }
-
   /** Perform compilation
     *
     * Emission will only be performed if [[EmitAnnotation]]s are present
@@ -482,7 +537,8 @@ trait Compiler extends LazyLogging {
           xform.runTransform(in)
         } catch {
           // Wrap exceptions from custom transforms so they are reported as such
-          case e: Exception if isCustomTransform(xform) => throw CustomTransformException(e)
+          case e: Exception if CatchCustomTransformExceptions.isCustomTransform(xform) =>
+            throw CustomTransformException(e)
         }
       }
     }

--- a/src/main/scala/firrtl/Driver.scala
+++ b/src/main/scala/firrtl/Driver.scala
@@ -13,7 +13,7 @@ import firrtl.transforms._
 import firrtl.Utils.throwInternalError
 import firrtl.stage.{FirrtlExecutionResultView, FirrtlStage}
 import firrtl.stage.phases.DriverCompatibility
-import firrtl.options.{StageUtils, Phase, Viewer}
+import firrtl.options.{Phase, PhaseManager, StageUtils, Viewer}
 import firrtl.options.phases.DeletedWrapper
 
 
@@ -211,13 +211,18 @@ object Driver {
 
     val annos = optionsManager.firrtlOptions.toAnnotations ++ optionsManager.commonOptions.toAnnotations
 
-    val phases: Seq[Phase] =
-      Seq( new DriverCompatibility.AddImplicitAnnotationFile,
-           new DriverCompatibility.AddImplicitFirrtlFile,
-           new DriverCompatibility.AddImplicitOutputFile,
-           new DriverCompatibility.AddImplicitEmitter,
-           new FirrtlStage )
+    val phases: Seq[Phase] = {
+      import DriverCompatibility._
+      new PhaseManager(
+        Seq( classOf[AddImplicitAnnotationFile],
+             classOf[AddImplicitFirrtlFile],
+             classOf[AddImplicitOutputFile],
+             classOf[AddImplicitEmitter],
+             classOf[FirrtlStage] )
+          .map(_.asInstanceOf[Class[Phase]]) )
+        .transformOrder
         .map(DeletedWrapper(_))
+    }
 
     val annosx = try {
       phases.foldLeft(annos)( (a, p) => p.transform(a) )

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -16,7 +16,7 @@ import firrtl.WrappedExpression._
 import Utils._
 import MemPortUtils.{memPortField, memType}
 import firrtl.options.{HasShellOptions, ShellOption, StageUtils, PhaseException}
-import firrtl.stage.RunFirrtlTransformAnnotation
+import firrtl.stage.{RunFirrtlTransformAnnotation, TransformManager}
 // Datastructures
 import scala.collection.mutable.ArrayBuffer
 
@@ -180,6 +180,11 @@ case class VRandom(width: BigInt) extends Expression {
 class VerilogEmitter extends SeqTransform with Emitter {
   def inputForm = LowForm
   def outputForm = LowForm
+
+  override val prerequisites = firrtl.stage.Forms.LowFormOptimized
+
+  override val dependents = Seq.empty
+
   val outputSuffix = ".v"
   val tab = "  "
   def AND(e1: WrappedExpression, e2: WrappedExpression): Expression = {
@@ -946,16 +951,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
     }
   }
 
-  /** Preamble for every emitted Verilog file */
-  def transforms = Seq(
-    new BlackBoxSourceHelper,
-    new ReplaceTruncatingArithmetic,
-    new FlattenRegUpdate,
-    new DeadCodeElimination,
-    passes.VerilogModulusCleanup,
-    new VerilogRename,
-    passes.VerilogPrep,
-    new AddDescriptionNodes)
+  def transforms = new TransformManager(firrtl.stage.Forms.VerilogOptimized, prerequisites).flattenedTransformOrder
 
   def emit(state: CircuitState, writer: Writer): Unit = {
     val circuit = runTransforms(state).circuit
@@ -1003,16 +999,18 @@ class VerilogEmitter extends SeqTransform with Emitter {
 
 class MinimumVerilogEmitter extends VerilogEmitter with Emitter {
 
+  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized
 
-  override def transforms = super.transforms.filter{
-    case _: DeadCodeElimination => false
-    case _ => true
-  }
+  override def transforms = new TransformManager(firrtl.stage.Forms.VerilogMinimumOptimized, prerequisites)
+    .flattenedTransformOrder
 
 }
 
 class SystemVerilogEmitter extends VerilogEmitter {
-  StageUtils.dramaticWarning("SystemVerilog Emitter is the same as the Verilog Emitter!")
-
   override val outputSuffix: String = ".sv"
+
+  override def execute(state: CircuitState): CircuitState = {
+    StageUtils.dramaticWarning("SystemVerilog Emitter is the same as the Verilog Emitter!")
+    super.execute(state)
+  }
 }

--- a/src/main/scala/firrtl/annotations/transforms/EliminateTargetPaths.scala
+++ b/src/main/scala/firrtl/annotations/transforms/EliminateTargetPaths.scala
@@ -131,7 +131,7 @@ class EliminateTargetPaths extends Transform {
     (cir.copy(modules = finalModuleList), renameMap)
   }
 
-  override protected def execute(state: CircuitState): CircuitState = {
+  override def execute(state: CircuitState): CircuitState = {
 
     val annotations = state.annotations.collect { case a: ResolvePaths => a }
 

--- a/src/main/scala/firrtl/options/StageAnnotations.scala
+++ b/src/main/scala/firrtl/options/StageAnnotations.scala
@@ -86,7 +86,7 @@ object OutputAnnotationFileAnnotation extends HasShellOptions {
 }
 
 /** If this [[firrtl.annotations.Annotation Annotation]] exists in an [[firrtl.AnnotationSeq AnnotationSeq]], then a
-  * [[firrtl.options.phase.WriteOutputAnnotations WriteOutputAnnotations]] will include
+  * [[firrtl.options.phases.WriteOutputAnnotations WriteOutputAnnotations]] will include
   * [[firrtl.annotations.DeletedAnnotation DeletedAnnotation]]s when it writes to a file.
   *  - set with '--write-deleted'
   */

--- a/src/main/scala/firrtl/passes/CheckChirrtl.scala
+++ b/src/main/scala/firrtl/passes/CheckChirrtl.scala
@@ -2,11 +2,14 @@
 
 package firrtl.passes
 
+import firrtl.Transform
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.traversals.Foreachers._
+import firrtl.options.PreservesAll
 
-object CheckChirrtl extends Pass {
+object CheckChirrtl extends Pass with DeprecatedPassObject {
+
   type NameSet = collection.mutable.HashSet[String]
 
   class NotUniqueException(info: Info, mname: String, name: String) extends PassException(
@@ -29,6 +32,19 @@ object CheckChirrtl extends Pass {
     s"$info: [module $mname] Memory size cannot be negative or zero.")
   class NoTopModuleException(info: Info, name: String) extends PassException(
     s"$info: A single module must be named $name.")
+
+  override protected lazy val underlying = new CheckChirrtl
+
+}
+
+class CheckChirrtl extends Pass with PreservesAll[Transform] {
+
+  import CheckChirrtl._
+
+  override val dependents = firrtl.stage.Forms.ChirrtlForm ++
+    Seq( classOf[CInferTypes],
+         classOf[CInferMDir],
+         classOf[RemoveCHIRRTL] )
 
   def run (c: Circuit): Circuit = {
     val errors = new Errors()
@@ -111,7 +127,7 @@ object CheckChirrtl extends Pass {
       m.foreach(checkChirrtlP(m.name, names))
       m.foreach(checkChirrtlS(m.info, m.name, names))
     }
-    
+
     c.modules.foreach(checkChirrtlM)
     c.modules count (_.name == c.main) match {
       case 1 =>

--- a/src/main/scala/firrtl/passes/CheckInitialization.scala
+++ b/src/main/scala/firrtl/passes/CheckInitialization.scala
@@ -6,6 +6,7 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.traversals.Foreachers._
+import firrtl.options.PreservesAll
 
 import annotation.tailrec
 
@@ -14,18 +15,18 @@ import annotation.tailrec
   * @note This pass looks for [[firrtl.WVoid]]s left behind by [[ExpandWhens]]
   * @note Assumes single connection (ie. no last connect semantics)
   */
-object CheckInitialization extends Pass {
-  private case class VoidExpr(stmt: Statement, voidDeps: Seq[Expression])
+class CheckInitialization extends Pass with PreservesAll[Transform] {
 
-  class RefNotInitializedException(info: Info, mname: String, name: String, trace: Seq[Statement]) extends PassException(
-      s"$info : [module $mname]  Reference $name is not fully initialized.\n" + 
-      trace.map(s => s"  ${get_info(s)} : ${s.serialize}").mkString("\n")
-    )
+  import CheckInitialization._
+
+  override val prerequisites = firrtl.stage.Forms.Resolved
+
+  private case class VoidExpr(stmt: Statement, voidDeps: Seq[Expression])
 
   private def getTrace(expr: WrappedExpression, voidExprs: Map[WrappedExpression, VoidExpr]): Seq[Statement] = {
     @tailrec
     def rec(e: WrappedExpression, map: Map[WrappedExpression, VoidExpr], trace: Seq[Statement]): Seq[Statement] = {
-      val voidExpr = map(e) 
+      val voidExpr = map(e)
       val newTrace = voidExpr.stmt +: trace
       if (voidExpr.voidDeps.nonEmpty) rec(voidExpr.voidDeps.head, map, newTrace) else newTrace
     }
@@ -88,4 +89,15 @@ object CheckInitialization extends Pass {
     errors.trigger()
     c
   }
+}
+
+object CheckInitialization extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new CheckInitialization
+
+  class RefNotInitializedException(info: Info, mname: String, name: String, trace: Seq[Statement]) extends PassException(
+      s"$info : [module $mname]  Reference $name is not fully initialized.\n" +
+      trace.map(s => s"  ${get_info(s)} : ${s.serialize}").mkString("\n")
+    )
+
 }

--- a/src/main/scala/firrtl/passes/ConvertFixedToSInt.scala
+++ b/src/main/scala/firrtl/passes/ConvertFixedToSInt.scala
@@ -8,10 +8,19 @@ import firrtl.ir._
 import firrtl._
 import firrtl.Mappers._
 import firrtl.Utils.{sub_type, module_type, field_type, max, throwInternalError}
+import firrtl.options.PreservesAll
 
 /** Replaces FixedType with SIntType, and correctly aligns all binary points
   */
-object ConvertFixedToSInt extends Pass {
+class ConvertFixedToSInt extends Pass with PreservesAll[Transform] {
+
+  override val prerequisites =
+    Seq( classOf[PullMuxes],
+         classOf[ReplaceAccesses],
+         classOf[ExpandConnects],
+         classOf[RemoveAccesses],
+         classOf[ExpandWhensAndCheck] ) ++ firrtl.stage.Forms.Deduped
+
   def alignArg(e: Expression, point: BigInt): Expression = e.tpe match {
     case FixedType(IntWidth(w), IntWidth(p)) => // assert(point >= p)
       if((point - p) > 0) {
@@ -83,29 +92,29 @@ object ConvertFixedToSInt extends Pass {
           types(name) = newType
           newStmt
         case WDefInstance(info, name, module, tpe) =>
-          val newType = moduleTypes(module) 
+          val newType = moduleTypes(module)
           types(name) = newType
           WDefInstance(info, name, module, newType)
-        case Connect(info, loc, exp) => 
+        case Connect(info, loc, exp) =>
           val point = calcPoint(Seq(loc))
           val newExp = alignArg(exp, point)
           Connect(info, loc, newExp) map updateExpType
-        case PartialConnect(info, loc, exp) => 
+        case PartialConnect(info, loc, exp) =>
           val point = calcPoint(Seq(loc))
           val newExp = alignArg(exp, point)
           PartialConnect(info, loc, newExp) map updateExpType
         // check Connect case, need to shl
         case s => (s map updateStmtType) map updateExpType
       }
- 
+
       m.ports.foreach(p => types(p.name) = p.tpe)
       m match {
         case Module(info, name, ports, body) => Module(info,name,ports,updateStmtType(body))
         case m:ExtModule => m
       }
     }
- 
-    val newModules = for(m <- c.modules) yield { 
+
+    val newModules = for(m <- c.modules) yield {
       val newPorts = m.ports.map(p => Port(p.info,p.name,p.direction,toSIntType(p.tpe)))
       m match {
          case Module(info, name, ports, body) => Module(info,name,newPorts,body)
@@ -113,8 +122,17 @@ object ConvertFixedToSInt extends Pass {
       }
     }
     newModules.foreach(m => moduleTypes(m.name) = module_type(m))
-    firrtl.passes.InferTypes.run(Circuit(c.info, newModules.map(onModule(_)), c.main ))
+
+    /* @todo This should be moved outside */
+    (new firrtl.passes.InferTypes).run(Circuit(c.info, newModules.map(onModule(_)), c.main ))
   }
 }
+
+object ConvertFixedToSInt extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new ConvertFixedToSInt
+
+}
+
 
 // vim: set ts=4 sw=4 et:

--- a/src/main/scala/firrtl/passes/ExpandWhens.scala
+++ b/src/main/scala/firrtl/passes/ExpandWhens.scala
@@ -8,6 +8,7 @@ import firrtl.Utils._
 import firrtl.Mappers._
 import firrtl.PrimOps._
 import firrtl.WrappedExpression._
+import firrtl.options.PreservesAll
 
 import annotation.tailrec
 import collection.mutable
@@ -23,7 +24,20 @@ import collection.mutable
   * @note Assumes bulk connects and isInvalids have been expanded
   * @note Assumes all references are declared
   */
-object ExpandWhens extends Pass {
+class ExpandWhens extends Pass with PreservesAll[Transform] {
+
+  override val prerequisites =
+    Seq( classOf[PullMuxes],
+         classOf[ReplaceAccesses],
+         classOf[ExpandConnects],
+         classOf[RemoveAccesses],
+         classOf[Uniquify] ) ++ firrtl.stage.Forms.Resolved
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case _: CheckInitialization | _: ResolveKinds | _: InferTypes => true
+    case _ => false
+  }
+
   /** Returns circuit with when and last connection semantics resolved */
   def run(c: Circuit): Circuit = {
     val modulesx = c.modules map {
@@ -286,4 +300,31 @@ object ExpandWhens extends Pass {
     DoPrim(And, Seq(e1, e2), Nil, BoolType)
   private def NOT(e: Expression) =
     DoPrim(Eq, Seq(e, zero), Nil, BoolType)
+}
+
+object ExpandWhens extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new ExpandWhens
+
+}
+
+class ExpandWhensAndCheck extends SeqTransform {
+
+  override val prerequisites =
+    Seq( classOf[PullMuxes],
+         classOf[ReplaceAccesses],
+         classOf[ExpandConnects],
+         classOf[RemoveAccesses],
+         classOf[Uniquify] ) ++ firrtl.stage.Forms.Deduped
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case _: ResolveKinds | _: InferTypes | _: ResolveGenders | _: InferWidths => true
+    case _ => false
+  }
+
+  override def inputForm = UnknownForm
+  override def outputForm = UnknownForm
+
+  override val transforms = Seq(new ExpandWhens, new CheckInitialization)
+
 }

--- a/src/main/scala/firrtl/passes/InferTypes.scala
+++ b/src/main/scala/firrtl/passes/InferTypes.scala
@@ -6,8 +6,14 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
+import firrtl.options.PreservesAll
 
-object InferTypes extends Pass {
+class InferTypes extends Pass with PreservesAll[Transform] {
+
+  override val prerequisites =
+    Seq( classOf[CheckHighForm],
+         classOf[ResolveKinds] ) ++ firrtl.stage.Forms.WorkingIR
+
   type TypeMap = collection.mutable.LinkedHashMap[String, Type]
 
   def run(c: Circuit): Circuit = {
@@ -69,12 +75,21 @@ object InferTypes extends Pass {
       val types = new TypeMap
       m map infer_types_p(types) map infer_types_s(types)
     }
- 
+
     c copy (modules = c.modules map infer_types)
   }
 }
 
-object CInferTypes extends Pass {
+object InferTypes extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new InferTypes
+
+}
+
+class CInferTypes extends Pass with PreservesAll[Transform] {
+
+  override val prerequisites = firrtl.stage.Forms.ChirrtlForm
+
   type TypeMap = collection.mutable.LinkedHashMap[String, Type]
 
   def run(c: Circuit): Circuit = {
@@ -123,12 +138,12 @@ object CInferTypes extends Pass {
       types(p.name) = p.tpe
       p
     }
- 
+
     def infer_types(m: DefModule): DefModule = {
       val types = new TypeMap
       m map infer_types_p(types) map infer_types_s(types)
     }
-   
+
     c copy (modules = c.modules map infer_types)
   }
 }

--- a/src/main/scala/firrtl/passes/InferWidths.scala
+++ b/src/main/scala/firrtl/passes/InferWidths.scala
@@ -11,6 +11,7 @@ import firrtl.annotations.{Annotation, ReferenceTarget}
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
+import firrtl.options.PreservesAll
 import firrtl.traversals.Foreachers._
 
 case class WidthGeqConstraintAnnotation(loc: ReferenceTarget, exp: ReferenceTarget) extends Annotation {
@@ -33,7 +34,15 @@ case class WidthGeqConstraintAnnotation(loc: ReferenceTarget, exp: ReferenceTarg
   }
 }
 
-class InferWidths extends Transform with ResolvedAnnotationPaths {
+class InferWidths extends Transform with ResolvedAnnotationPaths with PreservesAll[Transform] {
+
+  override val prerequisites =
+    Seq( classOf[passes.CheckHighForm],
+         classOf[passes.ResolveKinds],
+         classOf[passes.InferTypes],
+         classOf[passes.Uniquify],
+         classOf[passes.ResolveGenders] ) ++ firrtl.stage.Forms.WorkingIR
+
   def inputForm: CircuitForm = UnknownForm
   def outputForm: CircuitForm = UnknownForm
 
@@ -182,18 +191,18 @@ class InferWidths extends Transform with ResolvedAnnotationPaths {
       rec(w)
       has
     }
- 
+
     //; Forward solve
     //; Returns a solved list where each constraint undergoes:
     //;  1) Continuous Solving (using triangular solving)
     //;  2) Remove Cycles
     //;  3) Move to solved if not self-recursive
     val u = make_unique(l)
-    
+
     //println("======== UNIQUE CONSTRAINTS ========")
     //for (x <- u) { println(x) }
     //println("====================================")
- 
+
     val f = new ConstraintMap
     val o = ArrayBuffer[String]()
     for ((n, e) <- u) {
@@ -219,10 +228,10 @@ class InferWidths extends Transform with ResolvedAnnotationPaths {
         o += n
       }
     }
- 
+
     //println("Forward Solved Constraints")
     //for (x <- f) println(x)
- 
+
     //; Backwards Solve
     val b = new ConstraintMap
     for (i <- (o.size - 1) to 0 by -1) {
@@ -279,7 +288,7 @@ class InferWidths extends Transform with ResolvedAnnotationPaths {
     }
 
     def get_constraints_declared_type (t: Type): Type = t match {
-      case FixedType(_, p) => 
+      case FixedType(_, p) =>
         v += WGeq(p,IntWidth(0))
         t
       case _ => t map get_constraints_declared_type
@@ -315,7 +324,7 @@ class InferWidths extends Transform with ResolvedAnnotationPaths {
                get_constraints_t(UIntType(IntWidth(1)), s.reset.tpe))
            }
           v ++= get_constraints_t(s.tpe, s.init.tpe)
-        case (s:Conditionally) => v ++= 
+        case (s:Conditionally) => v ++=
            get_constraints_t(s.pred.tpe, UIntType(IntWidth(1))) ++
            get_constraints_t(UIntType(IntWidth(1)), s.pred.tpe)
         case Attach(_, exprs) =>
@@ -391,7 +400,8 @@ class InferWidths extends Transform with ResolvedAnnotationPaths {
       Port(p.info, p.name, p.direction, reduce_var_widths_t(p.tpe))
     }
 
-    InferTypes.run(c.copy(modules = c.modules map (_
+    /* @todo: This should be moved outside of [[InferWidths]] */
+    (new InferTypes).run(c.copy(modules = c.modules map (_
       map reduce_var_widths_p
       map reduce_var_widths_s)))
   }

--- a/src/main/scala/firrtl/passes/PadWidths.scala
+++ b/src/main/scala/firrtl/passes/PadWidths.scala
@@ -3,12 +3,28 @@
 package firrtl
 package passes
 
+import firrtl.{SystemVerilogEmitter, VerilogEmitter}
 import firrtl.ir._
 import firrtl.PrimOps._
 import firrtl.Mappers._
 
 // Makes all implicit width extensions and truncations explicit
-object PadWidths extends Pass {
+class PadWidths extends Pass {
+
+  override val prerequisites = firrtl.stage.Forms.LowForm ++
+    Seq( classOf[RemoveValidIf],
+         classOf[firrtl.transforms.ConstantPropagation] )
+
+  override val dependents =
+    Seq( classOf[firrtl.passes.memlib.VerilogMemDelays],
+         classOf[SystemVerilogEmitter],
+         classOf[VerilogEmitter] )
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case _: firrtl.transforms.ConstantPropagation | _: Legalize => true
+    case _ => false
+  }
+
   private def width(t: Type): Int = bitWidth(t).toInt
   private def width(e: Expression): Int = width(e.tpe)
   // Returns an expression with the correct integer width
@@ -59,4 +75,10 @@ object PadWidths extends Pass {
   }
 
   def run(c: Circuit): Circuit = c copy (modules = c.modules map (_ map onStmt))
+}
+
+object PadWidths extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new PadWidths
+
 }

--- a/src/main/scala/firrtl/passes/Passes.scala
+++ b/src/main/scala/firrtl/passes/Passes.scala
@@ -7,6 +7,7 @@ import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
 import firrtl.PrimOps._
+import firrtl.options.PreservesAll
 import firrtl.transforms.ConstantPropagation
 
 import scala.collection.mutable
@@ -30,6 +31,15 @@ trait Pass extends Transform {
   }
 }
 
+private[firrtl] trait DeprecatedPassObject { this: Pass =>
+
+  protected def underlying: Pass
+
+  @deprecated("Pass objects are now classes. Create an object or use the Dependency API", "1.2")
+  def run(c: Circuit): Circuit = underlying.run(c)
+
+}
+
 // Error handling
 class PassException(message: String) extends Exception(message)
 class PassExceptions(val exceptions: Seq[PassException]) extends Exception("\n" + exceptions.mkString("\n"))
@@ -45,8 +55,17 @@ class Errors {
   }
 }
 
+object ToWorkingIR extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new ToWorkingIR
+
+}
+
 // These should be distributed into separate files
-object ToWorkingIR extends Pass {
+class ToWorkingIR extends Pass with PreservesAll[Transform] {
+
+  override val prerequisites = firrtl.stage.Forms.HighForm
+
   def toExp(e: Expression): Expression = e map toExp match {
     case ex: Reference => WRef(ex.name, ex.tpe, UnknownKind, UNKNOWNGENDER)
     case ex: SubField => WSubField(ex.expr, ex.name, ex.tpe, UNKNOWNGENDER)
@@ -64,8 +83,17 @@ object ToWorkingIR extends Pass {
     c copy (modules = c.modules map (_ map toStmt))
 }
 
-object PullMuxes extends Pass {
-   def run(c: Circuit): Circuit = {
+object PullMuxes extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new PullMuxes
+
+}
+
+class PullMuxes extends Pass with PreservesAll[Transform] {
+
+  override val prerequisites = firrtl.stage.Forms.Deduped
+
+  def run(c: Circuit): Circuit = {
      def pull_muxes_e(e: Expression): Expression = e map pull_muxes_e match {
        case ex: WSubField => ex.expr match {
          case exx: Mux => Mux(exx.cond,
@@ -102,7 +130,12 @@ object PullMuxes extends Pass {
    }
 }
 
-object ExpandConnects extends Pass {
+class ExpandConnects extends Pass with PreservesAll[Transform] {
+
+  override val prerequisites =
+    Seq( classOf[PullMuxes],
+         classOf[ReplaceAccesses] ) ++ firrtl.stage.Forms.Deduped
+
   def run(c: Circuit): Circuit = {
     def expand_connects(m: Module): Module = {
       val genders = collection.mutable.LinkedHashMap[String,Gender]()
@@ -176,10 +209,19 @@ object ExpandConnects extends Pass {
   }
 }
 
+object ExpandConnects extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new ExpandConnects
+
+}
+
 
 // Replace shr by amount >= arg width with 0 for UInts and MSB for SInts
 // TODO replace UInt with zero-width wire instead
-object Legalize extends Pass {
+class Legalize extends Pass with PreservesAll[Transform] {
+
+  override val prerequisites = firrtl.stage.Forms.MidForm :+ classOf[LowerTypes]
+
   private def legalizeShiftRight(e: DoPrim): Expression = {
     require(e.op == Shr)
     e.args.head match {
@@ -250,6 +292,12 @@ object Legalize extends Pass {
   }
 }
 
+object Legalize extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new Legalize
+
+}
+
 /** Makes changes to the Firrtl AST to make Verilog emission easier
   *
   * - For each instance, adds wires to connect to each port
@@ -260,7 +308,14 @@ object Legalize extends Pass {
   *
   * @note The result of this pass is NOT legal Firrtl
   */
-object VerilogPrep extends Pass {
+class VerilogPrep extends Pass {
+
+  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
+    Seq( classOf[firrtl.transforms.BlackBoxSourceHelper],
+         classOf[firrtl.transforms.ReplaceTruncatingArithmetic],
+         classOf[firrtl.transforms.FlattenRegUpdate],
+         classOf[VerilogModulusCleanup],
+         classOf[firrtl.transforms.VerilogRename] )
 
   type AttachSourceMap = Map[WrappedExpression, Expression]
 
@@ -330,4 +385,10 @@ object VerilogPrep extends Pass {
     }
     c.copy(modules = modulesx)
   }
+}
+
+object VerilogPrep extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new VerilogPrep
+
 }

--- a/src/main/scala/firrtl/passes/RemoveAccesses.scala
+++ b/src/main/scala/firrtl/passes/RemoveAccesses.scala
@@ -2,18 +2,30 @@
 
 package firrtl.passes
 
-import firrtl.{WRef, WSubAccess, WSubIndex, WSubField, Namespace}
+import firrtl.{Namespace, Transform, WRef, WSubAccess, WSubIndex, WSubField}
 import firrtl.PrimOps.{And, Eq}
 import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.Utils._
 import firrtl.WrappedExpression._
+import firrtl.options.PreservesAll
 import scala.collection.mutable
 
 
 /** Removes all [[firrtl.WSubAccess]] from circuit
   */
 class RemoveAccesses extends Pass {
+
+  override val prerequisites =
+    Seq( classOf[PullMuxes],
+         classOf[ReplaceAccesses],
+         classOf[ExpandConnects] ) ++ firrtl.stage.Forms.Deduped
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case _: Uniquify => true
+    case _           => false
+  }
+
   private def AND(e1: Expression, e2: Expression) =
     if(e1 == one) e2
     else if(e2 == one) e1
@@ -159,7 +171,7 @@ class RemoveAccesses extends Pass {
       }
       Module(m.info, m.name, m.ports, squashEmpty(onStmt(m.body)))
     }
-  
+
     c copy (modules = c.modules map {
       case m: ExtModule => m
       case m: Module => remove_m(m)
@@ -167,13 +179,8 @@ class RemoveAccesses extends Pass {
   }
 }
 
-object RemoveAccesses extends Pass {
-  def apply: Pass = {
-    new RemoveAccesses()
-  }
+object RemoveAccesses extends Pass with DeprecatedPassObject {
 
-  def run(c: Circuit): Circuit = {
-    val t = new RemoveAccesses
-    t.run(c)
-  }
+  override protected lazy val underlying = new RemoveAccesses
+
 }

--- a/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
+++ b/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
@@ -8,12 +8,18 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
+import firrtl.options.PreservesAll
 
 case class MPort(name: String, clk: Expression)
 case class MPorts(readers: ArrayBuffer[MPort], writers: ArrayBuffer[MPort], readwriters: ArrayBuffer[MPort])
 case class DataRef(exp: Expression, male: String, female: String, mask: String, rdwrite: Boolean)
 
-object RemoveCHIRRTL extends Transform {
+class RemoveCHIRRTL extends Transform with PreservesAll[Transform] {
+
+  override val prerequisites = firrtl.stage.Forms.ChirrtlForm ++
+    Seq( classOf[passes.CInferTypes],
+         classOf[passes.CInferMDir] )
+
   def inputForm: CircuitForm = UnknownForm
   def outputForm: CircuitForm = UnknownForm
   val ut = UnknownType

--- a/src/main/scala/firrtl/passes/RemoveValidIf.scala
+++ b/src/main/scala/firrtl/passes/RemoveValidIf.scala
@@ -2,27 +2,24 @@
 
 package firrtl
 package passes
+
+import firrtl.{SystemVerilogEmitter, VerilogEmitter}
 import firrtl.Mappers._
 import firrtl.ir._
 import Utils.throwInternalError
 
 /** Remove [[firrtl.ir.ValidIf ValidIf]] and replace [[firrtl.ir.IsInvalid IsInvalid]] with a connection to zero */
-object RemoveValidIf extends Pass {
+class RemoveValidIf extends Pass {
 
-  val UIntZero = Utils.zero
-  val SIntZero = SIntLiteral(BigInt(0), IntWidth(1))
-  val ClockZero = DoPrim(PrimOps.AsClock, Seq(UIntZero), Seq.empty, ClockType)
-  val FixedZero = FixedLiteral(BigInt(0), IntWidth(1), IntWidth(0))
+  import RemoveValidIf._
 
-  /** Returns an [[firrtl.ir.Expression Expression]] equal to zero for a given [[firrtl.ir.GroundType GroundType]]
-    * @note Accepts [[firrtl.ir.Type Type]] but dyanmically expects [[firrtl.ir.GroundType GroundType]]
-    */
-  def getGroundZero(tpe: Type): Expression = tpe match {
-    case _: UIntType => UIntZero
-    case _: SIntType => SIntZero
-    case ClockType => ClockZero
-    case _: FixedType => FixedZero
-    case other => throwInternalError(s"Unexpected type $other")
+  override val prerequisites = firrtl.stage.Forms.LowForm
+
+  override val dependents = Seq(classOf[SystemVerilogEmitter], classOf[VerilogEmitter])
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case _: Legalize | _: firrtl.transforms.ConstantPropagation => true
+    case _ => false
   }
 
   // Recursive. Removes ValidIfs
@@ -50,4 +47,26 @@ object RemoveValidIf extends Pass {
   }
 
   def run(c: Circuit): Circuit = Circuit(c.info, c.modules.map(onModule), c.main)
+}
+
+object RemoveValidIf extends Pass with DeprecatedPassObject {
+
+  override lazy val underlying = new RemoveValidIf
+
+  val UIntZero = Utils.zero
+  val SIntZero = SIntLiteral(BigInt(0), IntWidth(1))
+  val ClockZero = DoPrim(PrimOps.AsClock, Seq(UIntZero), Seq.empty, ClockType)
+  val FixedZero = FixedLiteral(BigInt(0), IntWidth(1), IntWidth(0))
+
+  /** Returns an [[firrtl.ir.Expression Expression]] equal to zero for a given [[firrtl.ir.GroundType GroundType]]
+    * @note Accepts [[firrtl.ir.Type Type]] but dyanmically expects [[firrtl.ir.GroundType GroundType]]
+    */
+  def getGroundZero(tpe: Type): Expression = tpe match {
+    case _: UIntType => UIntZero
+    case _: SIntType => SIntZero
+    case ClockType => ClockZero
+    case _: FixedType => FixedZero
+    case other => throwInternalError(s"Unexpected type $other")
+  }
+
 }

--- a/src/main/scala/firrtl/passes/ReplaceAccesses.scala
+++ b/src/main/scala/firrtl/passes/ReplaceAccesses.scala
@@ -2,22 +2,32 @@
 
 package firrtl.passes
 
+import firrtl.Transform
 import firrtl.ir._
 import firrtl.{WSubAccess, WSubIndex}
 import firrtl.Mappers._
-
+import firrtl.options.PreservesAll
 
 /** Replaces constant [[firrtl.WSubAccess]] with [[firrtl.WSubIndex]]
   * TODO Fold in to High Firrtl Const Prop
   */
-object ReplaceAccesses extends Pass {
+class ReplaceAccesses extends Pass with PreservesAll[Transform] {
+
+  override val prerequisites = firrtl.stage.Forms.Deduped :+ classOf[PullMuxes]
+
   def run(c: Circuit): Circuit = {
     def onStmt(s: Statement): Statement = s map onStmt map onExp
     def onExp(e: Expression): Expression = e match {
       case WSubAccess(ex, UIntLiteral(value, width), t, g) => WSubIndex(onExp(ex), value.toInt, t, g)
       case _ => e map onExp
     }
-  
+
     c copy (modules = c.modules map (_ map onStmt))
   }
+}
+
+object ReplaceAccesses extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new ReplaceAccesses
+
 }

--- a/src/main/scala/firrtl/passes/SplitExpressions.scala
+++ b/src/main/scala/firrtl/passes/SplitExpressions.scala
@@ -3,7 +3,9 @@
 package firrtl
 package passes
 
+import firrtl.{SystemVerilogEmitter, VerilogEmitter}
 import firrtl.ir._
+import firrtl.options.PreservesAll
 import firrtl.Mappers._
 import firrtl.Utils.{kind, gender, get_info}
 
@@ -12,7 +14,14 @@ import scala.collection.mutable
 
 // Splits compound expressions into simple expressions
 //  and named intermediate nodes
-object SplitExpressions extends Pass {
+class SplitExpressions extends Pass with PreservesAll[Transform] {
+
+  override val prerequisites = firrtl.stage.Forms.LowForm ++
+    Seq( classOf[passes.RemoveValidIf],
+         classOf[firrtl.passes.memlib.VerilogMemDelays] )
+
+  override val dependents = Seq(classOf[SystemVerilogEmitter], classOf[VerilogEmitter])
+
    private def onModule(m: Module): Module = {
       val namespace = Namespace(m)
       def onStmt(s: Statement): Statement = {
@@ -62,4 +71,10 @@ object SplitExpressions extends Pass {
      }
      Circuit(c.info, modulesx, c.main)
    }
+}
+
+object SplitExpressions extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new SplitExpressions
+
 }

--- a/src/main/scala/firrtl/passes/Uniquify.scala
+++ b/src/main/scala/firrtl/passes/Uniquify.scala
@@ -8,8 +8,78 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
+import firrtl.options.PreservesAll
 import MemPortUtils.memType
 
+
+object Uniquify extends Transform with DeprecatedTransformObject {
+
+  override protected lazy val underlying = new Uniquify
+
+  /** Appends delim to prefix until no collisions of prefix + elts in names We don't add an _ in the collision check
+    * because elts could be Seq("") In this case, we're just really checking if prefix itself collides
+    */
+  @tailrec
+  def findValidPrefix(
+      prefix: String,
+      elts: Seq[String],
+      namespace: collection.mutable.HashSet[String]): String = {
+    elts find (elt => namespace.contains(prefix + elt)) match {
+      case Some(_) => findValidPrefix(prefix + "_", elts, namespace)
+      case None => prefix
+    }
+  }
+
+  /** Enumerates all possible names for a given type. For example:
+    * {{{
+    * foo : { bar : { a, b }[2], c }
+    *   => foo, foo bar, foo bar 0, foo bar 1, foo bar 0 a, foo bar 0 b, foo bar 1 a, foo bar 1 b, foo c
+    * }}}
+    */
+  private [firrtl] def enumerateNames(tpe: Type): Seq[Seq[String]] = tpe match {
+    case t: BundleType =>
+      t.fields flatMap { f =>
+        (enumerateNames(f.tpe) map (f.name +: _)) ++ Seq(Seq(f.name))
+      }
+    case t: VectorType =>
+      ((0 until t.size) map (i => Seq(i.toString))) ++
+      ((0 until t.size) flatMap { i =>
+        enumerateNames(t.tpe) map (i.toString +: _)
+      })
+    case _ => Seq()
+  }
+
+  /** Creates a Bundle Type from a Stmt */
+  def stmtToType(s: Statement)(implicit sinfo: Info, mname: String): BundleType = {
+    // Recursive helper
+    def recStmtToType(s: Statement): Seq[Field] = s match {
+      case sx: DefWire => Seq(Field(sx.name, Default, sx.tpe))
+      case sx: DefRegister => Seq(Field(sx.name, Default, sx.tpe))
+      case sx: WDefInstance => Seq(Field(sx.name, Default, sx.tpe))
+      case sx: DefMemory => sx.dataType match {
+        case (_: UIntType | _: SIntType | _: FixedType) =>
+          Seq(Field(sx.name, Default, memType(sx)))
+        case tpe: BundleType =>
+          val newFields = tpe.fields map ( f =>
+            DefMemory(sx.info, f.name, f.tpe, sx.depth, sx.writeLatency,
+              sx.readLatency, sx.readers, sx.writers, sx.readwriters)
+          ) flatMap recStmtToType
+          Seq(Field(sx.name, Default, BundleType(newFields)))
+        case tpe: VectorType =>
+          val newFields = (0 until tpe.size) map ( i =>
+            sx.copy(name = i.toString, dataType = tpe.tpe)
+          ) flatMap recStmtToType
+          Seq(Field(sx.name, Default, BundleType(newFields)))
+      }
+      case sx: DefNode => Seq(Field(sx.name, Default, sx.value.tpe))
+      case sx: Conditionally => recStmtToType(sx.conseq) ++ recStmtToType(sx.alt)
+      case sx: Block => (sx.stmts map recStmtToType).flatten
+      case sx => Seq()
+    }
+    BundleType(recStmtToType(s))
+  }
+
+}
 
 /** Resolve name collisions that would occur in [[LowerTypes]]
   *
@@ -31,7 +101,20 @@ import MemPortUtils.memType
   *      there WOULD be collisions in references a[0] and a_0 so we still have
   *      to rename a
   */
-object Uniquify extends Transform {
+class Uniquify extends Transform {
+
+  import Uniquify._
+
+  override val prerequisites =
+    Seq( classOf[CheckHighForm],
+         classOf[ResolveKinds],
+         classOf[InferTypes] ) ++ firrtl.stage.Forms.WorkingIR
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case _: ResolveKinds | _: InferTypes => true
+    case _ => false
+  }
+
   def inputForm = UnknownForm
   def outputForm = UnknownForm
   private case class UniquifyException(msg: String) extends FIRRTLException(msg)
@@ -40,37 +123,6 @@ object Uniquify extends Transform {
 
   // For creation of rename map
   private case class NameMapNode(name: String, elts: Map[String, NameMapNode])
-
-  // Appends delim to prefix until no collisions of prefix + elts in names
-  // We don't add an _ in the collision check because elts could be Seq("")
-  //   In this case, we're just really checking if prefix itself collides
-  @tailrec
-  def findValidPrefix(
-      prefix: String,
-      elts: Seq[String],
-      namespace: collection.mutable.HashSet[String]): String = {
-    elts find (elt => namespace.contains(prefix + elt)) match {
-      case Some(_) => findValidPrefix(prefix + "_", elts, namespace)
-      case None => prefix
-    }
-  }
-
-  // Enumerates all possible names for a given type
-  //   eg. foo : { bar : { a, b }[2], c }
-  //   => foo, foo bar, foo bar 0, foo bar 1, foo bar 0 a, foo bar 0 b,
-  //      foo bar 1 a, foo bar 1 b, foo c
-  private [firrtl] def enumerateNames(tpe: Type): Seq[Seq[String]] = tpe match {
-    case t: BundleType =>
-      t.fields flatMap { f =>
-        (enumerateNames(f.tpe) map (f.name +: _)) ++ Seq(Seq(f.name))
-      }
-    case t: VectorType =>
-      ((0 until t.size) map (i => Seq(i.toString))) ++
-      ((0 until t.size) flatMap { i =>
-        enumerateNames(t.tpe) map (i.toString +: _)
-      })
-    case _ => Seq()
-  }
 
   // Accepts a Type and an initial namespace
   // Returns new Type with uniquified names
@@ -202,36 +254,6 @@ object Uniquify extends Transform {
     case t => t
   }
 
-  // Creates a Bundle Type from a Stmt
-  def stmtToType(s: Statement)(implicit sinfo: Info, mname: String): BundleType = {
-    // Recursive helper
-    def recStmtToType(s: Statement): Seq[Field] = s match {
-      case sx: DefWire => Seq(Field(sx.name, Default, sx.tpe))
-      case sx: DefRegister => Seq(Field(sx.name, Default, sx.tpe))
-      case sx: WDefInstance => Seq(Field(sx.name, Default, sx.tpe))
-      case sx: DefMemory => sx.dataType match {
-        case (_: UIntType | _: SIntType | _: FixedType) =>
-          Seq(Field(sx.name, Default, memType(sx)))
-        case tpe: BundleType =>
-          val newFields = tpe.fields map ( f =>
-            DefMemory(sx.info, f.name, f.tpe, sx.depth, sx.writeLatency,
-              sx.readLatency, sx.readers, sx.writers, sx.readwriters)
-          ) flatMap recStmtToType
-          Seq(Field(sx.name, Default, BundleType(newFields)))
-        case tpe: VectorType =>
-          val newFields = (0 until tpe.size) map ( i =>
-            sx.copy(name = i.toString, dataType = tpe.tpe)
-          ) flatMap recStmtToType
-          Seq(Field(sx.name, Default, BundleType(newFields)))
-      }
-      case sx: DefNode => Seq(Field(sx.name, Default, sx.value.tpe))
-      case sx: Conditionally => recStmtToType(sx.conseq) ++ recStmtToType(sx.alt)
-      case sx: Block => (sx.stmts map recStmtToType).flatten
-      case sx => Seq()
-    }
-    BundleType(recStmtToType(s))
-  }
-
   // Everything wrapped in run so that it's thread safe
   def execute(state: CircuitState): CircuitState = {
     val c = state.circuit
@@ -265,7 +287,7 @@ object Uniquify extends Transform {
             if (nameMap.contains(sx.name)) {
               val node = nameMap(sx.name)
               val newType = uniquifyNamesType(sx.tpe, node.elts)
-              (Utils.create_exps(sx.name, sx.tpe) zip Utils.create_exps(node.name, newType)) foreach { 
+              (Utils.create_exps(sx.name, sx.tpe) zip Utils.create_exps(node.name, newType)) foreach {
                 case (from, to) => renames.rename(from.serialize, to.serialize)
               }
               DefWire(sx.info, node.name, newType)
@@ -382,4 +404,3 @@ object Uniquify extends Transform {
     CircuitState(result, outputForm, state.annotations, Some(renames))
   }
 }
-

--- a/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
+++ b/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
@@ -23,7 +23,12 @@ import scala.collection.mutable
  *  This is technically incorrect firrtl, but allows the verilog emitter
  *  to emit correct verilog without needing to add temporary nodes
  */
-object VerilogModulusCleanup extends Pass {
+class VerilogModulusCleanup extends Pass {
+
+  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
+    Seq( classOf[firrtl.transforms.BlackBoxSourceHelper],
+         classOf[firrtl.transforms.ReplaceTruncatingArithmetic],
+         classOf[firrtl.transforms.FlattenRegUpdate] )
 
   private def onModule(m: Module): Module = {
     val namespace = Namespace(m)
@@ -47,7 +52,7 @@ object VerilogModulusCleanup extends Pass {
 
       def removeRem(e: Expression): Expression = e match {
         case e: DoPrim => e.op match {
-          case Rem => 
+          case Rem =>
             val name = namespace.newTemp
             val newType = e mapType verilogRemWidth(e)
             v += DefNode(get_info(s), name, e mapType verilogRemWidth(e))
@@ -80,4 +85,10 @@ object VerilogModulusCleanup extends Pass {
     }
     Circuit(c.info, modules, c.main)
   }
+}
+
+object VerilogModulusCleanup extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new VerilogModulusCleanup
+
 }

--- a/src/main/scala/firrtl/passes/memlib/InferReadWrite.scala
+++ b/src/main/scala/firrtl/passes/memlib/InferReadWrite.scala
@@ -157,10 +157,10 @@ class InferReadWrite extends Transform with SeqTransformBased with HasShellOptio
 
   def transforms = Seq(
     InferReadWritePass,
-    CheckInitialization,
-    InferTypes,
-    ResolveKinds,
-    ResolveGenders
+    new CheckInitialization,
+    new InferTypes,
+    new ResolveKinds,
+    new ResolveGenders
   )
   def execute(state: CircuitState): CircuitState = {
     val runTransform = state.annotations.contains(InferReadWriteAnnotation)

--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
@@ -122,11 +122,11 @@ class ReplSeqMem extends Transform with HasShellOptions {
         new ReplaceMemMacros(outConfigFile),
         new WiringTransform,
         new SimpleMidTransform(RemoveEmpty),
-        new SimpleMidTransform(CheckInitialization),
-        new SimpleMidTransform(InferTypes),
-        Uniquify,
-        new SimpleMidTransform(ResolveKinds),
-        new SimpleMidTransform(ResolveGenders))
+        new SimpleMidTransform(new CheckInitialization),
+        new SimpleMidTransform(new InferTypes),
+        new Uniquify,
+        new SimpleMidTransform(new ResolveKinds),
+        new SimpleMidTransform(new ResolveGenders))
 
   def execute(state: CircuitState): CircuitState = {
     val annos = state.annotations.collect { case a: ReplSeqMemAnnotation => a }

--- a/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
+++ b/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
@@ -14,7 +14,17 @@ import MemPortUtils._
 import collection.mutable
 
 /** This pass generates delay reigsters for memories for verilog */
-object VerilogMemDelays extends Pass {
+class VerilogMemDelays extends Pass {
+
+  override val prerequisites = firrtl.stage.Forms.LowForm :+ classOf[firrtl.passes.RemoveValidIf]
+
+  override val dependents = Seq(classOf[VerilogEmitter], classOf[SystemVerilogEmitter])
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case _: firrtl.transforms.ConstantPropagation => true
+    case _ => false
+  }
+
   val ug = UNKNOWNGENDER
   type Netlist = collection.mutable.HashMap[String, Expression]
   implicit def expToString(e: Expression): String = e.serialize
@@ -94,7 +104,7 @@ object VerilogMemDelays extends Pass {
         Connect(NoInfo, memPortField(mem, writer, "addr"), addr),
         Connect(NoInfo, memPortField(mem, writer, "data"), data)
       )
- 
+
       stmts ++= ((sx.readers flatMap {reader =>
         // generate latency pipes for read ports (enable & addr)
         val clk = netlist(memPortField(sx, reader, "clk"))
@@ -158,4 +168,10 @@ object VerilogMemDelays extends Pass {
 
   def run(c: Circuit): Circuit =
     c copy (modules = c.modules map memDelayMod)
+}
+
+object VerilogMemDelays extends Pass with DeprecatedPassObject {
+
+  override protected lazy val underlying = new VerilogMemDelays
+
 }

--- a/src/main/scala/firrtl/passes/wiring/WiringTransform.scala
+++ b/src/main/scala/firrtl/passes/wiring/WiringTransform.scala
@@ -43,7 +43,7 @@ class WiringTransform extends Transform {
   /** Defines the sequence of Transform that should be applied */
   private def transforms(w: Seq[WiringInfo]): Seq[Transform] = Seq(
     new Wiring(w),
-    ToWorkingIR
+    new ToWorkingIR
   )
   def execute(state: CircuitState): CircuitState = {
     val annos = state.annotations.collect {

--- a/src/main/scala/firrtl/stage/FirrtlStage.scala
+++ b/src/main/scala/firrtl/stage/FirrtlStage.scala
@@ -3,24 +3,20 @@
 package firrtl.stage
 
 import firrtl.{AnnotationSeq, CustomTransformException, FIRRTLException, Utils}
-import firrtl.options.{Stage, Phase, PhaseException, Shell, OptionsException, StageMain}
+import firrtl.options.{DependencyManagerException, Phase, PhaseException, PhaseManager, PreservesAll, Shell, Stage,
+  OptionsException, StageMain}
 import firrtl.options.phases.DeletedWrapper
 import firrtl.passes.{PassException, PassExceptions}
 
 import scala.util.control.ControlThrowable
 
 
-class FirrtlStage extends Stage {
+class FirrtlStage extends Stage with PreservesAll[Phase] {
+
   val shell: Shell = new Shell("firrtl") with FirrtlCli
 
-  private val phases: Seq[Phase] =
-    Seq( new firrtl.stage.phases.AddDefaults,
-         new firrtl.stage.phases.AddImplicitEmitter,
-         new firrtl.stage.phases.Checks,
-         new firrtl.stage.phases.AddCircuit,
-         new firrtl.stage.phases.AddImplicitOutputFile,
-         new firrtl.stage.phases.Compiler,
-         new firrtl.stage.phases.WriteEmitted )
+  val phases: Seq[Phase] = new PhaseManager(Seq(classOf[firrtl.stage.phases.WriteEmitted]))
+      .transformOrder
       .map(DeletedWrapper(_))
 
   def run(annotations: AnnotationSeq): AnnotationSeq = try {
@@ -29,7 +25,7 @@ class FirrtlStage extends Stage {
     /* Rethrow the exceptions which are expected or due to the runtime environment (out of memory, stack overflow, etc.).
      * Any UNEXPECTED exceptions should be treated as internal errors. */
     case p @ (_: ControlThrowable | _: PassException | _: PassExceptions | _: FIRRTLException | _: OptionsException
-                | _: PhaseException) => throw p
+                | _: PhaseException | _: DependencyManagerException) => throw p
     case CustomTransformException(cause) => throw cause
     case e: Exception => Utils.throwInternalError(exception = Some(e))
   }

--- a/src/main/scala/firrtl/stage/Forms.scala
+++ b/src/main/scala/firrtl/stage/Forms.scala
@@ -1,0 +1,85 @@
+// See LICENSE for license details.
+
+package firrtl.stage
+
+import firrtl._
+import firrtl.Transform
+
+/*
+ * - InferWidths should have InferTypes split out
+ * - ConvertFixedToSInt should have InferTypes split out
+ * - Move InferTypes out of ZeroWidth
+ */
+
+object Forms {
+
+  val ChirrtlForm: Seq[Class[_ <: Transform]] = Seq.empty
+
+  val HighForm: Seq[Class[_ <: Transform]] = ChirrtlForm ++
+    Seq( classOf[passes.CheckChirrtl],
+         classOf[passes.CInferTypes],
+         classOf[passes.CInferMDir],
+         classOf[passes.RemoveCHIRRTL] )
+
+  val WorkingIR: Seq[Class[_ <: Transform]] = HighForm :+ classOf[passes.ToWorkingIR]
+
+  val Resolved: Seq[Class[_ <: Transform]] = WorkingIR ++
+    Seq( classOf[passes.CheckHighForm],
+         classOf[passes.ResolveKinds],
+         classOf[passes.InferTypes],
+         classOf[passes.CheckTypes],
+         classOf[passes.Uniquify],
+         classOf[passes.ResolveGenders],
+         classOf[passes.CheckGenders],
+         classOf[passes.InferWidths],
+         classOf[passes.CheckWidths] )
+
+  val Deduped: Seq[Class[_ <: Transform]] = Resolved :+ classOf[firrtl.transforms.DedupModules]
+
+  val MidForm: Seq[Class[_ <: Transform]] = Deduped ++
+    Seq( classOf[passes.PullMuxes],
+         classOf[passes.ReplaceAccesses],
+         classOf[passes.ExpandConnects],
+         classOf[passes.RemoveAccesses],
+         classOf[passes.ExpandWhensAndCheck],
+         classOf[passes.ConvertFixedToSInt],
+         classOf[passes.ZeroWidth] )
+
+  val LowForm: Seq[Class[_ <: Transform]] = MidForm ++
+    Seq( classOf[passes.LowerTypes],
+         classOf[passes.Legalize],
+         classOf[firrtl.transforms.RemoveReset],
+         classOf[firrtl.transforms.CheckCombLoops],
+         classOf[firrtl.transforms.RemoveWires] )
+
+  val LowFormMinimumOptimized: Seq[Class[_ <: Transform]] = LowForm ++
+    Seq( classOf[passes.RemoveValidIf],
+         classOf[passes.memlib.VerilogMemDelays],
+         classOf[passes.SplitExpressions] )
+
+  val LowFormOptimized: Seq[Class[_ <: Transform]] = LowFormMinimumOptimized ++
+    Seq( classOf[firrtl.transforms.ConstantPropagation],
+         classOf[passes.PadWidths],
+         classOf[firrtl.transforms.CombineCats],
+         classOf[passes.CommonSubexpressionElimination],
+         classOf[firrtl.transforms.DeadCodeElimination] )
+
+  val VerilogMinimumOptimized: Seq[Class[_ <: Transform]] = LowFormMinimumOptimized ++
+    Seq( classOf[firrtl.transforms.BlackBoxSourceHelper],
+         classOf[firrtl.transforms.ReplaceTruncatingArithmetic],
+         classOf[firrtl.transforms.FlattenRegUpdate],
+         classOf[passes.VerilogModulusCleanup],
+         classOf[firrtl.transforms.VerilogRename],
+         classOf[passes.VerilogPrep],
+         classOf[firrtl.AddDescriptionNodes] )
+
+  val VerilogOptimized: Seq[Class[_ <: Transform]] = LowFormOptimized ++
+    Seq( classOf[firrtl.transforms.BlackBoxSourceHelper],
+         classOf[firrtl.transforms.ReplaceTruncatingArithmetic],
+         classOf[firrtl.transforms.FlattenRegUpdate],
+         classOf[passes.VerilogModulusCleanup],
+         classOf[firrtl.transforms.VerilogRename],
+         classOf[passes.VerilogPrep],
+         classOf[firrtl.AddDescriptionNodes] )
+
+}

--- a/src/main/scala/firrtl/stage/TransformManager.scala
+++ b/src/main/scala/firrtl/stage/TransformManager.scala
@@ -1,0 +1,22 @@
+// See LICENSE for license details.
+
+package firrtl.stage
+
+import firrtl.{CircuitForm, CircuitState, Transform, UnknownForm}
+import firrtl.options.DependencyManager
+
+class TransformManager(
+  val targets: Seq[Class[_ <: Transform]],
+  val currentState: Seq[Class[_ <: Transform]] = Seq.empty,
+  val knownObjects: Set[Transform] = Set.empty) extends Transform with DependencyManager[CircuitState, Transform] {
+
+  override def inputForm: CircuitForm = UnknownForm
+
+  override def outputForm: CircuitForm = UnknownForm
+
+  override def execute(state: CircuitState): CircuitState = transform(state)
+
+  override protected def copy(a: Seq[Class[_ <: Transform]], b: Seq[Class[_ <: Transform]], c: Set[Transform]) =
+    new TransformManager(a, b, c)
+
+}

--- a/src/main/scala/firrtl/stage/phases/AddCircuit.scala
+++ b/src/main/scala/firrtl/stage/phases/AddCircuit.scala
@@ -5,7 +5,7 @@ package firrtl.stage.phases
 import firrtl.stage._
 
 import firrtl.{AnnotationSeq, Parser}
-import firrtl.options.{Phase, PhasePrerequisiteException}
+import firrtl.options.{Phase, PhasePrerequisiteException, PreservesAll}
 
 /** [[firrtl.options.Phase Phase]] that expands [[FirrtlFileAnnotation]]/[[FirrtlSourceAnnotation]] into
   * [[FirrtlCircuitAnnotation]]s and deletes the originals. This is part of the preprocessing done on an input
@@ -25,7 +25,9 @@ import firrtl.options.{Phase, PhasePrerequisiteException}
   * an [[InfoModeAnnotation]].'''.
   * @define infoModeException firrtl.options.PhasePrerequisiteException if no [[InfoModeAnnotation]] is present
   */
-class AddCircuit extends Phase {
+class AddCircuit extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites = Seq(classOf[AddDefaults], classOf[Checks])
 
   /** Extract the info mode from an [[AnnotationSeq]] or use the default info mode if no annotation exists
     * @param annotations some annotations

--- a/src/main/scala/firrtl/stage/phases/AddDefaults.scala
+++ b/src/main/scala/firrtl/stage/phases/AddDefaults.scala
@@ -3,14 +3,14 @@
 package firrtl.stage.phases
 
 import firrtl.AnnotationSeq
-import firrtl.options.{Phase, TargetDirAnnotation}
+import firrtl.options.{Phase, PreservesAll, TargetDirAnnotation}
 import firrtl.transforms.BlackBoxTargetDirAnno
 import firrtl.stage.{CompilerAnnotation, InfoModeAnnotation, FirrtlOptions}
 
 /** [[firrtl.options.Phase Phase]] that adds default [[FirrtlOption]] [[firrtl.annotations.Annotation Annotation]]s.
   * This is a part of the preprocessing done by [[FirrtlStage]].
   */
-class AddDefaults extends Phase {
+class AddDefaults extends Phase with PreservesAll[Phase] {
 
   /** Append any missing default annotations to an annotation sequence */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/stage/phases/AddImplicitEmitter.scala
+++ b/src/main/scala/firrtl/stage/phases/AddImplicitEmitter.scala
@@ -4,12 +4,14 @@ package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, EmitAnnotation, EmitCircuitAnnotation}
 import firrtl.stage.{CompilerAnnotation, RunFirrtlTransformAnnotation}
-import firrtl.options.Phase
+import firrtl.options.{Phase, PreservesAll}
 
 /** [[firrtl.options.Phase Phase]] that adds a [[firrtl.EmitCircuitAnnotation EmitCircuitAnnotation]] derived from a
   * [[firrtl.stage.CompilerAnnotation CompilerAnnotation]] if one does not already exist.
   */
-class AddImplicitEmitter extends Phase {
+class AddImplicitEmitter extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites = Seq(classOf[AddDefaults])
 
   def transform(annos: AnnotationSeq): AnnotationSeq = {
     val emitter = annos.collectFirst{ case a: EmitAnnotation => a }

--- a/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
+++ b/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
@@ -3,22 +3,26 @@
 package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, EmitAllModulesAnnotation}
-import firrtl.options.{Phase, Viewer}
+import firrtl.options.{Phase, PreservesAll, Viewer}
 import firrtl.stage.{FirrtlOptions, OutputFileAnnotation}
 
 /** [[firrtl.options.Phase Phase]] that adds an [[OutputFileAnnotation]] if one does not already exist.
   *
   * To determine the [[OutputFileAnnotation]], the following precedence is used. Whichever happens first succeeds:
   *  - Do nothing if an [[OutputFileAnnotation]] or [[EmitAllModulesAnnotation]] exist
-  *  - Use the main in the first discovered [[FirrtlCircuitAnnotation]] (see note below)
+  *  - Use the main in the first discovered [[firrtl.stage.FirrtlCircuitAnnotation FirrtlCircuitAnnotation]] (see note
+  *    below)
   *  - Use "a"
   *
   * The file suffix may or may not be specified, but this may be arbitrarily changed by the [[Emitter]].
   *
-  * @note This [[firrtl.options.Phase Phase]] has a dependency on [[AddCircuit]]. Only a [[FirrtlCircuitAnnotation]]
-  * will be used to implicitly set the [[OutputFileAnnotation]] (not other [[CircuitOption]] subclasses).
+  * @note This [[firrtl.options.Phase Phase]] has a dependency on [[AddCircuit]]. Only a
+  * [[firrtl.stage.FirrtlCircuitAnnotation FirrtlCircuitAnnotation]] will be used to implicitly set the
+  * [[OutputFileAnnotation]] (not other [[CircuitOption]] subclasses).
   */
-class AddImplicitOutputFile extends Phase {
+class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites = Seq(classOf[AddCircuit])
 
   /** Add an [[OutputFileAnnotation]] to an [[AnnotationSeq]] */
   def transform(annotations: AnnotationSeq): AnnotationSeq =

--- a/src/main/scala/firrtl/stage/phases/Checks.scala
+++ b/src/main/scala/firrtl/stage/phases/Checks.scala
@@ -6,7 +6,7 @@ import firrtl.stage._
 
 import firrtl.{AnnotationSeq, EmitAllModulesAnnotation, EmitCircuitAnnotation}
 import firrtl.annotations.Annotation
-import firrtl.options.{OptionsException, Phase}
+import firrtl.options.{OptionsException, Phase, PreservesAll}
 
 /** [[firrtl.options.Phase Phase]] that strictly validates an [[AnnotationSeq]]. The checks applied are intended to be
   * extremeley strict. Nothing is inferred or assumed to take a default value (for default value resolution see
@@ -16,11 +16,13 @@ import firrtl.options.{OptionsException, Phase}
   * certain that other [[firrtl.options.Phase Phase]]s or views will succeed. See [[FirrtlStage]] for a list of
   * [[firrtl.options.Phase Phase]] that commonly run before this.
   */
-class Checks extends Phase {
+class Checks extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites = Seq(classOf[AddDefaults], classOf[AddImplicitEmitter])
 
   /** Determine if annotations are sane
     *
-    * @param annos a sequence of [[annotation.Annotation]]
+    * @param annos a sequence of [[firrtl.annotations.Annotation Annotation]]
     * @return true if all checks pass
     * @throws firrtl.options.OptionsException if any checks fail
     */

--- a/src/main/scala/firrtl/stage/phases/Compiler.scala
+++ b/src/main/scala/firrtl/stage/phases/Compiler.scala
@@ -3,9 +3,8 @@
 package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, ChirrtlForm, CircuitState, Compiler => FirrtlCompiler, Transform, seqToAnnoSeq}
-import firrtl.options.{Phase, PhasePrerequisiteException, Translator}
-import firrtl.stage.{CompilerAnnotation, FirrtlCircuitAnnotation,
-  RunFirrtlTransformAnnotation}
+import firrtl.options.{Phase, PhasePrerequisiteException, PreservesAll, Translator}
+import firrtl.stage.{CompilerAnnotation, FirrtlCircuitAnnotation, Forms, RunFirrtlTransformAnnotation}
 
 import scala.collection.mutable
 
@@ -23,13 +22,13 @@ private [stage] case class Defaults(
   compiler: Option[FirrtlCompiler] = None)
 
 /** Runs the FIRRTL compilers on an [[AnnotationSeq]]. If the input [[AnnotationSeq]] contains more than one circuit
-  * (i.e., more than one [[FirrtlCircuitAnnotation]]), then annotations will be broken up and each run will be executed
-  * in parallel.
+  * (i.e., more than one [[firrtl.stage.FirrtlCircuitAnnotation FirrtlCircuitAnnotation]]), then annotations will be
+  * broken up and each run will be executed in parallel.
   *
   * The [[AnnotationSeq]] will be chunked up into compiler runs using the following algorithm. All annotations that
-  * occur before the first [[FirrtlCircuitAnnotation]] are treated as global annotations that apply to all circuits.
-  * Annotations after a circuit are only associated with their closest preceeding circuit. E.g., for the following
-  * annotations (where A, B, and C are some annotations):
+  * occur before the first [[firrtl.stage.FirrtlCircuitAnnotation FirrtlCircuitAnnotation]] are treated as global
+  * annotations that apply to all circuits. Annotations after a circuit are only associated with their closest
+  * preceeding circuit. E.g., for the following annotations (where A, B, and C are some annotations):
   *
   *    A(a), FirrtlCircuitAnnotation(x), B, FirrtlCircuitAnnotation(y), A(b), C, FirrtlCircuitAnnotation(z)
   *
@@ -42,7 +41,14 @@ private [stage] case class Defaults(
   * FirrtlCircuitAnnotation(y). Note: A(b) ''may'' overwrite A(a) if this is a CompilerAnnotation.
   * FirrtlCircuitAnnotation(z) has no annotations, so it only gets the default A(a).
   */
-class Compiler extends Phase with Translator[AnnotationSeq, Seq[CompilerRun]] {
+class Compiler extends Phase with Translator[AnnotationSeq, Seq[CompilerRun]] with PreservesAll[Phase] {
+
+  override val prerequisites =
+    Seq(classOf[AddDefaults],
+        classOf[AddImplicitEmitter],
+        classOf[Checks],
+        classOf[AddCircuit],
+        classOf[AddImplicitOutputFile])
 
   /** Convert an [[AnnotationSeq]] into a sequence of compiler runs. */
   protected def aToB(a: AnnotationSeq): Seq[CompilerRun] = {
@@ -85,15 +91,24 @@ class Compiler extends Phase with Translator[AnnotationSeq, Seq[CompilerRun]] {
     */
   protected def internalTransform(b: Seq[CompilerRun]): Seq[CompilerRun] = {
     def f(c: CompilerRun): CompilerRun = {
-      val statex = c
-        .compiler
-        .getOrElse { throw new PhasePrerequisiteException("No compiler specified!") }
-        .compile(c.stateIn, c.transforms.reverse)
-      c.copy(stateOut = Some(statex))
+      val targets = c.compiler match {
+        case Some(d) => compilerToTransforms(d) ++ c.transforms.map(_.getClass)
+        case None    => throw new PhasePrerequisiteException("No compiler specified!") }
+      val tm = new firrtl.stage.transforms.Compiler(targets)
+      c.copy(stateOut = Some(tm.transform(c.stateIn)))
     }
 
     if (b.size <= 1) { b.map(f)         }
     else             { b.par.map(f).seq }
+  }
+
+  private def compilerToTransforms(a: FirrtlCompiler): Seq[Class[_ <: Transform]] = a match {
+    case _: firrtl.NoneCompiler                                      => Forms.ChirrtlForm
+    case _: firrtl.HighFirrtlCompiler                                => Forms.HighForm
+    case _: firrtl.MiddleFirrtlCompiler                              => Forms.MidForm
+    case _: firrtl.LowFirrtlCompiler                                 => Forms.LowForm
+    case _: firrtl.VerilogCompiler | _: firrtl.SystemVerilogCompiler => Forms.LowFormOptimized
+    case _: firrtl.MinimumVerilogCompiler                            => Forms.LowFormMinimumOptimized
   }
 
 }

--- a/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
+++ b/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
@@ -7,8 +7,7 @@ import firrtl.stage._
 import firrtl.{AnnotationSeq, EmitAllModulesAnnotation, EmitCircuitAnnotation, FirrtlExecutionResult, Parser}
 import firrtl.annotations.NoTargetAnnotation
 import firrtl.proto.FromProto
-import firrtl.options.{InputAnnotationFileAnnotation, OptionsException, Phase,
-  StageOptions, StageUtils}
+import firrtl.options.{InputAnnotationFileAnnotation, OptionsException, Phase, PreservesAll, StageOptions, StageUtils}
 import firrtl.options.Viewer
 
 import scopt.OptionParser
@@ -62,7 +61,7 @@ object DriverCompatibility {
   /** Indicates that the implicit emitter, derived from a [[CompilerAnnotation]] should be an [[EmitAllModulesAnnotation]]
     * as opposed to an [[EmitCircuitAnnotation]].
     */
-  private [firrtl] case object EmitOneFilePerModuleAnnotation extends NoTargetAnnotation {
+  case object EmitOneFilePerModuleAnnotation extends NoTargetAnnotation {
 
     def addOptions(p: OptionParser[AnnotationSeq]): Unit = p
       .opt[Unit]("split-modules")
@@ -104,10 +103,11 @@ object DriverCompatibility {
     * [[firrtl.options.InputAnnotationFileAnnotation InputAnnotationFileAnnotation]] is present.
     *
     * The implicit annotation file is determined through the following complicated semantics:
-    *   - If an [[InputAnnotationFileAnnotation]] already exists, then nothing is modified
+    *   - If an [[firrtl.options.InputAnnotationFileAnnotation InputAnnotationFileAnnotation]] already exists, then
+    *     nothing is modified
     *   - If the derived topName (the `main` in a [[firrtl.ir.Circuit Circuit]]) is ''discernable'' (see below) and a
     *     file called `topName.anno` (exactly, not `topName.anno.json`) exists, then this will add an
-    *     [[InputAnnotationFileAnnotation]] using that `topName.anno`
+    *     [[firrtl.options.InputAnnotationFileAnnotation InputAnnotationFileAnnotation]] using that `topName.anno`
     *   - If any of this doesn't work, then the the [[AnnotationSeq]] is unmodified
     *
     * The precedence for determining the `topName` is the following (first one wins):
@@ -120,9 +120,14 @@ object DriverCompatibility {
     * @param annos input annotations
     * @return output annotations
     */
-  class AddImplicitAnnotationFile extends Phase {
+  class AddImplicitAnnotationFile extends Phase with PreservesAll[Phase] {
 
-    /** Try to add an [[InputAnnotationFileAnnotation]] implicitly specified by an [[AnnotationSeq]]. */
+    override val prerequisites = Seq(classOf[AddImplicitFirrtlFile])
+
+    override val dependents = Seq(classOf[FirrtlStage])
+
+    /** Try to add an [[firrtl.options.InputAnnotationFileAnnotation InputAnnotationFileAnnotation]] implicitly specified by
+      * an [[AnnotationSeq]]. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = annotations
       .collectFirst{ case a: InputAnnotationFileAnnotation => a } match {
         case Some(_) => annotations
@@ -154,7 +159,9 @@ object DriverCompatibility {
     * @param annotations input annotations
     * @return
     */
-  class AddImplicitFirrtlFile extends Phase {
+  class AddImplicitFirrtlFile extends Phase with PreservesAll[Phase] {
+
+    override val dependents = Seq(classOf[FirrtlStage])
 
     /** Try to add a [[FirrtlFileAnnotation]] implicitly specified by an [[AnnotationSeq]]. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {
@@ -173,7 +180,7 @@ object DriverCompatibility {
     }
   }
 
-  /** Adds an [[EmitAnnotation]] for each [[CompilerAnnotation]].
+  /** Adds an [[firrtl.EmitAnnotation EmitAnnotation]] for each [[CompilerAnnotation]].
     *
     * If an [[EmitOneFilePerModuleAnnotation]] exists, then this will add an [[EmitAllModulesAnnotation]]. Otherwise,
     * this adds an [[EmitCircuitAnnotation]]. This replicates old behavior where specifying a compiler automatically
@@ -181,7 +188,9 @@ object DriverCompatibility {
     */
   @deprecated("""AddImplicitEmitter should only be used to build Driver compatibility wrappers. Switch to Stage.""",
               "1.2")
-  class AddImplicitEmitter extends Phase {
+  class AddImplicitEmitter extends Phase with PreservesAll[Phase] {
+
+    override val dependents = Seq(classOf[FirrtlStage])
 
     /** Add one [[EmitAnnotation]] foreach [[CompilerAnnotation]]. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {
@@ -203,7 +212,11 @@ object DriverCompatibility {
     */
   @deprecated("""AddImplicitOutputFile should only be used to build Driver compatibility wrappers. Switch to Stage.""",
               "1.2")
-  class AddImplicitOutputFile extends Phase {
+  class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
+
+    override val prerequisites = Seq(classOf[AddImplicitFirrtlFile])
+
+    override val dependents = Seq(classOf[FirrtlStage])
 
     /** Add an [[OutputFileAnnotation]] derived from a [[TopNameAnnotation]] if needed. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
+++ b/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
@@ -3,7 +3,7 @@
 package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, EmittedModuleAnnotation, EmittedCircuitAnnotation}
-import firrtl.options.{Phase, StageOptions, Viewer}
+import firrtl.options.{Phase, PreservesAll, StageOptions, Viewer}
 import firrtl.stage.FirrtlOptions
 
 import java.io.PrintWriter
@@ -24,7 +24,9 @@ import java.io.PrintWriter
   *
   * Any annotations written to files will be deleted.
   */
-class WriteEmitted extends Phase {
+class WriteEmitted extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites = Seq(classOf[Compiler])
 
   /** Write any [[EmittedAnnotation]]s in an [[AnnotationSeq]] to files. Written [[EmittedAnnotation]]s are deleted. */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/stage/transforms/CatchCustomTransformExceptions.scala
+++ b/src/main/scala/firrtl/stage/transforms/CatchCustomTransformExceptions.scala
@@ -1,0 +1,30 @@
+// See LICENSE for license details.
+
+package firrtl.stage.transforms
+
+import firrtl.{CircuitState, CustomTransformException, Transform}
+
+class CatchCustomTransformExceptions(val underlying: Transform) extends Transform with WrappedTransform {
+
+  override def execute(c: CircuitState): CircuitState = try {
+    underlying.execute(c)
+  } catch {
+    case e: Exception if CatchCustomTransformExceptions.isCustomTransform(trueUnderlying) => throw CustomTransformException(e)
+  }
+
+}
+
+object CatchCustomTransformExceptions {
+
+  private[firrtl] def isCustomTransform(xform: Transform): Boolean = {
+    def getTopPackage(pack: java.lang.Package): java.lang.Package =
+      Package.getPackage(pack.getName.split('.').head)
+    // We use the top package of the Driver to get the top firrtl package
+    Option(xform.getClass.getPackage).map { p =>
+      getTopPackage(p) != firrtl.Driver.getClass.getPackage
+    }.getOrElse(true)
+  }
+
+  def apply(a: Transform): CatchCustomTransformExceptions = new CatchCustomTransformExceptions(a)
+
+}

--- a/src/main/scala/firrtl/stage/transforms/Compiler.scala
+++ b/src/main/scala/firrtl/stage/transforms/Compiler.scala
@@ -1,0 +1,19 @@
+// See LICENSE for license details.
+
+package firrtl.stage.transforms
+
+import firrtl.{CircuitState, Transform}
+import firrtl.stage.TransformManager
+
+class Compiler(
+  targets: Seq[Class[_ <: Transform]],
+  currentState: Seq[Class[_ <: Transform]] = Seq.empty,
+  knownObjects: Set[Transform] = Set.empty) extends TransformManager(targets, currentState, knownObjects) {
+
+  override val wrappers = Seq(
+    (a: Transform) => CatchCustomTransformExceptions(a),
+    (a: Transform) => TrackTransforms(a),
+    (a: Transform) => UpdateAnnotations(a)
+  )
+
+}

--- a/src/main/scala/firrtl/stage/transforms/TrackTransforms.scala
+++ b/src/main/scala/firrtl/stage/transforms/TrackTransforms.scala
@@ -1,0 +1,69 @@
+// See LICENSE for license details.
+
+package firrtl.stage.transforms
+
+import firrtl.{AnnotationSeq, CircuitState, Transform}
+import firrtl.annotations.NoTargetAnnotation
+import firrtl.options.DependencyManagerException
+
+case class TransformHistoryAnnotation(history: Seq[Transform], state: Set[Transform]) extends NoTargetAnnotation {
+
+  def add(transform: Transform,
+          invalidates: (Transform) => Boolean = (a: Transform) => false): TransformHistoryAnnotation =
+    this.copy(
+      history = transform +: this.history,
+      state = (this.state + transform).filterNot(invalidates)
+    )
+
+}
+
+object TransformHistoryAnnotation {
+
+  def apply(transform: Transform): TransformHistoryAnnotation = TransformHistoryAnnotation(
+    history = Seq(transform),
+    state = Set(transform)
+  )
+
+}
+
+class TrackTransforms(val underlying: Transform) extends Transform with WrappedTransform {
+
+  private def updateState(annotations: AnnotationSeq): AnnotationSeq = {
+    var foundAnnotation = false
+    val annotationsx = annotations.map {
+      case x: TransformHistoryAnnotation =>
+        foundAnnotation = true
+        x.add(trueUnderlying)
+      case x => x
+    }
+    if (!foundAnnotation) {
+      TransformHistoryAnnotation(trueUnderlying) +: annotationsx
+    } else {
+      annotationsx
+    }
+  }
+
+  override def execute(c: CircuitState): CircuitState = {
+    val state = c.annotations
+      .collectFirst{ case TransformHistoryAnnotation(_, state) => state }
+      .getOrElse(Set.empty[Transform])
+      .map(_.getClass)
+
+    if (!trueUnderlying.prerequisites.toSet.subsetOf(state)) {
+      throw new DependencyManagerException(
+        s"""|Tried to execute Transform '$trueUnderlying' for which run-time prerequisites were not satisfied:
+            |  state: ${state.mkString("\n    -", "\n    -", "")}
+            |  prerequisites: ${trueUnderlying.prerequisites.mkString("\n    -", "\n    -", "")}""".stripMargin)
+    }
+
+    val out = underlying.execute(c)
+    out.copy(annotations = updateState(out.annotations))
+  }
+
+}
+
+object TrackTransforms {
+
+  def apply(a: Transform): Transform = new TrackTransforms(a)
+
+}

--- a/src/main/scala/firrtl/stage/transforms/UpdateAnnotations.scala
+++ b/src/main/scala/firrtl/stage/transforms/UpdateAnnotations.scala
@@ -1,0 +1,95 @@
+// See LICENSE for license details.
+
+package firrtl.stage.transforms
+
+import firrtl.{AnnotationSeq, CircuitState, RenameMap, Transform, Utils}
+import firrtl.annotations.{Annotation, DeletedAnnotation}
+import firrtl.options.Translator
+
+import scala.collection.mutable
+
+class UpdateAnnotations(val underlying: Transform) extends Transform with WrappedTransform
+    with Translator[CircuitState, (CircuitState, CircuitState)] {
+
+  override def execute(c: CircuitState): CircuitState = underlying.execute(c)
+
+  def aToB(a: CircuitState): (CircuitState, CircuitState) = (a, a)
+
+  def bToA(b: (CircuitState, CircuitState)): CircuitState = {
+    val (state, result) = (b._1, b._2)
+
+    val remappedAnnotations = propagateAnnotations(state.annotations, result.annotations, result.renames)
+
+    logger.info(s"Form: ${result.form}")
+
+    logger.debug(s"Annotations:")
+    remappedAnnotations.foreach( a => logger.debug(a.serialize) )
+
+    logger.trace(s"Circuit:\n${result.circuit.serialize}")
+    logger.info(s"======== Finished Transform $name ========\n")
+
+    CircuitState(result.circuit, result.form, remappedAnnotations, None)
+  }
+
+  def internalTransform(b: (CircuitState, CircuitState)): (CircuitState, CircuitState) = {
+    logger.info(s"======== Starting Transform $name ========")
+
+    /* @todo: prepare should likely be factored out of this */
+    val (timeMillis, result) = Utils.time { execute( trueUnderlying.prepare(b._2) ) }
+
+    logger.info(s"""----------------------------${"-" * name.size}---------\n""")
+    logger.info(f"Time: $timeMillis%.1f ms")
+
+    (b._1, result)
+  }
+
+  /** Propagate annotations and update their names.
+    *
+    * @param inAnno input AnnotationSeq
+    * @param resAnno result AnnotationSeq
+    * @param renameOpt result RenameMap
+    * @return the updated annotations
+    */
+  private[firrtl] def propagateAnnotations(
+      inAnno: AnnotationSeq,
+      resAnno: AnnotationSeq,
+      renameOpt: Option[RenameMap]): AnnotationSeq = {
+    val newAnnotations = {
+      val inSet = mutable.LinkedHashSet() ++ inAnno
+      val resSet = mutable.LinkedHashSet() ++ resAnno
+      val deleted = (inSet -- resSet).map {
+        case DeletedAnnotation(xFormName, delAnno) => DeletedAnnotation(s"$xFormName+$name", delAnno)
+        case anno => DeletedAnnotation(name, anno)
+      }
+      val created = resSet -- inSet
+      val unchanged = resSet & inSet
+      (deleted ++ created ++ unchanged)
+    }
+
+    // For each annotation, rename all annotations.
+    val renames = renameOpt.getOrElse(RenameMap())
+    val remapped2original = mutable.LinkedHashMap[Annotation, mutable.LinkedHashSet[Annotation]]()
+    val keysOfNote = mutable.LinkedHashSet[Annotation]()
+    val finalAnnotations = newAnnotations.flatMap { anno =>
+      val remappedAnnos = anno.update(renames)
+      remappedAnnos.foreach { remapped =>
+        val set = remapped2original.getOrElseUpdate(remapped, mutable.LinkedHashSet.empty[Annotation])
+        set += anno
+        if(set.size > 1) keysOfNote += remapped
+      }
+      remappedAnnos
+    }.toSeq
+    keysOfNote.foreach { key =>
+      logger.debug(s"""The following original annotations are renamed to the same new annotation.""")
+      logger.debug(s"""Original Annotations:\n  ${remapped2original(key).mkString("\n  ")}""")
+      logger.debug(s"""New Annotation:\n  $key""")
+    }
+    finalAnnotations
+  }
+}
+
+object UpdateAnnotations {
+
+  def apply(a: Transform): UpdateAnnotations = new UpdateAnnotations(a)
+
+}

--- a/src/main/scala/firrtl/stage/transforms/WrappedTransform.scala
+++ b/src/main/scala/firrtl/stage/transforms/WrappedTransform.scala
@@ -1,0 +1,33 @@
+// See LICENSE for license details.
+
+package firrtl.stage.transforms
+
+import firrtl.Transform
+
+/** A [[firrtl.Transform]] that "wraps" a second [[firrtl.Transform Transform]] to do some work before and after the
+  * second [[firrtl.Transform Transform]].
+  *
+  * This is intended to synergize with the [[firrtl.options.DependencyManager.wrappers]] method.
+  * @see [[firrtl.stage.transforms.CatchCustomTransformException]]
+  * @see [[firrtl.stage.transforms.TrackTransforms]]
+  * @see [[firrtl.stage.transforms.UpdateAnnotations]]
+  */
+trait WrappedTransform { this: Transform =>
+
+  /** The underlying [[firrtl.Transform]] */
+  val underlying: Transform
+
+  /** Return the original [[firrtl.Transform]] if this wrapper is wrapping other wrappers. */
+  lazy final val trueUnderlying: Transform = underlying match {
+    case a: WrappedTransform => a.trueUnderlying
+    case _ => underlying
+  }
+
+  override final val inputForm = underlying.inputForm
+  override final val outputForm = underlying.outputForm
+  override final val prerequisites = underlying.prerequisites
+  override final val dependents = underlying.dependents
+  override final def invalidates(b: Transform): Boolean = underlying.invalidates(b)
+  override final lazy val name = underlying.name
+
+}

--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -55,6 +55,10 @@ class BlackBoxSourceHelper extends firrtl.Transform {
   override def inputForm: CircuitForm = LowForm
   override def outputForm: CircuitForm = LowForm
 
+  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized
+
+  override val dependents = Seq.empty
+
   /** Collect BlackBoxHelperAnnos and and find the target dir if specified
     * @param annos a list of generic annotations for this transform
     * @return BlackBoxHelperAnnos and target directory

--- a/src/main/scala/firrtl/transforms/CheckCombLoops.scala
+++ b/src/main/scala/firrtl/transforms/CheckCombLoops.scala
@@ -13,7 +13,7 @@ import firrtl.annotations._
 import firrtl.Utils.throwInternalError
 import firrtl.graph.{MutableDiGraph,DiGraph}
 import firrtl.analyses.InstanceGraph
-import firrtl.options.{RegisteredTransform, ShellOption}
+import firrtl.options.{PreservesAll, RegisteredTransform, ShellOption}
 
 object CheckCombLoops {
   class CombLoopException(info: Info, mname: String, cycle: Seq[String]) extends PassException(
@@ -58,9 +58,14 @@ case class CombinationalPath(sink: ReferenceTarget, sources: Seq[ReferenceTarget
   * @note The pass relies on ExtModulePathAnnotations to find loops through ExtModules
   * @note The pass will throw exceptions on "false paths"
   */
-class CheckCombLoops extends Transform with RegisteredTransform {
+class CheckCombLoops extends Transform with RegisteredTransform with PreservesAll[Transform] {
   def inputForm = LowForm
   def outputForm = LowForm
+
+  override val prerequisites = firrtl.stage.Forms.MidForm ++
+    Seq( classOf[passes.LowerTypes],
+         classOf[passes.Legalize],
+         classOf[firrtl.transforms.RemoveReset] )
 
   import CheckCombLoops._
 

--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -12,6 +12,7 @@ import firrtl.PrimOps._
 import firrtl.graph.DiGraph
 import firrtl.analyses.InstanceGraph
 import firrtl.annotations.TargetToken.Ref
+import firrtl.options.PreservesAll
 
 import annotation.tailrec
 import collection.mutable
@@ -90,10 +91,18 @@ object ConstantPropagation {
 
 }
 
-class ConstantPropagation extends Transform with ResolvedAnnotationPaths {
+class ConstantPropagation extends Transform with ResolvedAnnotationPaths with PreservesAll[Transform] {
   import ConstantPropagation._
   def inputForm = LowForm
   def outputForm = LowForm
+
+  override val prerequisites = firrtl.stage.Forms.LowForm :+ classOf[passes.RemoveValidIf]
+
+  override val dependents =
+    Seq( classOf[firrtl.passes.memlib.VerilogMemDelays],
+         classOf[firrtl.passes.SplitExpressions],
+         classOf[SystemVerilogEmitter],
+         classOf[VerilogEmitter] )
 
   override val annotationClasses: Traversable[Class[_]] = Seq(classOf[DontTouchAnnotation])
 

--- a/src/main/scala/firrtl/transforms/Dedup.scala
+++ b/src/main/scala/firrtl/transforms/Dedup.scala
@@ -9,7 +9,7 @@ import firrtl.analyses.InstanceGraph
 import firrtl.annotations._
 import firrtl.passes.{InferTypes, MemPortUtils}
 import firrtl.Utils.throwInternalError
-import firrtl.options.{HasShellOptions, ShellOption}
+import firrtl.options.{HasShellOptions, PreservesAll, ShellOption}
 
 // Datastructures
 import scala.collection.mutable
@@ -39,9 +39,13 @@ case object NoCircuitDedupAnnotation extends NoTargetAnnotation with HasShellOpt
   * Specifically, the restriction of instance loops must have been checked, or else this pass can
   *  infinitely recurse
   */
-class DedupModules extends Transform {
+class DedupModules extends Transform with PreservesAll[Transform] {
   def inputForm: CircuitForm = HighForm
   def outputForm: CircuitForm = HighForm
+
+  override val prerequisites = firrtl.stage.Forms.Resolved
+
+  override val dependents = Seq.empty
 
   /** Deduplicate a Circuit
     * @param state Input Firrtl AST
@@ -85,7 +89,7 @@ class DedupModules extends Transform {
       }
     )
 
-    (InferTypes.run(c.copy(modules = dedupedModules)), renameMap)
+    ((new InferTypes).run(c.copy(modules = dedupedModules)), renameMap)
   }
 }
 

--- a/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
+++ b/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
@@ -108,6 +108,17 @@ class FlattenRegUpdate extends Transform {
   def inputForm = MidForm
   def outputForm = MidForm
 
+  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
+    Seq( classOf[BlackBoxSourceHelper],
+         classOf[ReplaceTruncatingArithmetic] )
+
+  override val dependents = Seq.empty
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case _: DeadCodeElimination => true
+    case _ => false
+  }
+
   def execute(state: CircuitState): CircuitState = {
     val modulesx = state.circuit.modules.map {
       case mod: Module => FlattenRegUpdate.flattenReg(mod)

--- a/src/main/scala/firrtl/transforms/GroupComponents.scala
+++ b/src/main/scala/firrtl/transforms/GroupComponents.scala
@@ -61,7 +61,8 @@ class GroupComponents extends firrtl.Transform {
       case other => Seq(other)
     }
     val cs = state.copy(circuit = state.circuit.copy(modules = newModules))
-    val csx = ResolveKinds.execute(InferTypes.execute(cs))
+    /* @todo move ResolveKinds and InferTypes out */
+    val csx = (new ResolveKinds).execute((new InferTypes).execute(cs))
     csx
   }
 

--- a/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
+++ b/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
@@ -231,4 +231,14 @@ class RemoveKeywordCollisions(keywords: Set[String]) extends Transform {
 }
 
 /** Transform that removes collisions with Verilog keywords */
-class VerilogRename extends RemoveKeywordCollisions(v_keywords)
+class VerilogRename extends RemoveKeywordCollisions(v_keywords) {
+
+  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
+    Seq( classOf[BlackBoxSourceHelper],
+         classOf[ReplaceTruncatingArithmetic],
+         classOf[FlattenRegUpdate],
+         classOf[passes.VerilogModulusCleanup] )
+
+  override val dependents = Seq.empty
+
+}

--- a/src/main/scala/firrtl/transforms/RemoveReset.scala
+++ b/src/main/scala/firrtl/transforms/RemoveReset.scala
@@ -5,6 +5,7 @@ package transforms
 
 import firrtl.ir._
 import firrtl.Mappers._
+import firrtl.options.PreservesAll
 
 import scala.collection.mutable
 
@@ -12,9 +13,13 @@ import scala.collection.mutable
   *
   * @note This pass must run after LowerTypes
   */
-class RemoveReset extends Transform {
-  def inputForm = MidForm
-  def outputForm = MidForm
+class RemoveReset extends Transform with PreservesAll[Transform] {
+  def inputForm = LowForm
+  def outputForm = LowForm
+
+  override val prerequisites = firrtl.stage.Forms.MidForm ++
+    Seq( classOf[passes.LowerTypes],
+         classOf[passes.Legalize] )
 
   private case class Reset(cond: Expression, value: Expression)
 
@@ -41,4 +46,10 @@ class RemoveReset extends Transform {
     val c = state.circuit.map(onModule)
     state.copy(circuit = c)
   }
+}
+
+object RemoveReset extends Transform with DeprecatedTransformObject {
+
+  override protected lazy val underlying = new RemoveReset
+
 }

--- a/src/main/scala/firrtl/transforms/ReplaceTruncatingArithmetic.scala
+++ b/src/main/scala/firrtl/transforms/ReplaceTruncatingArithmetic.scala
@@ -66,6 +66,10 @@ class ReplaceTruncatingArithmetic extends Transform {
   def inputForm = LowForm
   def outputForm = LowForm
 
+  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized :+ classOf[BlackBoxSourceHelper]
+
+  override val dependents = Seq.empty
+
   def execute(state: CircuitState): CircuitState = {
     val modulesx = state.circuit.modules.map(ReplaceTruncatingArithmetic.onMod(_))
     state.copy(circuit = state.circuit.copy(modules = modulesx))

--- a/src/main/scala/firrtl/transforms/TopWiring.scala
+++ b/src/main/scala/firrtl/transforms/TopWiring.scala
@@ -224,9 +224,9 @@ class TopWiringTransform extends Transform {
   /** Run passes to fix up the circuit of making the new connections  */
   private def fixupCircuit(circuit: Circuit): Circuit = {
     val passes = Seq(
-      InferTypes,
-      ResolveKinds,
-      ResolveGenders
+      new InferTypes,
+      new ResolveKinds,
+      new ResolveGenders
     )
     passes.foldLeft(circuit) { case (c: Circuit, p: Pass) => p.run(c) }
   }

--- a/src/test/scala/firrtlTests/AnnotationTests.scala
+++ b/src/test/scala/firrtlTests/AnnotationTests.scala
@@ -629,7 +629,7 @@ class JsonAnnotationTests extends AnnotationTests with BackendCompilationUtiliti
     override def inputForm: CircuitForm = UnknownForm
     override def outputForm: CircuitForm = UnknownForm
 
-    protected def execute(state: CircuitState): CircuitState = state
+    def execute(state: CircuitState): CircuitState = state
   }
 
   "annotation order" should "should be preserved" in {

--- a/src/test/scala/firrtlTests/CInferMDirSpec.scala
+++ b/src/test/scala/firrtlTests/CInferMDirSpec.scala
@@ -8,7 +8,7 @@ import firrtl.passes._
 import firrtl.transforms._
 import annotations._
 
-class CInferMDir extends LowTransformSpec {
+class CInferMDirSpec extends LowTransformSpec {
   object CInferMDirCheckPass extends Pass {
     // finds the memory and check its read port
     def checkStmt(s: Statement): Boolean = s match {

--- a/src/test/scala/firrtlTests/ChirrtlSpec.scala
+++ b/src/test/scala/firrtlTests/ChirrtlSpec.scala
@@ -12,10 +12,10 @@ import firrtl._
 
 class ChirrtlSpec extends FirrtlFlatSpec {
   def transforms = Seq(
-    CheckChirrtl,
-    CInferTypes,
-    CInferMDir,
-    RemoveCHIRRTL,
+    new CheckChirrtl,
+    new CInferTypes,
+    new CInferMDir,
+    new RemoveCHIRRTL,
     ToWorkingIR,
     CheckHighForm,
     ResolveKinds,
@@ -76,7 +76,7 @@ class ChirrtlSpec extends FirrtlFlatSpec {
   for ((description, input) <- CheckSpec.nonUniqueExamples) {
     it should s"be asserted for $description" in {
       assertThrows[CheckChirrtl.NotUniqueException] {
-        Seq(ToWorkingIR, CheckChirrtl).foldLeft(Parser.parse(input)){ case (c, tx) => tx.run(c) }
+        Seq(ToWorkingIR, new CheckChirrtl).foldLeft(Parser.parse(input)){ case (c, tx) => tx.run(c) }
       }
     }
   }

--- a/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
+++ b/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
@@ -1,0 +1,286 @@
+// See LICENSE for license details.
+
+package firrtlTests
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import firrtl.{ChirrtlToHighFirrtl, CircuitForm, CircuitState, HighFirrtlToMiddleFirrtl, IRToWorkingIR,
+  LowFirrtlOptimization, MiddleFirrtlToLowFirrtl, MinimumLowFirrtlOptimization, ResolveAndCheck, Transform}
+import firrtl.passes
+import firrtl.stage.{Forms, TransformManager}
+import firrtl.transforms.IdentityTransform
+
+object Orderings {
+  val ChirrtlToHighFirrtl = Seq(
+    classOf[passes.CheckChirrtl],
+    classOf[passes.CInferTypes],
+    classOf[passes.CInferMDir],
+    classOf[passes.RemoveCHIRRTL] )
+  val ResolveAndCheck = Seq(
+    classOf[passes.CheckHighForm],
+    classOf[passes.ResolveKinds],
+    classOf[passes.InferTypes],
+    classOf[passes.CheckTypes],
+    classOf[passes.Uniquify],
+    classOf[passes.ResolveKinds],
+    classOf[passes.InferTypes],
+    classOf[passes.ResolveGenders],
+    classOf[passes.CheckGenders],
+    classOf[passes.InferWidths],
+    classOf[passes.CheckWidths] )
+  val HighFirrtlToMiddleFirrtl = Seq(
+    classOf[passes.PullMuxes],
+    classOf[passes.ReplaceAccesses],
+    classOf[passes.ExpandConnects],
+    classOf[passes.RemoveAccesses],
+    classOf[passes.Uniquify],
+    classOf[passes.ResolveKinds],
+    classOf[passes.InferTypes],
+    classOf[passes.ExpandWhensAndCheck],
+    classOf[passes.ResolveKinds],
+    classOf[passes.InferTypes],
+    classOf[passes.ResolveGenders],
+    classOf[passes.InferWidths],
+    classOf[passes.ConvertFixedToSInt],
+    classOf[passes.ZeroWidth],
+    classOf[passes.InferTypes] )
+  val MiddleFirrtlToLowFirrtl = Seq(
+    classOf[passes.LowerTypes],
+    classOf[passes.ResolveKinds],
+    classOf[passes.InferTypes],
+    classOf[passes.ResolveGenders],
+    classOf[passes.InferWidths],
+    classOf[passes.Legalize],
+    classOf[firrtl.transforms.RemoveReset],
+    classOf[firrtl.transforms.CheckCombLoops],
+    classOf[firrtl.transforms.RemoveWires] )
+  val MinimumLowFirrtlOptimization = Seq(
+    classOf[passes.RemoveValidIf],
+    classOf[passes.Legalize],
+    classOf[passes.memlib.VerilogMemDelays],
+    classOf[passes.SplitExpressions] )
+  val LowFirrtlOptimization = Seq(
+    classOf[passes.RemoveValidIf],
+    classOf[passes.Legalize],
+    classOf[firrtl.transforms.ConstantPropagation],
+    classOf[passes.PadWidths],
+    classOf[passes.Legalize],
+    classOf[firrtl.transforms.ConstantPropagation],
+    classOf[passes.memlib.VerilogMemDelays],
+    classOf[firrtl.transforms.ConstantPropagation],
+    classOf[passes.SplitExpressions],
+    classOf[firrtl.transforms.CombineCats],
+    classOf[passes.CommonSubexpressionElimination],
+    classOf[firrtl.transforms.DeadCodeElimination] )
+  val VerilogMinimumOptimized = Seq(
+    classOf[firrtl.transforms.BlackBoxSourceHelper],
+    classOf[firrtl.transforms.ReplaceTruncatingArithmetic],
+    classOf[firrtl.transforms.FlattenRegUpdate],
+    classOf[passes.VerilogModulusCleanup],
+    classOf[firrtl.transforms.VerilogRename],
+    classOf[passes.VerilogPrep],
+    classOf[firrtl.AddDescriptionNodes] )
+  val VerilogOptimized = Seq(
+    classOf[firrtl.transforms.BlackBoxSourceHelper],
+    classOf[firrtl.transforms.ReplaceTruncatingArithmetic],
+    classOf[firrtl.transforms.FlattenRegUpdate],
+    classOf[firrtl.transforms.DeadCodeElimination],
+    classOf[passes.VerilogModulusCleanup],
+    classOf[firrtl.transforms.VerilogRename],
+    classOf[passes.VerilogPrep],
+    classOf[firrtl.AddDescriptionNodes] )
+}
+
+object Transforms {
+  class IdentityTransformDiff(val inputForm: CircuitForm, val outputForm: CircuitForm) extends Transform {
+    override def execute(state: CircuitState): CircuitState = state
+  }
+  class HighToHigh extends IdentityTransform(firrtl.HighForm)
+  class MidToMid extends IdentityTransform(firrtl.MidForm)
+  class MidToHigh extends IdentityTransformDiff(firrtl.MidForm, firrtl.HighForm)
+  class LowToLow extends IdentityTransform(firrtl.LowForm)
+  class LowToMid extends IdentityTransformDiff(firrtl.LowForm, firrtl.MidForm)
+  class LowToHigh extends IdentityTransformDiff(firrtl.LowForm, firrtl.HighForm)
+}
+
+class LoweringCompilersSpec extends FlatSpec with Matchers {
+
+  behavior of "ChirrtlToHighFirrtl"
+
+  it should "replicate the old order" in {
+    (new ChirrtlToHighFirrtl)
+      .transforms
+      .map(_.getClass) should be (Orderings.ChirrtlToHighFirrtl)
+  }
+
+  behavior of "IRToWorkingIR"
+
+  it should "replicate the old order" in {
+    (new IRToWorkingIR)
+      .transforms
+      .map(_.getClass) should be (Seq(classOf[passes.ToWorkingIR]))
+  }
+
+  behavior of "ResolveAndCheck"
+
+  it should "replicate the old order" in {
+    (new ResolveAndCheck)
+      .transforms
+      .map(_.getClass) should be (Orderings.ResolveAndCheck)
+  }
+
+  behavior of "HighFirrtlToMiddleFirrtl"
+
+  it should "replicate the old order" in {
+    (new HighFirrtlToMiddleFirrtl)
+      .transforms
+      .map(_.getClass) should be (Orderings.HighFirrtlToMiddleFirrtl)
+  }
+
+  behavior of "MiddleFirrtlToLowFirrtl"
+
+  it should "replicate the old order" in {
+    (new MiddleFirrtlToLowFirrtl)
+      .transforms
+      .map(_.getClass) should be (Orderings.MiddleFirrtlToLowFirrtl)
+  }
+
+  behavior of "MinimumLowFirrtlOptimization"
+
+  it should "replicate the old order" in {
+    (new MinimumLowFirrtlOptimization)
+      .transforms
+      .map(_.getClass) should be (Orderings.MinimumLowFirrtlOptimization)
+  }
+
+  behavior of "LowFirrtlOptimization"
+
+  it should "replicate the old order" in {
+    (new LowFirrtlOptimization)
+      .transforms
+      .map(_.getClass) should be (Orderings.LowFirrtlOptimization)
+  }
+
+  behavior of "VerilogMinimumOptimized"
+
+  it should "replicate the old order" in {
+    (new TransformManager(Forms.VerilogMinimumOptimized, Forms.LowFormMinimumOptimized))
+      .flattenedTransformOrder
+      .map(_.getClass) should be (Orderings.VerilogMinimumOptimized)
+  }
+
+  behavior of "VerilogOptimized"
+
+  it should "replicate the old order" in {
+    (new TransformManager(Forms.VerilogOptimized, Forms.LowFormOptimized))
+      .flattenedTransformOrder
+      .map(_.getClass) should be (Orderings.VerilogOptimized)
+  }
+
+  behavior of "Chirrtl to Verilog"
+
+  it should "replicate the old order" in {
+    val oldOrder =
+      Orderings.ChirrtlToHighFirrtl ++
+        Some(classOf[passes.ToWorkingIR]) ++
+        Orderings.ResolveAndCheck ++
+        Some(classOf[firrtl.transforms.DedupModules]) ++
+        Orderings.HighFirrtlToMiddleFirrtl ++
+        Orderings.MiddleFirrtlToLowFirrtl ++
+        Orderings.LowFirrtlOptimization ++
+        Some(classOf[firrtl.VerilogEmitter])
+    (new TransformManager(Seq(classOf[firrtl.VerilogEmitter]), Forms.ChirrtlForm))
+      .flattenedTransformOrder.map(_.getClass) should be (oldOrder)
+  }
+
+  behavior of "Legacy Custom Transforms"
+
+  it should "work for High -> High" in {
+    val expected = Orderings.ChirrtlToHighFirrtl ++
+      Some(classOf[Transforms.HighToHigh]) ++
+      Some(classOf[passes.ToWorkingIR]) ++
+      Orderings.ResolveAndCheck ++
+      Some(classOf[firrtl.transforms.DedupModules]) ++
+      Orderings.HighFirrtlToMiddleFirrtl
+    (new TransformManager(Forms.MidForm :+ classOf[Transforms.HighToHigh]))
+      .flattenedTransformOrder
+      .map(_.getClass) should be (expected)
+  }
+
+  it should "work for Mid -> Mid" in {
+    val expected = Orderings.ChirrtlToHighFirrtl ++
+      Some(classOf[passes.ToWorkingIR]) ++
+      Orderings.ResolveAndCheck ++
+      Some(classOf[firrtl.transforms.DedupModules]) ++
+      Orderings.HighFirrtlToMiddleFirrtl ++
+      Some(classOf[Transforms.MidToMid]) ++
+      Orderings.MiddleFirrtlToLowFirrtl
+    (new TransformManager(Forms.LowForm :+ classOf[Transforms.MidToMid]))
+      .flattenedTransformOrder
+      .map(_.getClass) should be (expected)
+  }
+  it should "work for Mid -> High" in {
+    val expected = Orderings.ChirrtlToHighFirrtl ++
+      Some(classOf[passes.ToWorkingIR]) ++
+      Orderings.ResolveAndCheck ++
+      Some(classOf[firrtl.transforms.DedupModules]) ++
+      Orderings.HighFirrtlToMiddleFirrtl ++
+      Some(classOf[Transforms.MidToHigh]) ++
+      Some(classOf[passes.ToWorkingIR]) ++
+      Orderings.ResolveAndCheck ++
+      Some(classOf[firrtl.transforms.DedupModules]) ++
+      Orderings.HighFirrtlToMiddleFirrtl ++
+      Orderings.MiddleFirrtlToLowFirrtl
+    (new TransformManager(Forms.LowForm :+ classOf[Transforms.MidToHigh]))
+      .flattenedTransformOrder
+      .map(_.getClass) should be (expected)
+  }
+
+  it should "work for Low -> Low" in {
+    val expected = Orderings.ChirrtlToHighFirrtl ++
+      Some(classOf[passes.ToWorkingIR]) ++
+      Orderings.ResolveAndCheck ++
+      Some(classOf[firrtl.transforms.DedupModules]) ++
+      Orderings.HighFirrtlToMiddleFirrtl ++
+      Orderings.MiddleFirrtlToLowFirrtl ++
+      Some(classOf[Transforms.LowToLow]) ++
+      Orderings.LowFirrtlOptimization
+    (new TransformManager(Forms.LowFormOptimized :+ classOf[Transforms.LowToLow]))
+      .flattenedTransformOrder
+      .map(_.getClass) should be (expected)
+  }
+
+  it should "work for Low -> Mid" in {
+    val expected = Orderings.ChirrtlToHighFirrtl ++
+      Some(classOf[passes.ToWorkingIR]) ++
+      Orderings.ResolveAndCheck ++
+      Some(classOf[firrtl.transforms.DedupModules]) ++
+      Orderings.HighFirrtlToMiddleFirrtl ++
+      Orderings.MiddleFirrtlToLowFirrtl ++
+      Some(classOf[Transforms.LowToMid]) ++
+      Orderings.MiddleFirrtlToLowFirrtl ++
+      Orderings.LowFirrtlOptimization
+    (new TransformManager(Forms.LowFormOptimized :+ classOf[Transforms.LowToMid]))
+      .flattenedTransformOrder
+      .map(_.getClass) should be (expected)
+  }
+
+  it should "work for Low -> High" in {
+    val expected = Orderings.ChirrtlToHighFirrtl ++
+      Some(classOf[passes.ToWorkingIR]) ++
+      Orderings.ResolveAndCheck ++
+      Some(classOf[firrtl.transforms.DedupModules]) ++
+      Orderings.HighFirrtlToMiddleFirrtl ++
+      Orderings.MiddleFirrtlToLowFirrtl ++
+      Some(classOf[Transforms.LowToHigh]) ++
+      Some(classOf[passes.ToWorkingIR]) ++
+      Orderings.ResolveAndCheck ++
+      Some(classOf[firrtl.transforms.DedupModules]) ++
+      Orderings.HighFirrtlToMiddleFirrtl ++
+      Orderings.MiddleFirrtlToLowFirrtl ++
+      Orderings.LowFirrtlOptimization
+    (new TransformManager(Forms.LowFormOptimized :+ classOf[Transforms.LowToHigh]))
+      .flattenedTransformOrder
+      .map(_.getClass) should be (expected)
+  }
+}

--- a/src/test/scala/firrtlTests/fixed/RemoveFixedTypeSpec.scala
+++ b/src/test/scala/firrtlTests/fixed/RemoveFixedTypeSpec.scala
@@ -181,7 +181,7 @@ class RemoveFixedTypeSpec extends FirrtlFlatSpec {
     class CheckChirrtlTransform extends SeqTransform {
       def inputForm = ChirrtlForm
       def outputForm = ChirrtlForm
-      val transforms = Seq(passes.CheckChirrtl)
+      val transforms = Seq(new passes.CheckChirrtl)
     }
 
     val chirrtlTransform = new CheckChirrtlTransform
@@ -215,4 +215,3 @@ class RemoveFixedTypeSpec extends FirrtlFlatSpec {
     executeTest(input, check.split("\n") map normalized, passes)
   }
 }
-

--- a/src/test/scala/firrtlTests/stage/phases/CompilerSpec.scala
+++ b/src/test/scala/firrtlTests/stage/phases/CompilerSpec.scala
@@ -40,7 +40,7 @@ class CompilerSpec extends FlatSpec with Matchers {
 
     val expected = Seq(FirrtlCircuitAnnotation(circuitOut))
 
-    phase.transform(input).toSeq should be (expected)
+    phase.transform(input).collect{ case a: FirrtlCircuitAnnotation => a }.toSeq should be (expected)
   }
 
   it should "compile multiple FirrtlCircuitAnnotations" in new Fixture {

--- a/src/test/scala/firrtlTests/transforms/BlacklBoxSourceHelperSpec.scala
+++ b/src/test/scala/firrtlTests/transforms/BlacklBoxSourceHelperSpec.scala
@@ -101,11 +101,6 @@ class BlacklBoxSourceHelperTransformSpec extends LowTransformSpec {
     new java.io.File(s"test_run_dir/${BlackBoxSourceHelper.fileListName}").exists should be (true)
   }
 
-  "verilog compiler" should "have BlackBoxSourceHelper transform" in {
-    val verilogCompiler = new VerilogEmitter
-    verilogCompiler.transforms.map { x => x.getClass } should contain (classOf[BlackBoxSourceHelper])
-  }
-
   "verilog header files" should "be available but not mentioned in the file list" in {
     // Issue #917 - We don't want to list Verilog header files ("*.vh") in our file list.
     // We don't actually verify that the generated verilog code works,


### PR DESCRIPTION
*Re-opened version of #1105. GitHub can't seem to re-open that so I can change the base branch...*

This adds a Dependency API version of the FIRRTL compiler.

Roughly:

- Adds `TransformManager` for managing transforms (a `DependencyManager[Transform]`)
- Adds `firrtl.stage.transforms.Compiler` which replaces `firrtl.Compiler` and is, itself, a `Transform`
- Defines dependencies for all transforms and passes
- Adds compatibility logic for converting `inputForm`/`outputForm` to Dependency API
- New tests to ensure that the resulting transform orderings are sane