### PR TITLE
Fix RenameMap chaining

### DIFF
--- a/src/main/scala/firrtl/RenameMap.scala
+++ b/src/main/scala/firrtl/RenameMap.scala
@@ -44,7 +44,7 @@ final class RenameMap private (val underlying: mutable.HashMap[CompleteTarget, S
     if (next.chained.isEmpty) {
       new RenameMap(next.underlying, chained = Some(this))
     } else {
-      new RenameMap(next.underlying, chained = next.chained.map(_.andThen(this)))
+      new RenameMap(next.underlying, chained = next.chained.map(this.andThen(_)))
     }
   }
 

--- a/src/main/scala/firrtl/RenameMap.scala
+++ b/src/main/scala/firrtl/RenameMap.scala
@@ -40,7 +40,13 @@ final class RenameMap private (val underlying: mutable.HashMap[CompleteTarget, S
   /** Chain a [[RenameMap]] with this [[RenameMap]]
     * @param next the map to chain with this map
     */
-  def andThen(next: RenameMap) = new RenameMap(next.underlying, chained = Some(this))
+  def andThen(next: RenameMap): RenameMap = {
+    if (next.chained.isEmpty) {
+      new RenameMap(next.underlying, chained = Some(this))
+    } else {
+      new RenameMap(next.underlying, chained = next.chained.map(_.andThen(this)))
+    }
+  }
 
   /** Record that the from [[firrtl.annotations.CircuitTarget CircuitTarget]] is renamed to another
     * [[firrtl.annotations.CircuitTarget CircuitTarget]]
@@ -204,8 +210,10 @@ final class RenameMap private (val underlying: mutable.HashMap[CompleteTarget, S
       if (chainedRet.isEmpty) {
         Some(chainedRet)
       } else {
-        val hereRet = chainedRet.flatMap(hereCompleteGet)
-        if (hereRet.isEmpty) { None } else { Some(hereRet.flatten) }
+        val hereRet = (chainedRet.flatMap { target =>
+          hereCompleteGet(target).getOrElse(Seq(target))
+        }).distinct
+        if (hereRet.size == 1 && hereRet.head == key) { None } else { Some(hereRet) }
       }
     } else {
       hereCompleteGet(key)

--- a/src/test/scala/firrtlTests/RenameMapSpec.scala
+++ b/src/test/scala/firrtlTests/RenameMapSpec.scala
@@ -725,4 +725,35 @@ class RenameMapSpec extends FirrtlFlatSpec {
       Some(Seq(top.module("A1").ref("foo")))
     }
   }
+
+  it should "should able to chain chained rename maps" in {
+    val top = CircuitTarget("Top").module("Top")
+    val foo1 = top.instOf("foo1", "Mod")
+    val foo2 = top.instOf("foo2", "Mod")
+    val foo3 = top.instOf("foo3", "Mod")
+
+    val bar1 = top.instOf("bar1", "Mod")
+    val bar2 = top.instOf("bar2", "Mod")
+
+    val foo1Rename = RenameMap()
+    val foo2Rename = RenameMap()
+
+    val bar1Rename = RenameMap()
+    val bar2Rename = RenameMap()
+
+    foo1Rename.record(foo1, foo2)
+    foo2Rename.record(foo2, foo3)
+
+    bar1Rename.record(foo3, bar1)
+    bar2Rename.record(bar1, bar2)
+
+    val chained1 = foo1Rename.andThen(foo2Rename)
+    val chained2 = bar1Rename.andThen(bar2Rename)
+
+    val renames = chained1.andThen(chained2)
+
+    renames.get(foo1) should be {
+      Some(Seq(bar2))
+    }
+  }
 }


### PR DESCRIPTION
- fixes `completeGet` so that `RenameMap`s with intermediate chained maps that have no renames do not cause the entire chain to return `None`
- fixes `andThen` so that chaining two already chained `RenameMaps` works correctly