### PR TITLE
Change Dependency API to Class[_ <: A]

### DIFF
--- a/src/main/scala/firrtl/options/DependencyManager.scala
+++ b/src/main/scala/firrtl/options/DependencyManager.scala
@@ -22,15 +22,15 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
   /** Requested [[firrtl.options.TransformLike TransformLike]]s that should be run. Internally, this will be converted to
     * a set based on the ordering defined here.
     */
-  def targets: Seq[Class[_ <: B]]
-  private lazy val _targets: LinkedHashSet[Class[_ <: B]] = targets
-    .foldLeft(new LinkedHashSet[Class[_ <: B]]()){ case (a, b) => a += b }
+  def targets: Seq[Dependency]
+  private lazy val _targets: LinkedHashSet[Dependency] = targets
+    .foldLeft(new LinkedHashSet[Dependency]()){ case (a, b) => a += b }
 
   /** A sequence of [[firrtl.Transform]]s that have been run. Internally, this will be converted to an ordered set.
     */
-  def currentState: Seq[Class[_ <: B]]
-  private lazy val _currentState: LinkedHashSet[Class[_ <: B]] = currentState
-    .foldLeft(new LinkedHashSet[Class[_ <: B]]()){ case (a, b) => a += b }
+  def currentState: Seq[Dependency]
+  private lazy val _currentState: LinkedHashSet[Dependency] = currentState
+    .foldLeft(new LinkedHashSet[Dependency]()){ case (a, b) => a += b }
 
   /** Existing transform objects that have already been constructed */
   def knownObjects: Set[B]
@@ -42,8 +42,8 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
 
   /** Store of conversions between classes and objects. Objects that do not exist in the map will be lazily constructed.
     */
