### PR TITLE
Dependency API 2 (take 3)

### DIFF
--- a/src/main/scala/firrtl/Driver.scala
+++ b/src/main/scala/firrtl/Driver.scala
@@ -12,7 +12,7 @@ import firrtl.transforms._
 import firrtl.Utils.throwInternalError
 import firrtl.stage.{FirrtlExecutionResultView, FirrtlStage}
 import firrtl.stage.phases.DriverCompatibility
-import firrtl.options.{StageUtils, Phase, Viewer}
+import firrtl.options.{Dependency, Phase, PhaseManager, StageUtils, Viewer}
 import firrtl.options.phases.DeletedWrapper
 
 
@@ -210,13 +210,17 @@ object Driver {
 
     val annos = optionsManager.firrtlOptions.toAnnotations ++ optionsManager.commonOptions.toAnnotations
 
-    val phases: Seq[Phase] =
-      Seq( new DriverCompatibility.AddImplicitAnnotationFile,
-           new DriverCompatibility.AddImplicitFirrtlFile,
-           new DriverCompatibility.AddImplicitOutputFile,
-           new DriverCompatibility.AddImplicitEmitter,
-           new FirrtlStage )
+    val phases: Seq[Phase] = {
+      import DriverCompatibility._
+      new PhaseManager(
+        Seq( Dependency[AddImplicitFirrtlFile],
+             Dependency[AddImplicitAnnotationFile],
+             Dependency[AddImplicitOutputFile],
+             Dependency[AddImplicitEmitter],
+             Dependency[FirrtlStage] ))
+        .transformOrder
         .map(DeletedWrapper(_))
+    }
 
     val annosx = try {
       phases.foldLeft(annos)( (a, p) => p.transform(a) )
@@ -257,4 +261,3 @@ object Driver {
     execute(args)
   }
 }
-

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -4,53 +4,39 @@ package firrtl
 
 import firrtl.transforms.IdentityTransform
 import firrtl.options.StageUtils
+import firrtl.stage.{Forms, TransformManager}
 
+@deprecated("Use a TransformManager or some other Stage/Phase class. Will be removed in 1.3.", "1.2")
 sealed abstract class CoreTransform extends SeqTransform
 
 /** This transforms "CHIRRTL", the chisel3 IR, to "Firrtl". Note the resulting
   * circuit has only IR nodes, not WIR.
   */
+@deprecated("Use a TransformManager to handle lowering. Will be removed in 1.3.", "1.2")
 class ChirrtlToHighFirrtl extends CoreTransform {
   def inputForm = ChirrtlForm
   def outputForm = HighForm
-  def transforms = Seq(
-    passes.CheckChirrtl,
-    passes.CInferTypes,
-    passes.CInferMDir,
-    passes.RemoveCHIRRTL)
+  def transforms = new TransformManager(Forms.MinimalHighForm, Forms.ChirrtlForm).flattenedTransformOrder
 }
 
 /** Converts from the bare intermediate representation (ir.scala)
   * to a working representation (WIR.scala)
   */
+@deprecated("Use a TransformManager to handle lowering. Will be removed in 1.3.", "1.2")
 class IRToWorkingIR extends CoreTransform {
   def inputForm = HighForm
   def outputForm = HighForm
-  def transforms = Seq(passes.ToWorkingIR)
+  def transforms = new TransformManager(Forms.WorkingIR, Forms.MinimalHighForm).flattenedTransformOrder
 }
 
 /** Resolves types, kinds, and flows, and checks the circuit legality.
   * Operates on working IR nodes and high Firrtl.
   */
+@deprecated("Use a TransformManager to handle lowering. Will be removed in 1.3.", "1.2")
 class ResolveAndCheck extends CoreTransform {
   def inputForm = HighForm
   def outputForm = HighForm
-  def transforms = Seq(
-    passes.CheckHighForm,
-    passes.ResolveKinds,
-    passes.InferTypes,
-    passes.CheckTypes,
-    passes.Uniquify,
-    passes.ResolveKinds,
-    passes.InferTypes,
-    passes.ResolveFlows,
-    passes.CheckFlows,
-    new passes.InferBinaryPoints(),
-    new passes.TrimIntervals(),
-    new passes.InferWidths,
-    passes.CheckWidths,
-    new firrtl.transforms.InferResets,
-    passes.CheckTypes)
+  def transforms = new TransformManager(Forms.Resolved, Forms.WorkingIR).flattenedTransformOrder
 }
 
 /** Expands aggregate connects, removes dynamic accesses, and when
@@ -58,78 +44,40 @@ class ResolveAndCheck extends CoreTransform {
   * well-formed graph.
   * Operates on working IR nodes.
   */
+@deprecated("Use a TransformManager to handle lowering. Will be removed in 1.3.", "1.2")
 class HighFirrtlToMiddleFirrtl extends CoreTransform {
   def inputForm = HighForm
   def outputForm = MidForm
-  def transforms = Seq(
-    passes.PullMuxes,
-    passes.ReplaceAccesses,
-    passes.ExpandConnects,
-    passes.RemoveAccesses,
-    passes.Uniquify,
-    passes.ExpandWhens,
-    passes.CheckInitialization,
-    passes.ResolveKinds,
-    passes.InferTypes,
-    passes.CheckTypes,
-    passes.ResolveFlows,
-    new passes.InferWidths,
-    passes.CheckWidths,
-    new passes.RemoveIntervals(),
-    passes.ConvertFixedToSInt,
-    passes.ZeroWidth,
-    passes.InferTypes)
+  def transforms = new TransformManager(Forms.MidForm, Forms.Deduped).flattenedTransformOrder
 }
 
 /** Expands all aggregate types into many ground-typed components. Must
   * accept a well-formed graph of only middle Firrtl features.
   * Operates on working IR nodes.
   */
+@deprecated("Use a TransformManager to handle lowering. Will be removed in 1.3.", "1.2")
 class MiddleFirrtlToLowFirrtl extends CoreTransform {
   def inputForm = MidForm
   def outputForm = LowForm
-  def transforms = Seq(
-    passes.LowerTypes,
-    passes.ResolveKinds,
-    passes.InferTypes,
-    passes.ResolveFlows,
-    new passes.InferWidths,
-    passes.Legalize,
-    new firrtl.transforms.RemoveReset,
-    new firrtl.transforms.CheckCombLoops,
-    new checks.CheckResets,
-    new firrtl.transforms.RemoveWires)
+  def transforms = new TransformManager(Forms.LowForm, Forms.MidForm).flattenedTransformOrder
 }
 
 /** Runs a series of optimization passes on LowFirrtl
   * @note This is currently required for correct Verilog emission
   * TODO Fix the above note
   */
+@deprecated("Use a TransformManager to handle lowering. Will be removed in 1.3.", "1.2")
 class LowFirrtlOptimization extends CoreTransform {
   def inputForm = LowForm
   def outputForm = LowForm
-  def transforms = Seq(
-    passes.RemoveValidIf,
-    new firrtl.transforms.ConstantPropagation,
-    passes.PadWidths,
-    new firrtl.transforms.ConstantPropagation,
-    passes.Legalize,
-    passes.memlib.VerilogMemDelays, // TODO move to Verilog emitter
-    new firrtl.transforms.ConstantPropagation,
-    passes.SplitExpressions,
-    new firrtl.transforms.CombineCats,
-    passes.CommonSubexpressionElimination,
-    new firrtl.transforms.DeadCodeElimination)
+  def transforms = new TransformManager(Forms.LowFormOptimized, Forms.LowForm).flattenedTransformOrder
 }
 /** Runs runs only the optimization passes needed for Verilog emission */
+@deprecated("Use a TransformManager to handle lowering. Will be removed in 1.3.", "1.2")
 class MinimumLowFirrtlOptimization extends CoreTransform {
   def inputForm = LowForm
   def outputForm = LowForm
-  def transforms = Seq(
-    passes.RemoveValidIf,
-    passes.Legalize,
-    passes.memlib.VerilogMemDelays, // TODO move to Verilog emitter
-    passes.SplitExpressions)
+  def transforms = new TransformManager(Forms.LowFormMinimumOptimized, Forms.LowForm).flattenedTransformOrder
 }
 
 

--- a/src/main/scala/firrtl/annotations/transforms/EliminateTargetPaths.scala
+++ b/src/main/scala/firrtl/annotations/transforms/EliminateTargetPaths.scala
@@ -122,7 +122,7 @@ class EliminateTargetPaths extends Transform {
     (cir.copy(modules = finalModuleList), renameMap)
   }
 
-  override protected def execute(state: CircuitState): CircuitState = {
+  override def execute(state: CircuitState): CircuitState = {
 
     val (annotations, annotationsx) = state.annotations.partition{
       case a: ResolvePaths => true

--- a/src/main/scala/firrtl/checks/CheckResets.scala
+++ b/src/main/scala/firrtl/checks/CheckResets.scala
@@ -3,6 +3,7 @@
 package firrtl.checks
 
 import firrtl._
+import firrtl.options.{Dependency, PreservesAll}
 import firrtl.passes.{Errors, PassException}
 import firrtl.ir._
 import firrtl.traversals.Foreachers._
@@ -25,9 +26,18 @@ object CheckResets {
 // Must run after ExpandWhens
 // Requires
 //   - static single connections of ground types
-class CheckResets extends Transform {
+class CheckResets extends Transform with PreservesAll[Transform] {
   def inputForm: CircuitForm = MidForm
   def outputForm: CircuitForm = MidForm
+
+  override val prerequisites =
+    Seq( Dependency(passes.LowerTypes),
+         Dependency(passes.Legalize),
+         Dependency(firrtl.transforms.RemoveReset) ) ++ firrtl.stage.Forms.MidForm
+
+  override val optionalPrerequisites = Seq(Dependency[firrtl.transforms.CheckCombLoops])
+
+  override val dependents = Seq.empty
 
   import CheckResets._
 
@@ -72,4 +82,3 @@ class CheckResets extends Transform {
     state
   }
 }
-

--- a/src/main/scala/firrtl/passes/CheckChirrtl.scala
+++ b/src/main/scala/firrtl/passes/CheckChirrtl.scala
@@ -2,8 +2,16 @@
 
 package firrtl.passes
 
+import firrtl.Transform
 import firrtl.ir._
+import firrtl.options.{Dependency, PreservesAll}
 
-object CheckChirrtl extends Pass with CheckHighFormLike {
+object CheckChirrtl extends Pass with CheckHighFormLike with PreservesAll[Transform] {
+
+  override val dependents = firrtl.stage.Forms.ChirrtlForm ++
+    Seq( Dependency(CInferTypes),
+         Dependency(CInferMDir),
+         Dependency(RemoveCHIRRTL) )
+
   def errorOnChirrtl(info: Info, mname: String, s: Statement): Option[PassException] = None
 }

--- a/src/main/scala/firrtl/passes/CheckInitialization.scala
+++ b/src/main/scala/firrtl/passes/CheckInitialization.scala
@@ -6,6 +6,7 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.traversals.Foreachers._
+import firrtl.options.PreservesAll
 
 import annotation.tailrec
 
@@ -14,7 +15,10 @@ import annotation.tailrec
   * @note This pass looks for [[firrtl.WVoid]]s left behind by [[ExpandWhens]]
   * @note Assumes single connection (ie. no last connect semantics)
   */
-object CheckInitialization extends Pass {
+object CheckInitialization extends Pass with PreservesAll[Transform] {
+
+  override val prerequisites = firrtl.stage.Forms.Resolved
+
   private case class VoidExpr(stmt: Statement, voidDeps: Seq[Expression])
 
   class RefNotInitializedException(info: Info, mname: String, name: String, trace: Seq[Statement]) extends PassException(

--- a/src/main/scala/firrtl/passes/CheckWidths.scala
+++ b/src/main/scala/firrtl/passes/CheckWidths.scala
@@ -9,8 +9,14 @@ import firrtl.traversals.Foreachers._
 import firrtl.Utils._
 import firrtl.constraint.IsKnown
 import firrtl.annotations.{CircuitTarget, ModuleTarget, Target, TargetToken}
+import firrtl.options.{Dependency, PreservesAll}
 
-object CheckWidths extends Pass {
+object CheckWidths extends Pass with PreservesAll[Transform] {
+
+  override val prerequisites = Dependency[passes.InferWidths] +: firrtl.stage.Forms.WorkingIR
+
+  override val dependents = Seq(Dependency[transforms.InferResets])
+
   /** The maximum allowed width for any circuit element */
   val MaxWidth = 1000000
   val DshlMaxWidth = getUIntWidth(MaxWidth)

--- a/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
+++ b/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
@@ -5,9 +5,21 @@ package firrtl.passes
 import firrtl._
 import firrtl.ir._
 import firrtl.Mappers._
+import firrtl.options.{Dependency, PreservesAll}
 
+object CommonSubexpressionElimination extends Pass with PreservesAll[Transform] {
 
-object CommonSubexpressionElimination extends Pass {
+  override val prerequisites = firrtl.stage.Forms.LowForm ++
+    Seq( Dependency(firrtl.passes.RemoveValidIf),
+         Dependency[firrtl.transforms.ConstantPropagation],
+         Dependency(firrtl.passes.memlib.VerilogMemDelays),
+         Dependency(firrtl.passes.SplitExpressions),
+         Dependency[firrtl.transforms.CombineCats] )
+
+  override val dependents =
+    Seq( Dependency[SystemVerilogEmitter],
+         Dependency[VerilogEmitter] )
+
   private def cse(s: Statement): Statement = {
     val expressions = collection.mutable.HashMap[MemoizedHash[Expression], String]()
     val nodes = collection.mutable.HashMap[String, Expression]()

--- a/src/main/scala/firrtl/passes/InferTypes.scala
+++ b/src/main/scala/firrtl/passes/InferTypes.scala
@@ -6,8 +6,12 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
+import firrtl.options.{Dependency, PreservesAll}
 
-object InferTypes extends Pass {
+object InferTypes extends Pass with PreservesAll[Transform] {
+
+  override val prerequisites = Dependency(ResolveKinds) +: firrtl.stage.Forms.WorkingIR
+
   type TypeMap = collection.mutable.LinkedHashMap[String, Type]
 
   def run(c: Circuit): Circuit = {
@@ -79,12 +83,15 @@ object InferTypes extends Pass {
       val types = new TypeMap
       m map infer_types_p(types) map infer_types_s(types)
     }
- 
+
     c copy (modules = c.modules map infer_types)
   }
 }
 
-object CInferTypes extends Pass {
+object CInferTypes extends Pass with PreservesAll[Transform] {
+
+  override val prerequisites = firrtl.stage.Forms.ChirrtlForm
+
   type TypeMap = collection.mutable.LinkedHashMap[String, Type]
 
   def run(c: Circuit): Circuit = {
@@ -133,12 +140,12 @@ object CInferTypes extends Pass {
       types(p.name) = p.tpe
       p
     }
- 
+
     def infer_types(m: DefModule): DefModule = {
       val types = new TypeMap
       m map infer_types_p(types) map infer_types_s(types)
     }
-   
+
     c copy (modules = c.modules map infer_types)
   }
 }

--- a/src/main/scala/firrtl/passes/LowerTypes.scala
+++ b/src/main/scala/firrtl/passes/LowerTypes.scala
@@ -26,6 +26,15 @@ object LowerTypes extends Transform {
   def inputForm = UnknownForm
   def outputForm = UnknownForm
 
+  override val prerequisites = firrtl.stage.Forms.MidForm
+
+  override val dependents = Seq.empty
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case ResolveKinds | InferTypes | ResolveFlows | _: InferWidths => true
+    case _ => false
+  }
+
   /** Delimiter used in lowering names */
   val delim = "_"
   /** Expands a chain of referential [[firrtl.ir.Expression]]s into the equivalent lowered name

--- a/src/main/scala/firrtl/passes/RemoveAccesses.scala
+++ b/src/main/scala/firrtl/passes/RemoveAccesses.scala
@@ -2,18 +2,30 @@
 
 package firrtl.passes
 
-import firrtl.{WRef, WSubAccess, WSubIndex, WSubField, Namespace}
+import firrtl.{Namespace, Transform, WRef, WSubAccess, WSubIndex, WSubField}
 import firrtl.PrimOps.{And, Eq}
 import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.Utils._
 import firrtl.WrappedExpression._
-import scala.collection.mutable
+import firrtl.options.Dependency
 
+import scala.collection.mutable
 
 /** Removes all [[firrtl.WSubAccess]] from circuit
   */
-class RemoveAccesses extends Pass {
+object RemoveAccesses extends Pass {
+
+  override val prerequisites =
+    Seq( Dependency(PullMuxes),
+         Dependency(ReplaceAccesses),
+         Dependency(ExpandConnects) ) ++ firrtl.stage.Forms.Deduped
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case Uniquify => true
+    case _        => false
+  }
+
   private def AND(e1: Expression, e2: Expression) =
     if(e1 == one) e2
     else if(e2 == one) e1
@@ -164,16 +176,5 @@ class RemoveAccesses extends Pass {
       case m: ExtModule => m
       case m: Module => remove_m(m)
     })
-  }
-}
-
-object RemoveAccesses extends Pass {
-  def apply: Pass = {
-    new RemoveAccesses()
-  }
-
-  def run(c: Circuit): Circuit = {
-    val t = new RemoveAccesses
-    t.run(c)
   }
 }

--- a/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
+++ b/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
@@ -8,12 +8,18 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
+import firrtl.options.{Dependency, PreservesAll}
 
 case class MPort(name: String, clk: Expression)
 case class MPorts(readers: ArrayBuffer[MPort], writers: ArrayBuffer[MPort], readwriters: ArrayBuffer[MPort])
 case class DataRef(exp: Expression, male: String, female: String, mask: String, rdwrite: Boolean)
 
-object RemoveCHIRRTL extends Transform {
+object RemoveCHIRRTL extends Transform with PreservesAll[Transform] {
+
+  override val prerequisites = firrtl.stage.Forms.ChirrtlForm ++
+    Seq( Dependency(passes.CInferTypes),
+         Dependency(passes.CInferMDir) )
+
   def inputForm: CircuitForm = UnknownForm
   def outputForm: CircuitForm = UnknownForm
   val ut = UnknownType

--- a/src/main/scala/firrtl/passes/RemoveIntervals.scala
+++ b/src/main/scala/firrtl/passes/RemoveIntervals.scala
@@ -8,6 +8,7 @@ import firrtl._
 import firrtl.Mappers._
 import Implicits.{bigint2WInt}
 import firrtl.constraint.IsKnown
+import firrtl.options.{Dependency, PreservesAll}
 
 import scala.math.BigDecimal.RoundingMode._
 
@@ -35,7 +36,14 @@ class WrapWithRemainder(info: Info, mname: String, wrap: DoPrim)
   *      c. replace with SIntType
   * 3) Run InferTypes
   */
-class RemoveIntervals extends Pass {
+class RemoveIntervals extends Pass with PreservesAll[Transform] {
+
+  override val prerequisites: Seq[Dependency[Transform]] =
+    Seq( Dependency(PullMuxes),
+         Dependency(ReplaceAccesses),
+         Dependency(ExpandConnects),
+         Dependency(RemoveAccesses),
+         Dependency[ExpandWhensAndCheck] ) ++ firrtl.stage.Forms.Deduped
 
   def run(c: Circuit): Circuit = {
     val alignedCircuit = c

--- a/src/main/scala/firrtl/passes/RemoveValidIf.scala
+++ b/src/main/scala/firrtl/passes/RemoveValidIf.scala
@@ -2,9 +2,11 @@
 
 package firrtl
 package passes
+
 import firrtl.Mappers._
 import firrtl.ir._
 import Utils.throwInternalError
+import firrtl.options.Dependency
 
 /** Remove [[firrtl.ir.ValidIf ValidIf]] and replace [[firrtl.ir.IsInvalid IsInvalid]] with a connection to zero */
 object RemoveValidIf extends Pass {
@@ -25,6 +27,17 @@ object RemoveValidIf extends Pass {
     case _: FixedType => FixedZero
     case AsyncResetType => AsyncZero
     case other => throwInternalError(s"Unexpected type $other")
+  }
+
+  override val prerequisites = firrtl.stage.Forms.LowForm
+
+  override val dependents =
+    Seq( Dependency[SystemVerilogEmitter],
+         Dependency[VerilogEmitter] )
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case Legalize | _: firrtl.transforms.ConstantPropagation => true
+    case _ => false
   }
 
   // Recursive. Removes ValidIfs

--- a/src/main/scala/firrtl/passes/ReplaceAccesses.scala
+++ b/src/main/scala/firrtl/passes/ReplaceAccesses.scala
@@ -2,22 +2,26 @@
 
 package firrtl.passes
 
+import firrtl.Transform
 import firrtl.ir._
 import firrtl.{WSubAccess, WSubIndex}
 import firrtl.Mappers._
-
+import firrtl.options.{Dependency, PreservesAll}
 
 /** Replaces constant [[firrtl.WSubAccess]] with [[firrtl.WSubIndex]]
   * TODO Fold in to High Firrtl Const Prop
   */
-object ReplaceAccesses extends Pass {
+object ReplaceAccesses extends Pass with PreservesAll[Transform] {
+
+  override val prerequisites = firrtl.stage.Forms.Deduped :+ Dependency(PullMuxes)
+
   def run(c: Circuit): Circuit = {
     def onStmt(s: Statement): Statement = s map onStmt map onExp
     def onExp(e: Expression): Expression = e match {
       case WSubAccess(ex, UIntLiteral(value, width), t, g) => WSubIndex(onExp(ex), value.toInt, t, g)
       case _ => e map onExp
     }
-  
+
     c copy (modules = c.modules map (_ map onStmt))
   }
 }

--- a/src/main/scala/firrtl/passes/SplitExpressions.scala
+++ b/src/main/scala/firrtl/passes/SplitExpressions.scala
@@ -3,7 +3,9 @@
 package firrtl
 package passes
 
+import firrtl.{SystemVerilogEmitter, VerilogEmitter}
 import firrtl.ir._
+import firrtl.options.{Dependency, PreservesAll}
 import firrtl.Mappers._
 import firrtl.Utils.{kind, flow, get_info}
 
@@ -12,7 +14,16 @@ import scala.collection.mutable
 
 // Splits compound expressions into simple expressions
 //  and named intermediate nodes
-object SplitExpressions extends Pass {
+object SplitExpressions extends Pass with PreservesAll[Transform] {
+
+  override val prerequisites = firrtl.stage.Forms.LowForm ++
+    Seq( Dependency(firrtl.passes.RemoveValidIf),
+         Dependency(firrtl.passes.memlib.VerilogMemDelays) )
+
+  override val dependents =
+    Seq( Dependency[SystemVerilogEmitter],
+         Dependency[VerilogEmitter] )
+
    private def onModule(m: Module): Module = {
       val namespace = Namespace(m)
       def onStmt(s: Statement): Statement = {

--- a/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
+++ b/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
@@ -7,6 +7,7 @@ import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.PrimOps.{Bits, Rem}
 import firrtl.Utils._
+import firrtl.options.{Dependency, PreservesAll}
 
 import scala.collection.mutable
 
@@ -23,7 +24,20 @@ import scala.collection.mutable
  *  This is technically incorrect firrtl, but allows the verilog emitter
  *  to emit correct verilog without needing to add temporary nodes
  */
-object VerilogModulusCleanup extends Pass {
+object VerilogModulusCleanup extends Pass with PreservesAll[Transform] {
+
+  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
+    Seq( Dependency[firrtl.transforms.BlackBoxSourceHelper],
+         Dependency[firrtl.transforms.FixAddingNegativeLiterals],
+         Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
+         Dependency[firrtl.transforms.InlineBitExtractionsTransform],
+         Dependency[firrtl.transforms.InlineCastsTransform],
+         Dependency[firrtl.transforms.LegalizeClocksTransform],
+         Dependency[firrtl.transforms.FlattenRegUpdate] )
+
+  override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
+
+  override val dependents = Seq.empty
 
   private def onModule(m: Module): Module = {
     val namespace = Namespace(m)

--- a/src/main/scala/firrtl/passes/ZeroWidth.scala
+++ b/src/main/scala/firrtl/passes/ZeroWidth.scala
@@ -6,8 +6,24 @@ import firrtl.PrimOps._
 import firrtl.ir._
 import firrtl._
 import firrtl.Mappers._
+import firrtl.options.Dependency
 
 object ZeroWidth extends Transform {
+
+  override val prerequisites =
+    Seq( Dependency(PullMuxes),
+         Dependency(ReplaceAccesses),
+         Dependency(ExpandConnects),
+         Dependency(RemoveAccesses),
+         Dependency(Uniquify),
+         Dependency[ExpandWhensAndCheck],
+         Dependency(ConvertFixedToSInt) ) ++ firrtl.stage.Forms.Deduped
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case InferTypes => true
+    case _          => false
+  }
+
   def inputForm: CircuitForm = UnknownForm
   def outputForm: CircuitForm = UnknownForm
 

--- a/src/main/scala/firrtl/stage/Forms.scala
+++ b/src/main/scala/firrtl/stage/Forms.scala
@@ -1,0 +1,94 @@
+// See LICENSE for license details.
+
+package firrtl.stage
+
+import firrtl._
+import firrtl.options.Dependency
+import firrtl.stage.TransformManager.TransformDependency
+
+/*
+ * - InferWidths should have InferTypes split out
+ * - ConvertFixedToSInt should have InferTypes split out
+ * - Move InferTypes out of ZeroWidth
+ */
+
+object Forms {
+
+  lazy val ChirrtlForm: Seq[TransformDependency] = Seq.empty
+
+  lazy val MinimalHighForm: Seq[TransformDependency] = ChirrtlForm ++
+    Seq( Dependency(passes.CheckChirrtl),
+         Dependency(passes.CInferTypes),
+         Dependency(passes.CInferMDir),
+         Dependency(passes.RemoveCHIRRTL) )
+
+  lazy val WorkingIR: Seq[TransformDependency] = MinimalHighForm :+ Dependency(passes.ToWorkingIR)
+
+  lazy val Resolved: Seq[TransformDependency] = WorkingIR ++
+    Seq( Dependency(passes.CheckHighForm),
+         Dependency(passes.ResolveKinds),
+         Dependency(passes.InferTypes),
+         Dependency(passes.CheckTypes),
+         Dependency(passes.Uniquify),
+         Dependency(passes.ResolveFlows),
+         Dependency(passes.CheckFlows),
+         Dependency[passes.InferBinaryPoints],
+         Dependency[passes.TrimIntervals],
+         Dependency[passes.InferWidths],
+         Dependency(passes.CheckWidths),
+         Dependency[firrtl.transforms.InferResets] )
+
+  lazy val Deduped: Seq[TransformDependency] = Resolved :+ Dependency[firrtl.transforms.DedupModules]
+
+  lazy val HighForm: Seq[TransformDependency] = ChirrtlForm ++
+    MinimalHighForm ++
+    WorkingIR ++
+    Resolved ++
+    Deduped
+
+  lazy val MidForm: Seq[TransformDependency] = HighForm ++
+    Seq( Dependency(passes.PullMuxes),
+         Dependency(passes.ReplaceAccesses),
+         Dependency(passes.ExpandConnects),
+         Dependency(passes.RemoveAccesses),
+         Dependency[passes.ExpandWhensAndCheck],
+         Dependency[passes.RemoveIntervals],
+         Dependency(passes.ConvertFixedToSInt),
+         Dependency(passes.ZeroWidth) )
+
+  lazy val LowForm: Seq[TransformDependency] = MidForm ++
+    Seq( Dependency(passes.LowerTypes),
+         Dependency(passes.Legalize),
+         Dependency(firrtl.transforms.RemoveReset),
+         Dependency[firrtl.transforms.CheckCombLoops],
+         Dependency[checks.CheckResets],
+         Dependency[firrtl.transforms.RemoveWires] )
+
+  lazy val LowFormMinimumOptimized: Seq[TransformDependency] = LowForm ++
+    Seq( Dependency(passes.RemoveValidIf),
+         Dependency(passes.memlib.VerilogMemDelays),
+         Dependency(passes.SplitExpressions) )
+
+  lazy val LowFormOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
+    Seq( Dependency[firrtl.transforms.ConstantPropagation],
+         Dependency(passes.PadWidths),
+         Dependency[firrtl.transforms.CombineCats],
+         Dependency(passes.CommonSubexpressionElimination),
+         Dependency[firrtl.transforms.DeadCodeElimination] )
+
+  lazy val VerilogMinimumOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
+    Seq( Dependency[firrtl.transforms.BlackBoxSourceHelper],
+         Dependency[firrtl.transforms.FixAddingNegativeLiterals],
+         Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
+         Dependency[firrtl.transforms.InlineBitExtractionsTransform],
+         Dependency[firrtl.transforms.InlineCastsTransform],
+         Dependency[firrtl.transforms.LegalizeClocksTransform],
+         Dependency[firrtl.transforms.FlattenRegUpdate],
+         Dependency(passes.VerilogModulusCleanup),
+         Dependency[firrtl.transforms.VerilogRename],
+         Dependency(passes.VerilogPrep),
+         Dependency[firrtl.AddDescriptionNodes] )
+
+  lazy val VerilogOptimized: Seq[TransformDependency] = LowFormOptimized ++ VerilogMinimumOptimized
+
+}

--- a/src/main/scala/firrtl/stage/TransformManager.scala
+++ b/src/main/scala/firrtl/stage/TransformManager.scala
@@ -1,0 +1,34 @@
+// See LICENSE for license details.
+
+package firrtl.stage
+
+import firrtl.{CircuitForm, CircuitState, Transform, UnknownForm}
+import firrtl.options.{Dependency, DependencyManager}
+
+/** A [[Transform]] that ensures some other [[Transform]]s and their prerequisites are executed.
+  *
+  * @param targets the transforms you want to run
+  * @param currentState the transforms that have already run
+  * @param knownObjects existing transform objects that have already been constructed
+  */
+class TransformManager(
+  val targets: Seq[TransformManager.TransformDependency],
+  val currentState: Seq[TransformManager.TransformDependency] = Seq.empty,
+  val knownObjects: Set[Transform] = Set.empty) extends Transform with DependencyManager[CircuitState, Transform] {
+
+  override def inputForm: CircuitForm = UnknownForm
+
+  override def outputForm: CircuitForm = UnknownForm
+
+  override def execute(state: CircuitState): CircuitState = transform(state)
+
+  override protected def copy(a: Seq[Dependency[Transform]], b: Seq[Dependency[Transform]], c: Set[Transform]) = new TransformManager(a, b, c)
+
+}
+
+object TransformManager {
+
+  /** The type used to represent dependencies between [[Transform]]s */
+  type TransformDependency = Dependency[Transform]
+
+}

--- a/src/main/scala/firrtl/stage/phases/AddCircuit.scala
+++ b/src/main/scala/firrtl/stage/phases/AddCircuit.scala
@@ -5,7 +5,7 @@ package firrtl.stage.phases
 import firrtl.stage._
 
 import firrtl.{AnnotationSeq, Parser}
-import firrtl.options.{Phase, PhasePrerequisiteException}
+import firrtl.options.{Dependency, Phase, PhasePrerequisiteException, PreservesAll}
 
 /** [[firrtl.options.Phase Phase]] that expands [[FirrtlFileAnnotation]]/[[FirrtlSourceAnnotation]] into
   * [[FirrtlCircuitAnnotation]]s and deletes the originals. This is part of the preprocessing done on an input
@@ -25,7 +25,11 @@ import firrtl.options.{Phase, PhasePrerequisiteException}
   * an [[InfoModeAnnotation]].'''.
   * @define infoModeException firrtl.options.PhasePrerequisiteException if no [[InfoModeAnnotation]] is present
   */
-class AddCircuit extends Phase {
+class AddCircuit extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites = Seq(Dependency[AddDefaults], Dependency[Checks])
+
+  override val dependents = Seq.empty
 
   /** Extract the info mode from an [[AnnotationSeq]] or use the default info mode if no annotation exists
     * @param annotations some annotations

--- a/src/main/scala/firrtl/stage/phases/AddDefaults.scala
+++ b/src/main/scala/firrtl/stage/phases/AddDefaults.scala
@@ -3,14 +3,18 @@
 package firrtl.stage.phases
 
 import firrtl.AnnotationSeq
-import firrtl.options.{Phase, TargetDirAnnotation}
+import firrtl.options.{Phase, PreservesAll, TargetDirAnnotation}
 import firrtl.transforms.BlackBoxTargetDirAnno
 import firrtl.stage.{CompilerAnnotation, InfoModeAnnotation, FirrtlOptions}
 
 /** [[firrtl.options.Phase Phase]] that adds default [[FirrtlOption]] [[firrtl.annotations.Annotation Annotation]]s.
   * This is a part of the preprocessing done by [[FirrtlStage]].
   */
-class AddDefaults extends Phase {
+class AddDefaults extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites = Seq.empty
+
+  override val dependents = Seq.empty
 
   /** Append any missing default annotations to an annotation sequence */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/stage/phases/AddImplicitEmitter.scala
+++ b/src/main/scala/firrtl/stage/phases/AddImplicitEmitter.scala
@@ -4,12 +4,16 @@ package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, EmitAnnotation, EmitCircuitAnnotation}
 import firrtl.stage.{CompilerAnnotation, RunFirrtlTransformAnnotation}
-import firrtl.options.Phase
+import firrtl.options.{Dependency, Phase, PreservesAll}
 
 /** [[firrtl.options.Phase Phase]] that adds a [[firrtl.EmitCircuitAnnotation EmitCircuitAnnotation]] derived from a
   * [[firrtl.stage.CompilerAnnotation CompilerAnnotation]] if one does not already exist.
   */
-class AddImplicitEmitter extends Phase {
+class AddImplicitEmitter extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites = Seq(Dependency[AddDefaults])
+
+  override val dependents = Seq.empty
 
   def transform(annos: AnnotationSeq): AnnotationSeq = {
     val emitter = annos.collectFirst{ case a: EmitAnnotation => a }

--- a/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
+++ b/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
@@ -3,22 +3,28 @@
 package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, EmitAllModulesAnnotation}
-import firrtl.options.{Phase, Viewer}
+import firrtl.options.{Dependency, Phase, PreservesAll, Viewer}
 import firrtl.stage.{FirrtlOptions, OutputFileAnnotation}
 
 /** [[firrtl.options.Phase Phase]] that adds an [[OutputFileAnnotation]] if one does not already exist.
   *
   * To determine the [[OutputFileAnnotation]], the following precedence is used. Whichever happens first succeeds:
   *  - Do nothing if an [[OutputFileAnnotation]] or [[EmitAllModulesAnnotation]] exist
-  *  - Use the main in the first discovered [[FirrtlCircuitAnnotation]] (see note below)
+  *  - Use the main in the first discovered [[firrtl.stage.FirrtlCircuitAnnotation FirrtlCircuitAnnotation]] (see note
+  *    below)
   *  - Use "a"
   *
   * The file suffix may or may not be specified, but this may be arbitrarily changed by the [[Emitter]].
   *
-  * @note This [[firrtl.options.Phase Phase]] has a dependency on [[AddCircuit]]. Only a [[FirrtlCircuitAnnotation]]
-  * will be used to implicitly set the [[OutputFileAnnotation]] (not other [[CircuitOption]] subclasses).
+  * @note This [[firrtl.options.Phase Phase]] has a dependency on [[AddCircuit]]. Only a
+  * [[firrtl.stage.FirrtlCircuitAnnotation FirrtlCircuitAnnotation]] will be used to implicitly set the
+  * [[OutputFileAnnotation]] (not other [[firrtl.stage.CircuitOption CircuitOption]] subclasses).
   */
-class AddImplicitOutputFile extends Phase {
+class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites = Seq(Dependency[AddCircuit])
+
+  override val dependents = Seq.empty
 
   /** Add an [[OutputFileAnnotation]] to an [[AnnotationSeq]] */
   def transform(annotations: AnnotationSeq): AnnotationSeq =

--- a/src/main/scala/firrtl/stage/phases/CatchExceptions.scala
+++ b/src/main/scala/firrtl/stage/phases/CatchExceptions.scala
@@ -1,0 +1,37 @@
+// See LICENSE for license details.
+
+package firrtl.stage.phases
+
+import firrtl.{AnnotationSeq, CustomTransformException, FIRRTLException, FirrtlInternalException, FirrtlUserException,
+  Utils}
+import firrtl.options.{DependencyManagerException, Phase, PhaseException, OptionsException}
+import firrtl.passes.{PassException, PassExceptions}
+
+import scala.util.control.ControlThrowable
+
+class CatchExceptions(val underlying: Phase) extends Phase {
+
+  override final val prerequisites = underlying.prerequisites
+  override final val dependents = underlying.dependents
+  override final def invalidates(a: Phase): Boolean = underlying.invalidates(a)
+  override final lazy val name = underlying.name
+
+  override def transform(a: AnnotationSeq): AnnotationSeq = try {
+    underlying.transform(a)
+  } catch {
+    /* Rethrow the exceptions which are expected or due to the runtime environment (out of memory, stack overflow, etc.).
+     * Any UNEXPECTED exceptions should be treated as internal errors. */
+    case p @ (_: ControlThrowable | _: FIRRTLException | _: OptionsException | _: FirrtlUserException
+                | _: FirrtlInternalException | _: PhaseException | _: DependencyManagerException) => throw p
+    case CustomTransformException(cause) => throw cause
+    case e: Exception => Utils.throwInternalError(exception = Some(e))
+  }
+
+}
+
+
+object CatchExceptions {
+
+  def apply(p: Phase): CatchExceptions = new CatchExceptions(p)
+
+}

--- a/src/main/scala/firrtl/stage/phases/Checks.scala
+++ b/src/main/scala/firrtl/stage/phases/Checks.scala
@@ -6,7 +6,7 @@ import firrtl.stage._
 
 import firrtl.{AnnotationSeq, EmitAllModulesAnnotation, EmitCircuitAnnotation}
 import firrtl.annotations.Annotation
-import firrtl.options.{OptionsException, Phase}
+import firrtl.options.{Dependency, OptionsException, Phase, PreservesAll}
 
 /** [[firrtl.options.Phase Phase]] that strictly validates an [[AnnotationSeq]]. The checks applied are intended to be
   * extremeley strict. Nothing is inferred or assumed to take a default value (for default value resolution see
@@ -16,11 +16,15 @@ import firrtl.options.{OptionsException, Phase}
   * certain that other [[firrtl.options.Phase Phase]]s or views will succeed. See [[FirrtlStage]] for a list of
   * [[firrtl.options.Phase Phase]] that commonly run before this.
   */
-class Checks extends Phase {
+class Checks extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites = Seq(Dependency[AddDefaults], Dependency[AddImplicitEmitter])
+
+  override val dependents = Seq.empty
 
   /** Determine if annotations are sane
     *
-    * @param annos a sequence of [[annotation.Annotation]]
+    * @param annos a sequence of [[firrtl.annotations.Annotation Annotation]]
     * @return true if all checks pass
     * @throws firrtl.options.OptionsException if any checks fail
     */

--- a/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
+++ b/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
@@ -8,9 +8,9 @@ import firrtl.{AnnotationSeq, EmitAllModulesAnnotation, EmitCircuitAnnotation, F
 import firrtl.annotations.NoTargetAnnotation
 import firrtl.FileUtils
 import firrtl.proto.FromProto
-import firrtl.options.{InputAnnotationFileAnnotation, OptionsException, Phase,
-  StageOptions, StageUtils}
+import firrtl.options.{InputAnnotationFileAnnotation, OptionsException, Phase, PreservesAll, StageOptions, StageUtils}
 import firrtl.options.Viewer
+import firrtl.options.Dependency
 
 import scopt.OptionParser
 
@@ -63,7 +63,7 @@ object DriverCompatibility {
   /** Indicates that the implicit emitter, derived from a [[CompilerAnnotation]] should be an [[EmitAllModulesAnnotation]]
     * as opposed to an [[EmitCircuitAnnotation]].
     */
-  private [firrtl] case object EmitOneFilePerModuleAnnotation extends NoTargetAnnotation {
+  case object EmitOneFilePerModuleAnnotation extends NoTargetAnnotation {
 
     def addOptions(p: OptionParser[AnnotationSeq]): Unit = p
       .opt[Unit]("split-modules")
@@ -105,10 +105,11 @@ object DriverCompatibility {
     * [[firrtl.options.InputAnnotationFileAnnotation InputAnnotationFileAnnotation]] is present.
     *
     * The implicit annotation file is determined through the following complicated semantics:
-    *   - If an [[InputAnnotationFileAnnotation]] already exists, then nothing is modified
+    *   - If an [[firrtl.options.InputAnnotationFileAnnotation InputAnnotationFileAnnotation]] already exists, then
+    *     nothing is modified
     *   - If the derived topName (the `main` in a [[firrtl.ir.Circuit Circuit]]) is ''discernable'' (see below) and a
     *     file called `topName.anno` (exactly, not `topName.anno.json`) exists, then this will add an
-    *     [[InputAnnotationFileAnnotation]] using that `topName.anno`
+    *     [[firrtl.options.InputAnnotationFileAnnotation InputAnnotationFileAnnotation]] using that `topName.anno`
     *   - If any of this doesn't work, then the the [[AnnotationSeq]] is unmodified
     *
     * The precedence for determining the `topName` is the following (first one wins):
@@ -121,9 +122,14 @@ object DriverCompatibility {
     * @param annos input annotations
     * @return output annotations
     */
-  class AddImplicitAnnotationFile extends Phase {
+  class AddImplicitAnnotationFile extends Phase with PreservesAll[Phase] {
 
-    /** Try to add an [[InputAnnotationFileAnnotation]] implicitly specified by an [[AnnotationSeq]]. */
+    override val prerequisites = Seq(Dependency[AddImplicitFirrtlFile])
+
+    override val dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
+
+    /** Try to add an [[firrtl.options.InputAnnotationFileAnnotation InputAnnotationFileAnnotation]] implicitly specified by
+      * an [[AnnotationSeq]]. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = annotations
       .collectFirst{ case a: InputAnnotationFileAnnotation => a } match {
         case Some(_) => annotations
@@ -155,7 +161,11 @@ object DriverCompatibility {
     * @param annotations input annotations
     * @return
     */
-  class AddImplicitFirrtlFile extends Phase {
+  class AddImplicitFirrtlFile extends Phase with PreservesAll[Phase] {
+
+    override val prerequisites = Seq.empty
+
+    override val dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
 
     /** Try to add a [[FirrtlFileAnnotation]] implicitly specified by an [[AnnotationSeq]]. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {
@@ -174,7 +184,7 @@ object DriverCompatibility {
     }
   }
 
-  /** Adds an [[EmitAnnotation]] for each [[CompilerAnnotation]].
+  /** Adds an [[firrtl.EmitAnnotation EmitAnnotation]] for each [[CompilerAnnotation]].
     *
     * If an [[EmitOneFilePerModuleAnnotation]] exists, then this will add an [[EmitAllModulesAnnotation]]. Otherwise,
     * this adds an [[EmitCircuitAnnotation]]. This replicates old behavior where specifying a compiler automatically
@@ -182,7 +192,11 @@ object DriverCompatibility {
     */
   @deprecated("""AddImplicitEmitter should only be used to build Driver compatibility wrappers. Switch to Stage.""",
               "1.2")
-  class AddImplicitEmitter extends Phase {
+  class AddImplicitEmitter extends Phase with PreservesAll[Phase] {
+
+    override val prerequisites = Seq.empty
+
+    override val dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
 
     /** Add one [[EmitAnnotation]] foreach [[CompilerAnnotation]]. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {
@@ -204,7 +218,11 @@ object DriverCompatibility {
     */
   @deprecated("""AddImplicitOutputFile should only be used to build Driver compatibility wrappers. Switch to Stage.""",
               "1.2")
-  class AddImplicitOutputFile extends Phase {
+  class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
+
+    override val prerequisites = Seq(Dependency[AddImplicitFirrtlFile])
+
+    override val dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
 
     /** Add an [[OutputFileAnnotation]] derived from a [[TopNameAnnotation]] if needed. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
+++ b/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
@@ -3,7 +3,7 @@
 package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, EmittedModuleAnnotation, EmittedCircuitAnnotation}
-import firrtl.options.{Phase, StageOptions, Viewer}
+import firrtl.options.{Phase, PreservesAll, StageOptions, Viewer}
 import firrtl.stage.FirrtlOptions
 
 import java.io.PrintWriter
@@ -24,7 +24,11 @@ import java.io.PrintWriter
   *
   * Any annotations written to files will be deleted.
   */
-class WriteEmitted extends Phase {
+class WriteEmitted extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites = Seq.empty
+
+  override val dependents = Seq.empty
 
   /** Write any [[EmittedAnnotation]]s in an [[AnnotationSeq]] to files. Written [[EmittedAnnotation]]s are deleted. */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/stage/transforms/CatchCustomTransformExceptions.scala
+++ b/src/main/scala/firrtl/stage/transforms/CatchCustomTransformExceptions.scala
@@ -1,0 +1,30 @@
+// See LICENSE for license details.
+
+package firrtl.stage.transforms
+
+import firrtl.{CircuitState, CustomTransformException, Transform}
+
+class CatchCustomTransformExceptions(val underlying: Transform) extends Transform with WrappedTransform {
+
+  override def execute(c: CircuitState): CircuitState = try {
+    underlying.execute(c)
+  } catch {
+    case e: Exception if CatchCustomTransformExceptions.isCustomTransform(trueUnderlying) => throw CustomTransformException(e)
+  }
+
+}
+
+object CatchCustomTransformExceptions {
+
+  private[firrtl] def isCustomTransform(xform: Transform): Boolean = {
+    def getTopPackage(pack: java.lang.Package): java.lang.Package =
+      Package.getPackage(pack.getName.split('.').head)
+    // We use the top package of the Driver to get the top firrtl package
+    Option(xform.getClass.getPackage).map { p =>
+      getTopPackage(p) != firrtl.Driver.getClass.getPackage
+    }.getOrElse(true)
+  }
+
+  def apply(a: Transform): CatchCustomTransformExceptions = new CatchCustomTransformExceptions(a)
+
+}

--- a/src/main/scala/firrtl/stage/transforms/Compiler.scala
+++ b/src/main/scala/firrtl/stage/transforms/Compiler.scala
@@ -1,0 +1,47 @@
+// See LICENSE for license details.
+
+package firrtl.stage.transforms
+
+import firrtl.{CircuitState, Transform, VerilogEmitter}
+import firrtl.options.DependencyManagerUtils.CharSet
+import firrtl.stage.TransformManager
+
+class Compiler(
+  targets: Seq[TransformManager.TransformDependency],
+  currentState: Seq[TransformManager.TransformDependency] = Seq.empty,
+  knownObjects: Set[Transform] = Set.empty) extends TransformManager(targets, currentState, knownObjects) {
+
+  override val wrappers = Seq(
+    (a: Transform) => CatchCustomTransformExceptions(a),
+    (a: Transform) => UpdateAnnotations(a)
+  )
+
+  override def customPrintHandling(
+    tab: String,
+    charSet: CharSet,
+    size: Int): Option[PartialFunction[(Transform, Int), Seq[String]]] = {
+
+    val (l, n, c) = (charSet.lastNode, charSet.notLastNode, charSet.continuation)
+    val last = size - 1
+
+    val f: PartialFunction[(Transform, Int), Seq[String]] = {
+      {
+        case (a: VerilogEmitter, `last`) =>
+          val firstTransforms = a.transforms.dropRight(1)
+          val lastTransform = a.transforms.last
+          Seq(s"$tab$l ${a.name}") ++
+            firstTransforms.map(t => s"""$tab${" " * c.size} $n ${t.name}""") :+
+            s"""$tab${" " * c.size} $l ${lastTransform.name}"""
+        case (a: VerilogEmitter, _) =>
+          val firstTransforms = a.transforms.dropRight(1)
+          val lastTransform = a.transforms.last
+          Seq(s"$tab$n ${a.name}") ++
+            firstTransforms.map(t => s"""$tab$c $n ${t.name}""") :+
+            s"""$tab$c $l ${lastTransform.name}"""
+      }
+    }
+
+    Some(f)
+  }
+
+}

--- a/src/main/scala/firrtl/stage/transforms/TrackTransforms.scala
+++ b/src/main/scala/firrtl/stage/transforms/TrackTransforms.scala
@@ -1,0 +1,69 @@
+// See LICENSE for license details.
+
+package firrtl.stage.transforms
+
+import firrtl.{AnnotationSeq, CircuitState, Transform}
+import firrtl.annotations.NoTargetAnnotation
+import firrtl.options.{Dependency, DependencyManagerException}
+
+case class TransformHistoryAnnotation(history: Seq[Transform], state: Set[Transform]) extends NoTargetAnnotation {
+
+  def add(transform: Transform,
+          invalidates: (Transform) => Boolean = (a: Transform) => false): TransformHistoryAnnotation =
+    this.copy(
+      history = transform +: this.history,
+      state = (this.state + transform).filterNot(invalidates)
+    )
+
+}
+
+object TransformHistoryAnnotation {
+
+  def apply(transform: Transform): TransformHistoryAnnotation = TransformHistoryAnnotation(
+    history = Seq(transform),
+    state = Set(transform)
+  )
+
+}
+
+class TrackTransforms(val underlying: Transform) extends Transform with WrappedTransform {
+
+  private def updateState(annotations: AnnotationSeq): AnnotationSeq = {
+    var foundAnnotation = false
+    val annotationsx = annotations.map {
+      case x: TransformHistoryAnnotation =>
+        foundAnnotation = true
+        x.add(trueUnderlying)
+      case x => x
+    }
+    if (!foundAnnotation) {
+      TransformHistoryAnnotation(trueUnderlying) +: annotationsx
+    } else {
+      annotationsx
+    }
+  }
+
+  override def execute(c: CircuitState): CircuitState = {
+    val state = c.annotations
+      .collectFirst{ case TransformHistoryAnnotation(_, state) => state }
+      .getOrElse(Set.empty[Transform])
+      .map(Dependency.fromTransform(_))
+
+    if (!trueUnderlying.prerequisites.toSet.subsetOf(state)) {
+      throw new DependencyManagerException(
+        s"""|Tried to execute Transform '$trueUnderlying' for which run-time prerequisites were not satisfied:
+            |  state: ${state.mkString("\n    -", "\n    -", "")}
+            |  prerequisites: ${trueUnderlying.prerequisites.mkString("\n    -", "\n    -", "")}""".stripMargin)
+    }
+
+    val out = underlying.execute(c)
+    out.copy(annotations = updateState(out.annotations))
+  }
+
+}
+
+object TrackTransforms {
+
+  def apply(a: Transform): Transform = new TrackTransforms(a)
+
+}

--- a/src/main/scala/firrtl/stage/transforms/UpdateAnnotations.scala
+++ b/src/main/scala/firrtl/stage/transforms/UpdateAnnotations.scala
@@ -1,0 +1,95 @@
+// See LICENSE for license details.
+
+package firrtl.stage.transforms
+
+import firrtl.{AnnotationSeq, CircuitState, RenameMap, Transform, Utils}
+import firrtl.annotations.{Annotation, DeletedAnnotation}
+import firrtl.options.Translator
+
+import scala.collection.mutable
+
+class UpdateAnnotations(val underlying: Transform) extends Transform with WrappedTransform
+    with Translator[CircuitState, (CircuitState, CircuitState)] {
+
+  override def execute(c: CircuitState): CircuitState = underlying.execute(c)
+
+  def aToB(a: CircuitState): (CircuitState, CircuitState) = (a, a)
+
+  def bToA(b: (CircuitState, CircuitState)): CircuitState = {
+    val (state, result) = (b._1, b._2)
+
+    val remappedAnnotations = propagateAnnotations(state.annotations, result.annotations, result.renames)
+
+    logger.info(s"Form: ${result.form}")
+
+    logger.debug(s"Annotations:")
+    remappedAnnotations.foreach( a => logger.debug(a.serialize) )
+
+    logger.trace(s"Circuit:\n${result.circuit.serialize}")
+    logger.info(s"======== Finished Transform $name ========\n")
+
+    CircuitState(result.circuit, result.form, remappedAnnotations, None)
+  }
+
+  def internalTransform(b: (CircuitState, CircuitState)): (CircuitState, CircuitState) = {
+    logger.info(s"======== Starting Transform $name ========")
+
+    /* @todo: prepare should likely be factored out of this */
+    val (timeMillis, result) = Utils.time { execute( trueUnderlying.prepare(b._2) ) }
+
+    logger.info(s"""----------------------------${"-" * name.size}---------\n""")
+    logger.info(f"Time: $timeMillis%.1f ms")
+
+    (b._1, result)
+  }
+
+  /** Propagate annotations and update their names.
+    *
+    * @param inAnno input AnnotationSeq
+    * @param resAnno result AnnotationSeq
+    * @param renameOpt result RenameMap
+    * @return the updated annotations
+    */
+  private[firrtl] def propagateAnnotations(
+      inAnno: AnnotationSeq,
+      resAnno: AnnotationSeq,
+      renameOpt: Option[RenameMap]): AnnotationSeq = {
+    val newAnnotations = {
+      val inSet = mutable.LinkedHashSet() ++ inAnno
+      val resSet = mutable.LinkedHashSet() ++ resAnno
+      val deleted = (inSet -- resSet).map {
+        case DeletedAnnotation(xFormName, delAnno) => DeletedAnnotation(s"$xFormName+$name", delAnno)
+        case anno => DeletedAnnotation(name, anno)
+      }
+      val created = resSet -- inSet
+      val unchanged = resSet & inSet
+      (deleted ++ created ++ unchanged)
+    }
+
+    // For each annotation, rename all annotations.
+    val renames = renameOpt.getOrElse(RenameMap())
+    val remapped2original = mutable.LinkedHashMap[Annotation, mutable.LinkedHashSet[Annotation]]()
+    val keysOfNote = mutable.LinkedHashSet[Annotation]()
+    val finalAnnotations = newAnnotations.flatMap { anno =>
+      val remappedAnnos = anno.update(renames)
+      remappedAnnos.foreach { remapped =>
+        val set = remapped2original.getOrElseUpdate(remapped, mutable.LinkedHashSet.empty[Annotation])
+        set += anno
+        if(set.size > 1) keysOfNote += remapped
+      }
+      remappedAnnos
+    }.toSeq
+    keysOfNote.foreach { key =>
+      logger.debug(s"""The following original annotations are renamed to the same new annotation.""")
+      logger.debug(s"""Original Annotations:\n  ${remapped2original(key).mkString("\n  ")}""")
+      logger.debug(s"""New Annotation:\n  $key""")
+    }
+    finalAnnotations
+  }
+}
+
+object UpdateAnnotations {
+
+  def apply(a: Transform): UpdateAnnotations = new UpdateAnnotations(a)
+
+}

--- a/src/main/scala/firrtl/stage/transforms/WrappedTransform.scala
+++ b/src/main/scala/firrtl/stage/transforms/WrappedTransform.scala
@@ -1,0 +1,33 @@
+// See LICENSE for license details.
+
+package firrtl.stage.transforms
+
+import firrtl.Transform
+
+/** A [[firrtl.Transform]] that "wraps" a second [[firrtl.Transform Transform]] to do some work before and after the
+  * second [[firrtl.Transform Transform]].
+  *
+  * This is intended to synergize with the [[firrtl.options.DependencyManager.wrappers]] method.
+  * @see [[firrtl.stage.transforms.CatchCustomTransformExceptions]]
+  * @see [[firrtl.stage.transforms.TrackTransforms]]
+  * @see [[firrtl.stage.transforms.UpdateAnnotations]]
+  */
+trait WrappedTransform { this: Transform =>
+
+  /** The underlying [[firrtl.Transform]] */
+  val underlying: Transform
+
+  /** Return the original [[firrtl.Transform]] if this wrapper is wrapping other wrappers. */
+  lazy final val trueUnderlying: Transform = underlying match {
+    case a: WrappedTransform => a.trueUnderlying
+    case _ => underlying
+  }
+
+  override final val inputForm = underlying.inputForm
+  override final val outputForm = underlying.outputForm
+  override final val prerequisites = underlying.prerequisites
+  override final val dependents = underlying.dependents
+  override final def invalidates(b: Transform): Boolean = underlying.invalidates(b)
+  override final lazy val name = underlying.name
+
+}

--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -6,6 +6,7 @@ import java.io.{File, FileNotFoundException, FileInputStream, FileOutputStream, 
 
 import firrtl._
 import firrtl.annotations._
+import firrtl.options.PreservesAll
 
 import scala.collection.immutable.ListSet
 
@@ -54,11 +55,17 @@ class BlackBoxNotFoundException(fileName: String, message: String) extends Firrt
   * will set the directory where the Verilog will be written.  This annotation is typically be
   * set by the execution harness, or directly in the tests
   */
-class BlackBoxSourceHelper extends firrtl.Transform {
+class BlackBoxSourceHelper extends firrtl.Transform with PreservesAll[Transform] {
   import BlackBoxSourceHelper._
   private val DefaultTargetDir = new File(".")
   override def inputForm: CircuitForm = LowForm
   override def outputForm: CircuitForm = LowForm
+
+  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized
+
+  override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
+
+  override val dependents = Seq.empty
 
   /** Collect BlackBoxHelperAnnos and and find the target dir if specified
     * @param annos a list of generic annotations for this transform

--- a/src/main/scala/firrtl/transforms/CheckCombLoops.scala
+++ b/src/main/scala/firrtl/transforms/CheckCombLoops.scala
@@ -4,7 +4,6 @@ package firrtl.transforms
 
 import scala.collection.mutable
 
-
 import firrtl._
 import firrtl.ir._
 import firrtl.passes.{Errors, PassException}
@@ -13,7 +12,7 @@ import firrtl.annotations._
 import firrtl.Utils.throwInternalError
 import firrtl.graph._
 import firrtl.analyses.InstanceGraph
-import firrtl.options.{RegisteredTransform, ShellOption}
+import firrtl.options.{Dependency, PreservesAll, RegisteredTransform, ShellOption}
 
 /*
  * A case class that represents a net in the circuit. This is
@@ -95,9 +94,18 @@ case class CombinationalPath(sink: ReferenceTarget, sources: Seq[ReferenceTarget
   * @note The pass relies on ExtModulePathAnnotations to find loops through ExtModules
   * @note The pass will throw exceptions on "false paths"
   */
-class CheckCombLoops extends Transform with RegisteredTransform {
+class CheckCombLoops extends Transform with RegisteredTransform with PreservesAll[Transform] {
   def inputForm = LowForm
   def outputForm = LowForm
+
+  override val prerequisites = firrtl.stage.Forms.MidForm ++
+    Seq( Dependency(passes.LowerTypes),
+         Dependency(passes.Legalize),
+         Dependency(firrtl.transforms.RemoveReset) )
+
+  override val optionalPrerequisites = Seq.empty
+
+  override val dependents = Seq.empty
 
   import CheckCombLoops._
 

--- a/src/main/scala/firrtl/transforms/Dedup.scala
+++ b/src/main/scala/firrtl/transforms/Dedup.scala
@@ -9,7 +9,7 @@ import firrtl.analyses.InstanceGraph
 import firrtl.annotations._
 import firrtl.passes.{InferTypes, MemPortUtils}
 import firrtl.Utils.throwInternalError
-import firrtl.options.{HasShellOptions, ShellOption}
+import firrtl.options.{HasShellOptions, PreservesAll, ShellOption}
 
 // Datastructures
 import scala.collection.mutable
@@ -39,9 +39,13 @@ case object NoCircuitDedupAnnotation extends NoTargetAnnotation with HasShellOpt
   * Specifically, the restriction of instance loops must have been checked, or else this pass can
   *  infinitely recurse
   */
-class DedupModules extends Transform {
+class DedupModules extends Transform with PreservesAll[Transform] {
   def inputForm: CircuitForm = HighForm
   def outputForm: CircuitForm = HighForm
+
+  override val prerequisites = firrtl.stage.Forms.Resolved
+
+  override val dependents = Seq.empty
 
   /** Deduplicate a Circuit
     * @param state Input Firrtl AST

--- a/src/main/scala/firrtl/transforms/GroupComponents.scala
+++ b/src/main/scala/firrtl/transforms/GroupComponents.scala
@@ -61,6 +61,7 @@ class GroupComponents extends firrtl.Transform {
       case other => Seq(other)
     }
     val cs = state.copy(circuit = state.circuit.copy(modules = newModules))
+    /* @todo move ResolveKinds and InferTypes out */
     val csx = ResolveKinds.execute(InferTypes.execute(cs))
     csx
   }

--- a/src/main/scala/firrtl/transforms/InlineBitExtractions.scala
+++ b/src/main/scala/firrtl/transforms/InlineBitExtractions.scala
@@ -3,6 +3,7 @@ package transforms
 
 import firrtl.ir._
 import firrtl.Mappers._
+import firrtl.options.{Dependency, PreservesAll}
 import firrtl.PrimOps.{Bits, Head, Tail, Shr}
 import firrtl.Utils.{isBitExtract, isTemp}
 import firrtl.WrappedExpression._
@@ -91,9 +92,18 @@ object InlineBitExtractionsTransform {
 }
 
 /** Inline nodes that are simple bits */
-class InlineBitExtractionsTransform extends Transform {
+class InlineBitExtractionsTransform extends Transform with PreservesAll[Transform] {
   def inputForm = UnknownForm
   def outputForm = UnknownForm
+
+  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
+    Seq( Dependency[BlackBoxSourceHelper],
+         Dependency[FixAddingNegativeLiterals],
+         Dependency[ReplaceTruncatingArithmetic] )
+
+  override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
+
+  override val dependents = Seq.empty
 
   def execute(state: CircuitState): CircuitState = {
     val modulesx = state.circuit.modules.map(InlineBitExtractionsTransform.onMod(_))

--- a/src/main/scala/firrtl/transforms/RemoveReset.scala
+++ b/src/main/scala/firrtl/transforms/RemoveReset.scala
@@ -7,6 +7,7 @@ import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.traversals.Foreachers._
 import firrtl.WrappedExpression.we
+import firrtl.options.Dependency
 
 import scala.collection.{immutable, mutable}
 
@@ -14,9 +15,22 @@ import scala.collection.{immutable, mutable}
   *
   * @note This pass must run after LowerTypes
   */
-class RemoveReset extends Transform {
-  def inputForm = MidForm
-  def outputForm = MidForm
+object RemoveReset extends Transform {
+  def inputForm = LowForm
+  def outputForm = LowForm
+
+  override val prerequisites = firrtl.stage.Forms.MidForm ++
+    Seq( Dependency(passes.LowerTypes),
+         Dependency(passes.Legalize) )
+
+  override val optionalPrerequisites = Seq.empty
+
+  override val dependents = Seq.empty
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case firrtl.passes.ResolveFlows => true
+    case _                          => false
+  }
 
   private case class Reset(cond: Expression, value: Expression)
 

--- a/src/main/scala/logger/Logger.scala
+++ b/src/main/scala/logger/Logger.scala
@@ -361,7 +361,7 @@ object Logger {
     */
   def setOptions(inputAnnotations: AnnotationSeq): Unit = {
     val annotations =
-      Seq( AddDefaults, Checks )
+      Seq( new AddDefaults, Checks )
       .foldLeft(inputAnnotations)((a, p) => p.transform(a))
 
     val lopts = view[LoggerOptions](annotations)

--- a/src/main/scala/logger/phases/AddDefaults.scala
+++ b/src/main/scala/logger/phases/AddDefaults.scala
@@ -3,12 +3,15 @@
 package logger.phases
 
 import firrtl.AnnotationSeq
-import firrtl.options.Phase
+import firrtl.options.{Phase, PreservesAll}
 
 import logger.{LoggerOption, LogLevelAnnotation}
 
 /** Add default logger [[Annotation]]s */
-private [logger] object AddDefaults extends Phase {
+private [logger] class AddDefaults extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites = Seq.empty
+  override val dependents = Seq.empty
 
   /** Add missing default [[Logger]] [[Annotation]]s to an [[AnnotationSeq]]
     * @param annotations input annotations

--- a/src/main/scala/logger/phases/Checks.scala
+++ b/src/main/scala/logger/phases/Checks.scala
@@ -4,7 +4,7 @@ package logger.phases
 
 import firrtl.AnnotationSeq
 import firrtl.annotations.Annotation
-import firrtl.options.Phase
+import firrtl.options.{Dependency, Phase, PreservesAll}
 
 import logger.{LogLevelAnnotation, LogFileAnnotation, LoggerException}
 
@@ -12,7 +12,10 @@ import scala.collection.mutable
 
 /** Check that an [[firrtl.AnnotationSeq AnnotationSeq]] has all necessary [[firrtl.annotations.Annotation Annotation]]s
   * for a [[Logger]] */
-object Checks extends Phase {
+object Checks extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites = Seq(Dependency[AddDefaults])
+  override val dependents = Seq.empty
 
   /** Ensure that an [[firrtl.AnnotationSeq AnnotationSeq]] has necessary [[Logger]] [[firrtl.annotations.Annotation
     * Annotation]]s

--- a/src/test/scala/firrtlTests/AnnotationTests.scala
+++ b/src/test/scala/firrtlTests/AnnotationTests.scala
@@ -627,7 +627,7 @@ class JsonAnnotationTests extends AnnotationTests with BackendCompilationUtiliti
     override def inputForm: CircuitForm = UnknownForm
     override def outputForm: CircuitForm = UnknownForm
 
-    protected def execute(state: CircuitState): CircuitState = state
+    def execute(state: CircuitState): CircuitState = state
   }
 
   "annotation order" should "should be preserved" in {

--- a/src/test/scala/firrtlTests/CInferMDirSpec.scala
+++ b/src/test/scala/firrtlTests/CInferMDirSpec.scala
@@ -7,7 +7,7 @@ import firrtl.ir._
 import firrtl.passes._
 import firrtl.transforms._
 
-class CInferMDir extends LowTransformSpec {
+class CInferMDirSpec extends LowTransformSpec {
   object CInferMDirCheckPass extends Pass {
     // finds the memory and check its read port
     def checkStmt(s: Statement): Boolean = s match {

--- a/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
+++ b/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
@@ -1,0 +1,349 @@
+// See LICENSE for license details.
+
+package firrtlTests
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import firrtl._
+import firrtl.passes
+import firrtl.options.Dependency
+import firrtl.stage.{Forms, TransformManager}
+import firrtl.transforms.IdentityTransform
+
+sealed trait PatchAction { val line: Int }
+
+case class Add(line: Int, transforms: Seq[Dependency[Transform]]) extends PatchAction
+case class Del(line: Int) extends PatchAction
+
+object Transforms {
+  class IdentityTransformDiff(val inputForm: CircuitForm, val outputForm: CircuitForm) extends Transform {
+    override def execute(state: CircuitState): CircuitState = state
+    override def name: String = s">>>>> $inputForm -> $outputForm <<<<<"
+  }
+  import firrtl.{ChirrtlForm => C, HighForm => H, MidForm => M, LowForm => L, UnknownForm => U}
+  class ChirrtlToChirrtl extends IdentityTransformDiff(C, C)
+  class HighToChirrtl    extends IdentityTransformDiff(H, C)
+  class HighToHigh       extends IdentityTransformDiff(H, H)
+  class MidToMid         extends IdentityTransformDiff(M, M)
+  class MidToChirrtl     extends IdentityTransformDiff(M, C)
+  class MidToHigh        extends IdentityTransformDiff(M, H)
+  class LowToChirrtl     extends IdentityTransformDiff(L, C)
+  class LowToHigh        extends IdentityTransformDiff(L, H)
+  class LowToMid         extends IdentityTransformDiff(L, M)
+  class LowToLow         extends IdentityTransformDiff(L, L)
+}
+
+class LoweringCompilersSpec extends FlatSpec with Matchers {
+
+  def legacyTransforms(a: CoreTransform): Seq[Transform] = a match {
+    case _: ChirrtlToHighFirrtl => Seq(
+      passes.CheckChirrtl,
+      passes.CInferTypes,
+      passes.CInferMDir,
+      passes.RemoveCHIRRTL)
+    case _: IRToWorkingIR => Seq(passes.ToWorkingIR)
+    case _: ResolveAndCheck => Seq(
+      passes.CheckHighForm,
+      passes.ResolveKinds,
+      passes.InferTypes,
+      passes.CheckTypes,
+      passes.Uniquify,
+      passes.ResolveKinds,
+      passes.InferTypes,
+      passes.ResolveFlows,
+      passes.CheckFlows,
+      new passes.InferBinaryPoints,
+      new passes.TrimIntervals,
+      new passes.InferWidths,
+      passes.CheckWidths,
+      new firrtl.transforms.InferResets)
+    case _: HighFirrtlToMiddleFirrtl => Seq(
+      passes.PullMuxes,
+      passes.ReplaceAccesses,
+      passes.ExpandConnects,
+      passes.RemoveAccesses,
+      passes.Uniquify,
+      passes.ExpandWhens,
+      passes.CheckInitialization,
+      passes.ResolveKinds,
+      passes.InferTypes,
+      passes.CheckTypes,
+      passes.ResolveFlows,
+      new passes.InferWidths,
+      passes.CheckWidths,
+      new passes.RemoveIntervals,
+      passes.ConvertFixedToSInt,
+      passes.ZeroWidth,
+      passes.InferTypes)
+    case _: MiddleFirrtlToLowFirrtl => Seq(
+      passes.LowerTypes,
+      passes.ResolveKinds,
+      passes.InferTypes,
+      passes.ResolveFlows,
+      new passes.InferWidths,
+      passes.Legalize,
+      firrtl.transforms.RemoveReset,
+      passes.ResolveFlows,
+      new firrtl.transforms.CheckCombLoops,
+      new checks.CheckResets,
+      new firrtl.transforms.RemoveWires)
+    case _: LowFirrtlOptimization => Seq(
+      passes.RemoveValidIf,
+      new firrtl.transforms.ConstantPropagation,
+      passes.PadWidths,
+      new firrtl.transforms.ConstantPropagation,
+      passes.Legalize,
+      passes.memlib.VerilogMemDelays, // TODO move to Verilog emitter
+      new firrtl.transforms.ConstantPropagation,
+      passes.SplitExpressions,
+      new firrtl.transforms.CombineCats,
+      passes.CommonSubexpressionElimination,
+      new firrtl.transforms.DeadCodeElimination)
+    case _: MinimumLowFirrtlOptimization => Seq(
+      passes.RemoveValidIf,
+      passes.Legalize,
+      passes.memlib.VerilogMemDelays, // TODO move to Verilog emitter
+      passes.SplitExpressions)
+  }
+
+  def compare(a: Seq[Transform], b: TransformManager, patches: Seq[PatchAction] = Seq.empty): Unit = {
+    info(s"""Transform Order:\n${b.prettyPrint("    ")}""")
+
+    val m = new scala.collection.mutable.HashMap[Int, Seq[Dependency[Transform]]].withDefault(_ => Seq.empty)
+    a.map(Dependency.fromTransform).zipWithIndex.foreach{ case (t, idx) => m(idx) = Seq(t) }
+
+    patches.foreach {
+      case Add(line, txs) => m(line - 1) = m(line - 1) ++ txs
+      case Del(line)      => m.remove(line - 1)
+    }
+
+    val patched = scala.collection.immutable.TreeMap(m.toArray:_*).values.flatten
+
+    patched
+      .zip(b.flattenedTransformOrder.map(Dependency.fromTransform))
+      .foreach{ case (aa, bb) => bb should be (aa) }
+
+    info(s"found ${b.flattenedTransformOrder.size} transforms")
+    patched.size should be (b.flattenedTransformOrder.size)
+  }
+
+  behavior of "ChirrtlToHighFirrtl"
+
+  it should "replicate the old order" in {
+    val tm = new TransformManager(Forms.MinimalHighForm, Forms.ChirrtlForm)
+    compare(legacyTransforms(new firrtl.ChirrtlToHighFirrtl), tm)
+  }
+
+  behavior of "IRToWorkingIR"
+
+  it should "replicate the old order" in {
+    val tm = new TransformManager(Forms.WorkingIR, Forms.MinimalHighForm)
+    compare(legacyTransforms(new firrtl.IRToWorkingIR), tm)
+  }
+
+  behavior of "ResolveAndCheck"
+
+  it should "replicate the old order" in {
+    val tm = new TransformManager(Forms.Resolved, Forms.WorkingIR)
+    val patches = Seq(
+      Add(14, Seq(Dependency.fromTransform(firrtl.passes.CheckTypes)))
+    )
+    compare(legacyTransforms(new ResolveAndCheck), tm, patches)
+  }
+
+  behavior of "HighFirrtlToMiddleFirrtl"
+
+  it should "replicate the old order" in {
+    val tm = new TransformManager(Forms.MidForm, Forms.Deduped)
+    val patches = Seq(
+      Add(5, Seq(Dependency(firrtl.passes.ResolveKinds),
+                 Dependency(firrtl.passes.InferTypes))),
+      Del(6),
+      Del(7),
+      Add(6, Seq(Dependency[firrtl.passes.ExpandWhensAndCheck])),
+      Del(10),
+      Del(11),
+      Del(12),
+      Add(11, Seq(Dependency(firrtl.passes.ResolveFlows),
+                  Dependency[firrtl.passes.InferWidths])),
+      Del(13)
+    )
+    compare(legacyTransforms(new HighFirrtlToMiddleFirrtl), tm, patches)
+  }
+
+  behavior of "MiddleFirrtlToLowFirrtl"
+
+  it should "replicate the old order" in {
+    val tm = new TransformManager(Forms.LowForm, Forms.MidForm)
+    compare(legacyTransforms(new MiddleFirrtlToLowFirrtl), tm)
+  }
+
+  behavior of "MinimumLowFirrtlOptimization"
+
+  it should "replicate the old order" in {
+    val tm = new TransformManager(Forms.LowFormMinimumOptimized, Forms.LowForm)
+    compare(legacyTransforms(new MinimumLowFirrtlOptimization), tm)
+  }
+
+  behavior of "LowFirrtlOptimization"
+
+  it should "replicate the old order" in {
+    val tm = new TransformManager(Forms.LowFormOptimized, Forms.LowForm)
+    val patches = Seq(
+      Add(7, Seq(Dependency(firrtl.passes.Legalize)))
+    )
+    compare(legacyTransforms(new LowFirrtlOptimization), tm, patches)
+  }
+
+  behavior of "VerilogMinimumOptimized"
+
+  it should "replicate the old order" in {
+    val legacy = Seq(
+      new firrtl.transforms.BlackBoxSourceHelper,
+      new firrtl.transforms.FixAddingNegativeLiterals,
+      new firrtl.transforms.ReplaceTruncatingArithmetic,
+      new firrtl.transforms.InlineBitExtractionsTransform,
+      new firrtl.transforms.InlineCastsTransform,
+      new firrtl.transforms.LegalizeClocksTransform,
+      new firrtl.transforms.FlattenRegUpdate,
+      firrtl.passes.VerilogModulusCleanup,
+      new firrtl.transforms.VerilogRename,
+      firrtl.passes.VerilogPrep,
+      new firrtl.AddDescriptionNodes)
+    val tm = new TransformManager(Forms.VerilogMinimumOptimized, (new firrtl.VerilogEmitter).prerequisites)
+    compare(legacy, tm)
+  }
+
+  behavior of "VerilogOptimized"
+
+  it should "replicate the old order" in {
+    val legacy = Seq(
+      new firrtl.transforms.BlackBoxSourceHelper,
+      new firrtl.transforms.FixAddingNegativeLiterals,
+      new firrtl.transforms.ReplaceTruncatingArithmetic,
+      new firrtl.transforms.InlineBitExtractionsTransform,
+      new firrtl.transforms.InlineCastsTransform,
+      new firrtl.transforms.LegalizeClocksTransform,
+      new firrtl.transforms.FlattenRegUpdate,
+      new firrtl.transforms.DeadCodeElimination,
+      firrtl.passes.VerilogModulusCleanup,
+      new firrtl.transforms.VerilogRename,
+      firrtl.passes.VerilogPrep,
+      new firrtl.AddDescriptionNodes)
+    val tm = new TransformManager(Forms.VerilogOptimized, Forms.LowFormOptimized)
+    compare(legacy, tm)
+  }
+
+  behavior of "Legacy Custom Transforms"
+
+  it should "work for Chirrtl -> Chirrtl" in {
+    val expected = new Transforms.ChirrtlToChirrtl :: new firrtl.ChirrtlEmitter :: Nil
+    val tm = new TransformManager(Dependency[firrtl.ChirrtlEmitter] :: Dependency[Transforms.ChirrtlToChirrtl] :: Nil)
+    compare(expected, tm)
+  }
+
+  it should "work for High -> High" in {
+    val expected =
+      new TransformManager(Forms.HighForm).flattenedTransformOrder ++
+        Some(new Transforms.HighToHigh) ++
+        (new TransformManager(Forms.MidForm, Forms.HighForm).flattenedTransformOrder)
+    val tm = new TransformManager(Forms.MidForm :+ Dependency[Transforms.HighToHigh])
+    compare(expected, tm)
+  }
+
+  it should "work for High -> Chirrtl" in {
+    val expected =
+      new TransformManager(Forms.HighForm).flattenedTransformOrder ++
+        Some(new Transforms.HighToChirrtl) ++
+        (new TransformManager(Forms.HighForm, Forms.ChirrtlForm).flattenedTransformOrder)
+    val tm = new TransformManager(Forms.HighForm :+ Dependency[Transforms.HighToChirrtl])
+    compare(expected, tm)
+  }
+
+  it should "work for Mid -> Mid" in {
+    val expected =
+      new TransformManager(Forms.MidForm).flattenedTransformOrder ++
+        Some(new Transforms.MidToMid) ++
+        (new TransformManager(Forms.LowForm, Forms.MidForm).flattenedTransformOrder)
+    val tm = new TransformManager(Forms.LowForm :+ Dependency[Transforms.MidToMid])
+    compare(expected, tm)
+  }
+
+  it should "work for Mid -> High" in {
+    val expected =
+      new TransformManager(Forms.MidForm).flattenedTransformOrder ++
+        Some(new Transforms.MidToHigh) ++
+        (new TransformManager(Forms.LowForm, Forms.MinimalHighForm).flattenedTransformOrder)
+    val tm = new TransformManager(Forms.LowForm :+ Dependency[Transforms.MidToHigh])
+    compare(expected, tm)
+  }
+
+  it should "work for Mid -> Chirrtl" in {
+    val expected =
+      new TransformManager(Forms.MidForm).flattenedTransformOrder ++
+        Some(new Transforms.MidToChirrtl) ++
+        (new TransformManager(Forms.LowForm, Forms.ChirrtlForm).flattenedTransformOrder)
+    val tm = new TransformManager(Forms.LowForm :+ Dependency[Transforms.MidToChirrtl])
+    compare(expected, tm)
+  }
+
+  it should "work for Low -> Low" in {
+    val expected =
+      new TransformManager(Forms.LowFormOptimized).flattenedTransformOrder ++
+        Seq(new Transforms.LowToLow)
+    val tm = new TransformManager(Forms.LowFormOptimized :+ Dependency[Transforms.LowToLow])
+    compare(expected, tm)
+  }
+
+  it should "work for Low -> Mid" in {
+    val expected =
+      new TransformManager(Forms.LowFormOptimized).flattenedTransformOrder ++
+        Seq(new Transforms.LowToMid) ++
+        (new TransformManager(Forms.LowFormOptimized, Forms.MidForm).flattenedTransformOrder)
+    val tm = new TransformManager(Forms.LowFormOptimized :+ Dependency[Transforms.LowToMid])
+    compare(expected, tm)
+  }
+
+  it should "work for Low -> High" in {
+    val expected =
+      new TransformManager(Forms.LowFormOptimized).flattenedTransformOrder ++
+        Seq(new Transforms.LowToHigh) ++
+        (new TransformManager(Forms.LowFormOptimized, Forms.MinimalHighForm).flattenedTransformOrder)
+    val tm = new TransformManager(Forms.LowFormOptimized :+ Dependency[Transforms.LowToHigh])
+    compare(expected, tm)
+  }
+
+  it should "work for Low -> Chirrtl" in {
+    val expected =
+      new TransformManager(Forms.LowFormOptimized).flattenedTransformOrder ++
+        Seq(new Transforms.LowToChirrtl) ++
+        (new TransformManager(Forms.LowFormOptimized, Forms.ChirrtlForm).flattenedTransformOrder)
+    val tm = new TransformManager(Forms.LowFormOptimized :+ Dependency[Transforms.LowToChirrtl])
+    compare(expected, tm)
+  }
+
+  it should "schedule inputForm=LowForm after MiddleFirrtlToLowFirrtl for the LowFirrtlEmitter" in {
+    val expected =
+      new TransformManager(Forms.LowForm).flattenedTransformOrder ++
+        Seq(new Transforms.LowToLow, new firrtl.LowFirrtlEmitter)
+    val tm = (new TransformManager(Seq(Dependency[firrtl.LowFirrtlEmitter], Dependency[Transforms.LowToLow])))
+    compare(expected, tm)
+  }
+
+  it should "schedule inputForm=LowForm after MinimumLowFirrtlOptimizations for the MinimalVerilogEmitter" in {
+    val expected =
+      new TransformManager(Forms.LowFormMinimumOptimized).flattenedTransformOrder ++
+        Seq(new Transforms.LowToLow, new firrtl.MinimumVerilogEmitter)
+    val tm = (new TransformManager(Seq(Dependency[firrtl.MinimumVerilogEmitter], Dependency[Transforms.LowToLow])))
+    compare(expected, tm)
+  }
+
+  it should "schedule inputForm=LowForm after LowFirrtlOptimizations for the VerilogEmitter" in {
+    val expected =
+      new TransformManager(Forms.LowFormOptimized).flattenedTransformOrder ++
+        Seq(new Transforms.LowToLow, new firrtl.VerilogEmitter)
+    val tm = (new TransformManager(Seq(Dependency[firrtl.VerilogEmitter], Dependency[Transforms.LowToLow])))
+    compare(expected, tm)
+  }
+
+}

--- a/src/test/scala/firrtlTests/VerilogEmitterTests.scala
+++ b/src/test/scala/firrtlTests/VerilogEmitterTests.scala
@@ -13,12 +13,12 @@ class DoPrimVerilog extends FirrtlFlatSpec {
   "Xorr" should "emit correctly" in {
     val compiler = new VerilogCompiler
     val input =
-      """circuit Xorr : 
-        |  module Xorr : 
+      """circuit Xorr :
+        |  module Xorr :
         |    input a: UInt<4>
         |    output b: UInt<1>
         |    b <= xorr(a)""".stripMargin
-    val check = 
+    val check =
       """module Xorr(
         |  input  [3:0] a,
         |  output  b
@@ -31,12 +31,12 @@ class DoPrimVerilog extends FirrtlFlatSpec {
   "Andr" should "emit correctly" in {
     val compiler = new VerilogCompiler
     val input =
-      """circuit Andr : 
-        |  module Andr : 
+      """circuit Andr :
+        |  module Andr :
         |    input a: UInt<4>
         |    output b: UInt<1>
         |    b <= andr(a)""".stripMargin
-    val check = 
+    val check =
       """module Andr(
         |  input  [3:0] a,
         |  output  b
@@ -49,12 +49,12 @@ class DoPrimVerilog extends FirrtlFlatSpec {
   "Orr" should "emit correctly" in {
     val compiler = new VerilogCompiler
     val input =
-      """circuit Orr : 
-        |  module Orr : 
+      """circuit Orr :
+        |  module Orr :
         |    input a: UInt<4>
         |    output b: UInt<1>
         |    b <= orr(a)""".stripMargin
-    val check = 
+    val check =
       """module Orr(
         |  input  [3:0] a,
         |  output  b
@@ -187,8 +187,8 @@ class DoPrimVerilog extends FirrtlFlatSpec {
         |""".stripMargin
     val check =
       """module Test(
-        |  input  [7:0] in, 
-        |  output  out 
+        |  input  [7:0] in,
+        |  output  out
         |);
         |  wire [7:0] _GEN_0;
         |  assign out = _GEN_0[0];

--- a/src/test/scala/firrtlTests/transforms/BlackBoxSourceHelperSpec.scala
+++ b/src/test/scala/firrtlTests/transforms/BlackBoxSourceHelperSpec.scala
@@ -100,11 +100,6 @@ class BlacklBoxSourceHelperTransformSpec extends LowTransformSpec {
     new java.io.File(s"test_run_dir/${BlackBoxSourceHelper.defaultFileListName}").exists should be (true)
   }
 
-  "verilog compiler" should "have BlackBoxSourceHelper transform" in {
-    val verilogCompiler = new VerilogEmitter
-    verilogCompiler.transforms.map { x => x.getClass } should contain (classOf[BlackBoxSourceHelper])
-  }
-
   "verilog header files" should "be available but not mentioned in the file list" in {
     // Issue #917 - We don't want to list Verilog header files ("*.vh") in our file list.
     // We don't actually verify that the generated verilog code works,


### PR DESCRIPTION
### Dependencies

- Prerequisites: [#1357, #1423]

### Overview

(Apologies for the email traffic. [GitHub has restrictions on re-opening PRs that have been forced pushed](https://github.com/isaacs/github/issues/361), so I have to re-create this... again.) *Re-opened version of #1115 (which was a re-opened of #1105)...*

This adds a Dependency API version of the FIRRTL compiler.

- Adds `optionalPrerequisistes` member to `DependencyAPI`
- Adds `TransformManager` for managing transforms (a `DependencyManager[Transform]`)
- Adds `firrtl.stage.transforms.Compiler` which replaces `firrtl.Compiler` and is, itself, a `Transform`
- Defines dependencies for all transforms and passes
- Any transform/pass object is deprecated in favor of a transform/pass class
- Adds compatibility logic for converting `inputForm`/`outputForm` to Dependency API
- New tests to ensure that the resulting transform orderings are sane
- Mass deprecations

The new transform order deviates from the original `LoweringCompilers.scala` order (and is tested/documented in `LoweringCompilersSpec.scala`. Namely:

- `ResolveAndCheck`
  - One `CheckTypes` is appended
  - see the test case: https://github.com/freechipsproject/firrtl/pull/1123/files#diff-
- `HighFirrtlToMiddleFirrtl`
  - `ResolveKinds` and `InferTypes` run after `Uniquify`
  - `ExpandWhens` and `CheckInitialization` are collapsed to one transform: `ExpandWhensAndCheck`
  - `CheckResets` runs after `InferWidths`
  - `CheckWidths` does not run
  - see the test case: https://github.com/freechipsproject/firrtl/pull/1123/files#diff-ba7d72efa1d556670c3affbe82a41222R93
- `LowFirrtlOptimization`
  - An additional `Legalize` runs after the second `ConstantPropagation`
  - see the test case: https://github.com/freechipsproject/firrtl/pull/1123/files#diff-ba7d72efa1d556670c3affbe82a41222R130

In summary: 5 new transforms run, one transform is removed. Therefore, there is an expectation that this will be slower than the original compiler.

Additionally, this adds pretty printing for `DependencyManager`s with the ability for customization via a `customPrintHandling` method to print additional information about or recurse into `Transform`s which are not `DependencyManager`s, e.g., the `VerilogEmitter`. When running with `--log-level info` you can now get more structured information about what transforms will be run in what order. See the following output for `-X verilog`:

```
Computed transform order in: 406.9 ms
Determined Transform order that will be executed:
  firrtl.stage.transforms.Compiler
  ├── firrtl.passes.CheckChirrtl$
  ├── firrtl.passes.CInferTypes$
  ├── firrtl.passes.CInferMDir$
  ├── firrtl.passes.RemoveCHIRRTL$
  ├── firrtl.passes.ToWorkingIR$
  ├── firrtl.passes.CheckHighForm$
  ├── firrtl.passes.ResolveKinds$
  ├── firrtl.passes.InferTypes$
  ├── firrtl.passes.CheckTypes$
  ├── firrtl.passes.Uniquify$
  ├── firrtl.stage.TransformManager
  │   ├── firrtl.passes.ResolveKinds$
  │   └── firrtl.passes.InferTypes$
  ├── firrtl.passes.ResolveFlows$
  ├── firrtl.passes.CheckFlows$
  ├── firrtl.passes.InferBinaryPoints
  ├── firrtl.passes.TrimIntervals
  ├── firrtl.passes.InferWidths
  ├── firrtl.passes.CheckWidths$
  ├── firrtl.transforms.InferResets
  ├── firrtl.stage.TransformManager
  │   └── firrtl.passes.CheckTypes$
  ├── firrtl.transforms.DedupModules
  ├── firrtl.passes.PullMuxes$
  ├── firrtl.passes.ReplaceAccesses$
  ├── firrtl.passes.ExpandConnects$
  ├── firrtl.passes.RemoveAccesses$
  ├── firrtl.stage.TransformManager
  │   ├── firrtl.passes.Uniquify$
  │   └── firrtl.stage.TransformManager
  │       ├── firrtl.passes.ResolveKinds$
  │       └── firrtl.passes.InferTypes$
  ├── firrtl.passes.ExpandWhensAndCheck
  ├── firrtl.stage.TransformManager
  │   ├── firrtl.passes.ResolveKinds$
  │   ├── firrtl.passes.InferTypes$
  │   ├── firrtl.passes.ResolveFlows$
  │   └── firrtl.passes.InferWidths
  ├── firrtl.passes.RemoveIntervals
  ├── firrtl.passes.ConvertFixedToSInt$
  ├── firrtl.passes.ZeroWidth$
  ├── firrtl.stage.TransformManager
  │   └── firrtl.passes.InferTypes$
  ├── firrtl.passes.LowerTypes$
  ├── firrtl.stage.TransformManager
  │   ├── firrtl.passes.ResolveKinds$
  │   ├── firrtl.passes.InferTypes$
  │   ├── firrtl.passes.ResolveFlows$
  │   └── firrtl.passes.InferWidths
  ├── firrtl.passes.Legalize$
  ├── firrtl.transforms.RemoveReset$
  ├── firrtl.stage.TransformManager
  │   └── firrtl.passes.ResolveFlows$
  ├── firrtl.transforms.CheckCombLoops
  ├── firrtl.checks.CheckResets
  ├── firrtl.transforms.RemoveWires
  ├── firrtl.passes.RemoveValidIf$
  ├── firrtl.transforms.ConstantPropagation
  ├── firrtl.passes.PadWidths$
  ├── firrtl.stage.TransformManager
  │   ├── firrtl.transforms.ConstantPropagation
  │   └── firrtl.passes.Legalize$
  ├── firrtl.passes.memlib.VerilogMemDelays$
  ├── firrtl.stage.TransformManager
  │   ├── firrtl.transforms.ConstantPropagation
  │   └── firrtl.stage.TransformManager
  │       └── firrtl.passes.Legalize$
  ├── firrtl.passes.SplitExpressions$
  ├── firrtl.transforms.CombineCats
  ├── firrtl.passes.CommonSubexpressionElimination$
  ├── firrtl.transforms.DeadCodeElimination
  └── firrtl.VerilogEmitter
      ├── firrtl.transforms.BlackBoxSourceHelper
      ├── firrtl.transforms.FixAddingNegativeLiterals
      ├── firrtl.transforms.ReplaceTruncatingArithmetic
      ├── firrtl.transforms.InlineBitExtractionsTransform
      ├── firrtl.transforms.InlineCastsTransform
      ├── firrtl.transforms.LegalizeClocksTransform
      ├── firrtl.transforms.FlattenRegUpdate
      ├── firrtl.transforms.DeadCodeElimination
      ├── firrtl.passes.VerilogModulusCleanup$
      ├── firrtl.transforms.VerilogRename
      ├── firrtl.passes.VerilogPrep$
      └── firrtl.AddDescriptionNodes
```

API Changes:

- The old behavior of `-fct foo,bar,foo` would result in `foo` being run twice. With the Dependency API, this is equivalent to `-fct foo,bar`. If a user wants to have the behavior where `Seq(foo, bar, foo)` runs, then they have to express this using the Dependency API (`bar` depends on `foo` and invalidates `foo`). This old behavior is *not* preserved.

Todo:

- [x] Preserve hysteresis behavior of `outputForm = HighForm`
- [x] Test that ordering of form-based transforms still works. (This isn't the best test, but it adds to the `CustomTransformSpec` to test that the ordering of transforms specified is the same as what executes.)
- [x] Switch `Forms.HighForm` to include everything up through dedup
- [x] Fix `inputForm = Forms.LowForm` scheduling; a transform with `LowForm` input should occur after `MiddleFirrtlToLowFirrtl` if using the `LowFirrtlEmitter` and after `LowFirrtlOptimizations` if using the `*VerilogEmitter`s
- [x] Placement of `CheckResets`
- [x] Check `Legalize` placement
  - This uses the same order for `Legalize` with one additional `Legalize`
- [x] Placement of additional `InferTypes`/`ResolveFlows` in optimizations (see: https://github.com/freechipsproject/firrtl/issues/1171#issuecomment-544767661)
- [x] Jack/SiFive sign-off: as of 2020-03-05, this is passing SiFive Verilog regressions on 1.2.x with @albert-magyar changes in #1422 cherry-picked
- [x] Update Chisel3 to use `Dependency` (https://github.com/freechipsproject/chisel3/pull/1270)
- [x] Check performance: +-5% for Rocket-sized designs

On performance, there's a constant overhead which makes normalized runtime look bad for the benchmarks. However, once these get large enough in runtime, things don't really matter and it converges to about +-5%.

Meta:

- Fixes #446
- Oddities of `inputForm`/`outputForm` are documented in #1165 