-  protected lazy val classToObject: LinkedHashMap[Class[_ <: B], B] = {
-    val init = LinkedHashMap[Class[_ <: B], B](knownObjects.map(x => x.getClass -> x).toSeq: _*)
+  protected lazy val classToObject: LinkedHashMap[Dependency, B] = {
+    val init = LinkedHashMap[Dependency, B](knownObjects.map(x => x.getClass -> x).toSeq: _*)
     (_targets ++ _currentState)
       .filter(!init.contains(_))
       .map(x => init(x) = safeConstruct(x))
@@ -54,32 +54,32 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
     * requirements. This is used to solve sub-problems arising from invalidations.
     */
   protected def copy(
-    targets: Seq[Class[_ <: B]],
-    currentState: Seq[Class[_ <: B]],
+    targets: Seq[Dependency],
+    currentState: Seq[Dependency],
     knownObjects: ISet[B] = classToObject.values.toSet): B
 
   /** Implicit conversion from Class[B] to B */
-  private implicit def cToO(c: Class[_ <: B]): B = classToObject.getOrElseUpdate(c, safeConstruct(c))
+  private implicit def cToO(c: Dependency): B = classToObject.getOrElseUpdate(c, safeConstruct(c))
 
   /** Implicit conversion from B to Class[B] */
-  private implicit def oToC(b: B): Class[_ <: B] = b.getClass
+  private implicit def oToC(b: B): Dependency = b.getClass
 
   /** Modified breadth-first search that supports multiple starting nodes and a custom extractor that can be used to
     * generate/filter the edges to explore. Additionally, this will include edges to previously discovered nodes.
     */
-  private def bfs( start: LinkedHashSet[Class[_ <: B]],
-                   blacklist: LinkedHashSet[Class[_ <: B]],
-                   extractor: B => Set[Class[_ <: B]] ): LinkedHashMap[B, LinkedHashSet[B]] = {
+  private def bfs( start: LinkedHashSet[Dependency],
+                   blacklist: LinkedHashSet[Dependency],
+                   extractor: B => Set[Dependency] ): LinkedHashMap[B, LinkedHashSet[B]] = {
 
     val (queue, edges) = {
-      val a: Queue[Class[_ <: B]]                    = Queue(start.toSeq:_*)
+      val a: Queue[Dependency]                    = Queue(start.toSeq:_*)
       val b: LinkedHashMap[B, LinkedHashSet[B]] = LinkedHashMap[B, LinkedHashSet[B]](
         start.map((cToO(_) -> LinkedHashSet[B]())).toSeq:_*)
       (a, b)
     }
 
     while (queue.nonEmpty) {
-      val u: Class[_ <: B] = queue.dequeue
+      val u: Dependency = queue.dequeue
       for (v <- extractor(classToObject(u))) {
         if (!blacklist.contains(v) && !edges.contains(v)) {
           queue.enqueue(v)
@@ -107,7 +107,7 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
     val edges = bfs(
       start = _targets -- _currentState,
       blacklist = _currentState,
-      extractor = (p: B) => new LinkedHashSet[Class[_ <: B]]() ++ p.prerequisites -- _currentState)
+      extractor = (p: B) => new LinkedHashSet[Dependency]() ++ p.prerequisites -- _currentState)
     DiGraph(edges)
   }
 
@@ -230,7 +230,7 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
   final override def transform(annotations: A): A = {
 
     /* A local store of each wrapper to it's underlying class. */
-    val wrapperToClass = new HashMap[B, Class[_ <: B]]
+    val wrapperToClass = new HashMap[B, Dependency]
 
     /* The determined, flat order of transforms is wrapped with surrounding transforms while populating wrapperToClass so
      * that each wrapped transform object can be dereferenced to its underlying class. Each wrapped transform is then
@@ -354,10 +354,17 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
   * @param targets the [[Phase]]s you want to run
   */
 class PhaseManager(
-  val targets: Seq[Class[_ <: Phase]],
-  val currentState: Seq[Class[_ <: Phase]] = Seq.empty,
+  val targets: Seq[PhaseManager.PhaseDependency],
+  val currentState: Seq[PhaseManager.PhaseDependency] = Seq.empty,
   val knownObjects: Set[Phase] = Set.empty) extends Phase with DependencyManager[AnnotationSeq, Phase] {
 
-  protected def copy(a: Seq[Class[_ <: Phase]], b: Seq[Class[_ <: Phase]], c: ISet[Phase]) = new PhaseManager(a, b, c)
+  protected def copy(a: Seq[Dependency], b: Seq[Dependency], c: ISet[Phase]) = new PhaseManager(a, b, c)
+
+}
+
+object PhaseManager {
+
+  /** The type used to represent dependencies between [[Phase]]s */
+  type PhaseDependency = Class[_ <: Phase]
 
 }

--- a/src/main/scala/firrtl/options/Phase.scala
+++ b/src/main/scala/firrtl/options/Phase.scala
@@ -45,8 +45,8 @@ trait DependencyAPI[A <: DependencyAPI[A]] { this: TransformLike[_] =>
   /** All transform that must run before this transform
     * $seqNote
     */
-  def prerequisites: Seq[Class[A]] = Seq.empty
-  private[options] lazy val _prerequisites: LinkedHashSet[Class[A]] = new LinkedHashSet() ++ prerequisites.toSet
+  def prerequisites: Seq[Class[_ <: A]] = Seq.empty
+  private[options] lazy val _prerequisites: LinkedHashSet[Class[_ <: A]] = new LinkedHashSet() ++ prerequisites.toSet
 
   /** All transforms that must run ''after'' this transform
     *
@@ -67,22 +67,14 @@ trait DependencyAPI[A <: DependencyAPI[A]] { this: TransformLike[_] =>
     * @see [[firrtl.passes.CheckTypes]] for an example of an optional checking [[firrtl.Transform]]
     * $seqNote
     */
-  def dependents: Seq[Class[A]] = Seq.empty
-  private[options] lazy val _dependents: LinkedHashSet[Class[A]] = new LinkedHashSet() ++ dependents.toSet
+  def dependents: Seq[Class[_ <: A]] = Seq.empty
+  private[options] lazy val _dependents: LinkedHashSet[Class[_ <: A]] = new LinkedHashSet() ++ dependents.toSet
 
   /** A function that, given a transform will return true if this transform invalidates/undos the effects of the input
     * transform
     * @note Can a [[firrtl.options.Phase Phase]] ever invalidate itself?
     */
   def invalidates(a: A): Boolean = true
-
-  /** Helper method to return the underlying class */
-  final def asClass: Class[A] = this.getClass.asInstanceOf[Class[A]]
-
-  /** Implicit conversion that allows for terser specification of [[DependencyAPI.prerequisites prerequisites]] and
-    * [[DependencyAPI.dependents dependents]].
-    */
-  implicit def classHelper(a: Class[_ <: A]): Class[A] = a.asInstanceOf[Class[A]]
 
 }
 

--- a/src/main/scala/firrtl/options/Phase.scala
+++ b/src/main/scala/firrtl/options/Phase.scala
@@ -42,11 +42,14 @@ trait TransformLike[A] extends LazyLogging {
   */
 trait DependencyAPI[A <: DependencyAPI[A]] { this: TransformLike[_] =>
 
+  /** The type used to express dependencies: a class which itself has dependencies. */
+  type Dependency = Class[_ <: A]
+
   /** All transform that must run before this transform
     * $seqNote
     */
-  def prerequisites: Seq[Class[_ <: A]] = Seq.empty
-  private[options] lazy val _prerequisites: LinkedHashSet[Class[_ <: A]] = new LinkedHashSet() ++ prerequisites.toSet
+  def prerequisites: Seq[Dependency] = Seq.empty
+  private[options] lazy val _prerequisites: LinkedHashSet[Dependency] = new LinkedHashSet() ++ prerequisites.toSet
 
   /** All transforms that must run ''after'' this transform
     *
@@ -67,8 +70,8 @@ trait DependencyAPI[A <: DependencyAPI[A]] { this: TransformLike[_] =>
     * @see [[firrtl.passes.CheckTypes]] for an example of an optional checking [[firrtl.Transform]]
     * $seqNote
     */
-  def dependents: Seq[Class[_ <: A]] = Seq.empty
-  private[options] lazy val _dependents: LinkedHashSet[Class[_ <: A]] = new LinkedHashSet() ++ dependents.toSet
+  def dependents: Seq[Dependency] = Seq.empty
+  private[options] lazy val _dependents: LinkedHashSet[Dependency] = new LinkedHashSet() ++ dependents.toSet
 
   /** A function that, given a transform will return true if this transform invalidates/undos the effects of the input
     * transform

--- a/src/test/scala/firrtlTests/options/PhaseManagerSpec.scala
+++ b/src/test/scala/firrtlTests/options/PhaseManagerSpec.scala
@@ -23,7 +23,7 @@ class A extends IdentityPhase {
 
 /** [[Phase]] that requires [[A]] and invalidates nothing */
 class B extends IdentityPhase {
-  override def prerequisites = Seq(classOf[A])
+  override def prerequisites: Seq[Dependency] = Seq(classOf[A])
   override def invalidates(phase: Phase): Boolean = false
 }
 

--- a/src/test/scala/firrtlTests/options/PhaseManagerSpec.scala
+++ b/src/test/scala/firrtlTests/options/PhaseManagerSpec.scala
@@ -23,19 +23,19 @@ class A extends IdentityPhase {
 
 /** [[Phase]] that requires [[A]] and invalidates nothing */
 class B extends IdentityPhase {
-  override def prerequisites: Seq[Class[Phase]] = Seq(classOf[A])
+  override def prerequisites = Seq(classOf[A])
   override def invalidates(phase: Phase): Boolean = false
 }
 
 /** [[Phase]] that requires [[B]] and invalidates nothing */
 class C extends IdentityPhase {
-  override def prerequisites: Seq[Class[Phase]] = Seq(classOf[A])
+  override def prerequisites = Seq(classOf[A])
   override def invalidates(phase: Phase): Boolean = false
 }
 
 /** [[Phase]] that requires [[A]] and invalidates [[A]] */
 class D extends IdentityPhase {
-  override def prerequisites: Seq[Class[Phase]] = Seq(classOf[A])
+  override def prerequisites = Seq(classOf[A])
   override def invalidates(phase: Phase): Boolean = phase match {
     case _: A => true
     case _ => false
@@ -44,13 +44,13 @@ class D extends IdentityPhase {
 
 /** [[Phase]] that requires [[B]] and invalidates nothing */
 class E extends IdentityPhase {
-  override def prerequisites: Seq[Class[Phase]] = Seq(classOf[B])
+  override def prerequisites = Seq(classOf[B])
   override def invalidates(phase: Phase): Boolean = false
 }
 
 /** [[Phase]] that requires [[B]] and [[C]] and invalidates [[E]] */
 class F extends IdentityPhase {
-  override def prerequisites: Seq[Class[Phase]] = Seq(classOf[B], classOf[C])
+  override def prerequisites = Seq(classOf[B], classOf[C])
   override def invalidates(phase: Phase): Boolean = phase match {
     case _: E => true
     case _ => false
@@ -60,7 +60,7 @@ class F extends IdentityPhase {
 
 /** [[Phase]] that requires [[C]] and invalidates [[F]] */
 class G extends IdentityPhase {
-  override def prerequisites: Seq[Class[Phase]] = Seq(classOf[C])
+  override def prerequisites = Seq(classOf[C])
   override def invalidates(phase: Phase): Boolean = phase match {
     case _: F => true
     case _ => false
@@ -68,11 +68,11 @@ class G extends IdentityPhase {
 }
 
 class CyclicA extends IdentityPhase with PreservesAll[Phase] {
-  override def prerequisites: Seq[Class[Phase]] = Seq(classOf[CyclicB])
+  override def prerequisites = Seq(classOf[CyclicB])
 }
 
 class CyclicB extends IdentityPhase with PreservesAll[Phase] {
-  override def prerequisites: Seq[Class[Phase]] = Seq(classOf[CyclicA])
+  override def prerequisites = Seq(classOf[CyclicA])
 }
 
 class CyclicC extends IdentityPhase {
@@ -95,25 +95,25 @@ object ComplicatedFixture {
     override def invalidates(phase: Phase): Boolean = false
   }
   class B extends IdentityPhase {
-    override def prerequisites: Seq[Class[Phase]] = Seq(classOf[A])
+    override def prerequisites = Seq(classOf[A])
     override def invalidates(phase: Phase): Boolean = false
   }
   class C extends IdentityPhase {
-    override def prerequisites: Seq[Class[Phase]] = Seq(classOf[A])
+    override def prerequisites = Seq(classOf[A])
     override def invalidates(phase: Phase): Boolean = phase match {
       case _: B => true
       case _ => false
     }
   }
   class D extends IdentityPhase {
-    override def prerequisites: Seq[Class[Phase]] = Seq(classOf[B])
+    override def prerequisites = Seq(classOf[B])
     override def invalidates(phase: Phase): Boolean = phase match {
       case _: C | _: E => true
       case _ => false
     }
   }
   class E extends IdentityPhase {
-    override def prerequisites: Seq[Class[Phase]] = Seq(classOf[B])
+    override def prerequisites = Seq(classOf[B])
     override def invalidates(phase: Phase): Boolean = false
   }
 
@@ -132,13 +132,13 @@ object RepeatedAnalysisFixture {
     override def invalidates(phase: Phase): Boolean = false
   }
   class A extends InvalidatesAnalysis {
-    override def prerequisites: Seq[Class[Phase]] = Seq(classOf[Analysis])
+    override def prerequisites = Seq(classOf[Analysis])
   }
   class B extends InvalidatesAnalysis {
-    override def prerequisites: Seq[Class[Phase]] = Seq(classOf[A], classOf[Analysis])
+    override def prerequisites = Seq(classOf[A], classOf[Analysis])
   }
   class C extends InvalidatesAnalysis {
-    override def prerequisites: Seq[Class[Phase]] = Seq(classOf[B], classOf[Analysis])
+    override def prerequisites = Seq(classOf[B], classOf[Analysis])
   }
 
 }
@@ -149,21 +149,21 @@ object InvertedAnalysisFixture {
     override def invalidates(phase: Phase): Boolean = false
   }
   class A extends IdentityPhase {
-    override def prerequisites: Seq[Class[Phase]] = Seq(classOf[Analysis])
+    override def prerequisites = Seq(classOf[Analysis])
     override def invalidates(phase: Phase): Boolean = phase match {
       case _: Analysis => true
       case _ => false
     }
   }
   class B extends IdentityPhase {
-    override def prerequisites: Seq[Class[Phase]] = Seq(classOf[Analysis])
+    override def prerequisites = Seq(classOf[Analysis])
     override def invalidates(phase: Phase): Boolean = phase match {
       case _: Analysis | _: A => true
       case _ => false
     }
   }
   class C extends IdentityPhase {
-    override def prerequisites: Seq[Class[Phase]] = Seq(classOf[Analysis])
+    override def prerequisites = Seq(classOf[Analysis])
     override def invalidates(phase: Phase): Boolean = phase match {
       case _: Analysis | _: B => true
       case _ => false
@@ -179,7 +179,7 @@ object DependentsFixture {
   }
 
   class Second extends IdentityPhase {
-    override val prerequisites: Seq[Class[Phase]] = Seq(classOf[First])
+    override val prerequisites = Seq(classOf[First])
     override def invalidates(phase: Phase): Boolean = false
   }
 
@@ -188,8 +188,8 @@ object DependentsFixture {
    * loop detection.
    */
   class Custom extends IdentityPhase {
-    override val prerequisites: Seq[Class[Phase]] = Seq(classOf[First])
-    override val dependents: Seq[Class[Phase]] = Seq(classOf[Second])
+    override val prerequisites = Seq(classOf[First])
+    override val dependents = Seq(classOf[Second])
     override def invalidates(phase: Phase): Boolean = false
   }
 
@@ -219,7 +219,7 @@ object ChainedInvalidationFixture {
     override def invalidates(phase: Phase): Boolean = false
   }
   class E extends IdentityPhase {
-    override val prerequisites: Seq[Class[Phase]] = Seq(classOf[A], classOf[B], classOf[C], classOf[D])
+    override val prerequisites = Seq(classOf[A], classOf[B], classOf[C], classOf[D])
     override def invalidates(phase: Phase): Boolean = false
   }
 
@@ -253,8 +253,8 @@ object UnrelatedFixture {
   class B15 extends IdentityPhase with PreservesAll[Phase]
 
   class B6Sub extends B6 {
-    override val prerequisites = Seq(classOf[B6]).asInstanceOf[Seq[Class[Phase]]]
-    override val dependents = Seq(classOf[B7]).asInstanceOf[Seq[Class[Phase]]]
+    override val prerequisites = Seq(classOf[B6])
+    override val dependents = Seq(classOf[B7])
   }
 
   class B6_0 extends B6Sub
@@ -275,7 +275,7 @@ object UnrelatedFixture {
   class B6_15 extends B6Sub
 
   class B8Dep extends B8 {
-    override val dependents = Seq(classOf[B8]).asInstanceOf[Seq[Class[Phase]]]
+    override val dependents = Seq(classOf[B8])
   }
 
   class B8_0 extends B8Dep
@@ -333,12 +333,10 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
 
   }
 
-  implicit def f(a: Class[_ <: Phase]): Class[Phase] = a.asInstanceOf[Class[Phase]]
-
   behavior of this.getClass.getName
 
   it should "do nothing if all targets are reached" in {
-    val targets: Seq[Class[Phase]] = Seq(classOf[A], classOf[B], classOf[C], classOf[D])
+    val targets = Seq(classOf[A], classOf[B], classOf[C], classOf[D])
     val pm = new PhaseManager(targets, targets)
 
     writeGraphviz(pm, "test_run_dir/PhaseManagerSpec/DoNothing")
@@ -347,27 +345,27 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
   }
 
   it should "handle a simple dependency" in {
-    val targets: Seq[Class[Phase]] = Seq(classOf[B])
-    val order: Seq[Class[Phase]] = Seq(classOf[A], classOf[B])
+    val targets = Seq(classOf[B])
+    val order = Seq(classOf[A], classOf[B])
     val pm = new PhaseManager(targets)
 
     writeGraphviz(pm, "test_run_dir/PhaseManagerSpec/SimpleDependency")
 
-    pm.flattenedTransformOrder.map(_.asClass) should be (order)
+    pm.flattenedTransformOrder.map(_.getClass) should be (order)
   }
 
   it should "handle a simple dependency with an invalidation" in {
-    val targets: Seq[Class[Phase]] = Seq(classOf[A], classOf[B], classOf[C], classOf[D])
-    val order: Seq[Class[Phase]] = Seq(classOf[A], classOf[D], classOf[A], classOf[B], classOf[C])
+    val targets = Seq(classOf[A], classOf[B], classOf[C], classOf[D])
+    val order = Seq(classOf[A], classOf[D], classOf[A], classOf[B], classOf[C])
     val pm = new PhaseManager(targets)
 
     writeGraphviz(pm, "test_run_dir/PhaseManagerSpec/OneInvalidate")
 
-    pm.flattenedTransformOrder.map(_.asClass) should be (order)
+    pm.flattenedTransformOrder.map(_.getClass) should be (order)
   }
 
   it should "handle a dependency with two invalidates optimally" in {
-    val targets: Seq[Class[Phase]] = Seq(classOf[A], classOf[B], classOf[C], classOf[E], classOf[F], classOf[G])
+    val targets = Seq(classOf[A], classOf[B], classOf[C], classOf[E], classOf[F], classOf[G])
     val pm = new PhaseManager(targets)
 
     writeGraphviz(pm, "test_run_dir/PhaseManagerSpec/TwoInvalidates")
@@ -376,7 +374,7 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
   }
 
   it should "throw an exception for cyclic prerequisites" in {
-    val targets: Seq[Class[Phase]] = Seq(classOf[CyclicA], classOf[CyclicB])
+    val targets = Seq(classOf[CyclicA], classOf[CyclicB])
     val pm = new PhaseManager(targets)
 
     writeGraphviz(pm, "test_run_dir/PhaseManagerSpec/CyclicPrerequisites")
@@ -386,7 +384,7 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
   }
 
   it should "throw an exception for cyclic invalidates" in {
-    val targets: Seq[Class[Phase]] = Seq(classOf[CyclicC], classOf[CyclicD])
+    val targets = Seq(classOf[CyclicC], classOf[CyclicD])
     val pm = new PhaseManager(targets)
 
     writeGraphviz(pm, "test_run_dir/PhaseManagerSpec/CyclicInvalidates")
@@ -397,8 +395,7 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
 
   it should "handle a complicated graph" in {
     val f = ComplicatedFixture
-    val targets: Seq[Class[Phase]] = Seq(classOf[f.A], classOf[f.B], classOf[f.C], classOf[f.D], classOf[f.E])
-      .map(_.asInstanceOf[Class[Phase]])
+    val targets = Seq(classOf[f.A], classOf[f.B], classOf[f.C], classOf[f.D], classOf[f.E])
     val pm = new PhaseManager(targets)
 
     writeGraphviz(pm, "test_run_dir/PhaseManagerSpec/Complicated")
@@ -409,40 +406,36 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
 
   it should "handle repeated recomputed analyses" in {
     val f = RepeatedAnalysisFixture
-    val targets: Seq[Class[Phase]] = Seq(classOf[f.A], classOf[f.B], classOf[f.C])
-      .map(_.asInstanceOf[Class[Phase]])
-    val order: Seq[Class[Phase]] =
+    val targets = Seq(classOf[f.A], classOf[f.B], classOf[f.C])
+    val order =
       Seq( classOf[f.Analysis],
            classOf[f.A],
            classOf[f.Analysis],
            classOf[f.B],
            classOf[f.Analysis],
            classOf[f.C])
-        .map(_.asInstanceOf[Class[Phase]])
     val pm = new PhaseManager(targets)
 
     writeGraphviz(pm, "test_run_dir/PhaseManagerSpec/RepeatedAnalysis")
 
-    pm.flattenedTransformOrder.map(_.asClass) should be (order)
+    pm.flattenedTransformOrder.map(_.getClass) should be (order)
   }
 
   it should "handle inverted repeated recomputed analyses" in {
     val f = InvertedAnalysisFixture
-    val targets: Seq[Class[Phase]] = Seq(classOf[f.A], classOf[f.B], classOf[f.C])
-      .map(_.asInstanceOf[Class[Phase]])
-    val order: Seq[Class[Phase]] =
+    val targets = Seq(classOf[f.A], classOf[f.B], classOf[f.C])
+    val order =
       Seq( classOf[f.Analysis],
            classOf[f.C],
            classOf[f.Analysis],
            classOf[f.B],
            classOf[f.Analysis],
            classOf[f.A])
-        .map(_.asInstanceOf[Class[Phase]])
     val pm = new PhaseManager(targets)
 
     writeGraphviz(pm, "test_run_dir/PhaseManagerSpec/InvertedRepeatedAnalysis")
 
-    pm.flattenedTransformOrder.map(_.asClass) should be (order)
+    pm.flattenedTransformOrder.map(_.getClass) should be (order)
   }
 
   /** This test shows how the dependents member can be used to run one transform before another. */
@@ -450,35 +443,31 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
     val f = DependentsFixture
 
     info("without the custom transform it runs: First -> Second")
-    val pm = new PhaseManager(Seq(classOf[f.Second]).map(_.asInstanceOf[Class[Phase]]))
-    val orderNoCustom: Seq[Class[Phase]] = Seq(classOf[f.First], classOf[f.Second])
-      .map(_.asInstanceOf[Class[Phase]])
-    pm.flattenedTransformOrder.map(_.asClass) should be (orderNoCustom)
+    val pm = new PhaseManager(Seq(classOf[f.Second]))
+    val orderNoCustom = Seq(classOf[f.First], classOf[f.Second])
+    pm.flattenedTransformOrder.map(_.getClass) should be (orderNoCustom)
 
     info("with the custom transform it runs:    First -> Custom -> Second")
-    val pmCustom = new PhaseManager(Seq(classOf[f.Custom], classOf[f.Second]).map(_.asInstanceOf[Class[Phase]]))
-    val orderCustom: Seq[Class[Phase]] = Seq(classOf[f.First], classOf[f.Custom], classOf[f.Second])
-      .map(_.asInstanceOf[Class[Phase]])
+    val pmCustom = new PhaseManager(Seq(classOf[f.Custom], classOf[f.Second]))
+    val orderCustom = Seq(classOf[f.First], classOf[f.Custom], classOf[f.Second])
 
     writeGraphviz(pmCustom, "test_run_dir/PhaseManagerSpec/SingleDependent")
 
-    pmCustom.flattenedTransformOrder.map(_.asClass) should be (orderCustom)
+    pmCustom.flattenedTransformOrder.map(_.getClass) should be (orderCustom)
   }
 
   it should "handle chained invalidation" in {
     val f = ChainedInvalidationFixture
 
-    val targets: Seq[Class[Phase]] = Seq(classOf[f.A], classOf[f.E])
-      .map(_.asInstanceOf[Class[Phase]])
-    val current: Seq[Class[Phase]] = Seq(classOf[f.B], classOf[f.C], classOf[f.D]).map(_.asInstanceOf[Class[Phase]])
+    val targets = Seq(classOf[f.A], classOf[f.E])
+    val current = Seq(classOf[f.B], classOf[f.C], classOf[f.D])
 
     val pm = new PhaseManager(targets, current)
-    val order: Seq[Class[Phase]] = Seq( classOf[f.A], classOf[f.B], classOf[f.C], classOf[f.D], classOf[f.E] )
-      .map(_.asInstanceOf[Class[Phase]])
+    val order = Seq( classOf[f.A], classOf[f.B], classOf[f.C], classOf[f.D], classOf[f.E] )
 
     writeGraphviz(pm, "test_run_dir/PhaseManagerSpec/ChainedInvalidate")
 
-    pm.flattenedTransformOrder.map(_.asClass) should be (order)
+    pm.flattenedTransformOrder.map(_.getClass) should be (order)
   }
 
   it should "maintain the order of input targets" in {
@@ -501,7 +490,7 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
            classOf[f.B12],
            classOf[f.B13],
            classOf[f.B14],
-           classOf[f.B15] ).asInstanceOf[Seq[Class[Phase]]]
+           classOf[f.B15] )
     /** A sequence of custom transforms that should all run after B6 and before B7. This exercises correct ordering of the
       * prerequisiteGraph and dependentsGraph.
       */
@@ -521,7 +510,7 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
            classOf[f.B6_12],
            classOf[f.B6_13],
            classOf[f.B6_14],
-           classOf[f.B6_15] ).asInstanceOf[Seq[Class[Phase]]]
+           classOf[f.B6_15] )
     /** A sequence of transforms that are invalidated by B0 and only define dependents on B8. This exercises the ordering
       * defined by "otherDependents".
       */
@@ -541,7 +530,7 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
            classOf[f.B8_12],
            classOf[f.B8_13],
            classOf[f.B8_14],
-           classOf[f.B8_15] ).asInstanceOf[Seq[Class[Phase]]]
+           classOf[f.B8_15] )
 
     /** The resulting order: B0--B6, B6_0--B6_B15, B7, B8_0--B8_15, B8--B15 */
     val expected = targets.slice(0, 7) ++ prerequisiteTargets ++ Some(targets(7)) ++ current ++ targets.drop(8)
@@ -550,7 +539,7 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
 
     writeGraphviz(pm, "test_run_dir/PhaseManagerSpec/DeterministicOrder")
 
-    pm.flattenedTransformOrder.map(_.asClass) should be (expected)
+    pm.flattenedTransformOrder.map(_.getClass) should be (expected)
   }
 
 }


### PR DESCRIPTION
This changes `prerequisites` and `dependents` specification in the Dependency API to use `Class[_ <: A]` instead of `Class[A]`.

This avoids the need for a ton of janky `.asInstanceOf[Class[A]]` nonsense later. This should have been a mammoth code smell to me and I'm not sure why this didn't occur to me earlier...