### PR TITLE
Allow name of blackbox resource .f file to change from static value

### DIFF
--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -172,8 +172,8 @@ object BlackBoxSourceHelper {
       // If the path isn't canonical, when make tries to determine dependencies based on the *__ver.d file, we end up with errors like:
       //  make[1]: *** No rule to make target `test_run_dir/examples.AccumBlackBox_PeekPokeTest_Verilator345491158/AccumBlackBox.v', needed by `.../chisel-testers/test_run_dir/examples.AccumBlackBox_PeekPokeTest_Verilator345491158/VAccumBlackBoxWrapper.h'.  Stop.
       //  or we end up including the same file multiple times.
-      val outputFile = outputFileName.getOrElse(defaultFileListName)
-      writeTextToFile(files.map(_.getCanonicalPath).mkString("\n"), new File(targetDir, outputFile))
+      val outputFile = outputFileName.map(new File(_)).getOrElse(new File(targetDir, defaultFileListName))
+      writeTextToFile(files.map(_.getCanonicalPath).mkString("\n"), outputFile)
     }
   }
 

--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -71,8 +71,8 @@ class BlackBoxSourceHelper extends firrtl.Transform {
           val targetDir = new File(dir)
           if (!targetDir.exists()) { FileUtils.makeDirectory(targetDir.getAbsolutePath) }
           (acc, targetDir, flistName)
-        case a: BlackBoxHelperAnno => (acc + a, tdir, flistName)
         case BlackBoxResourceFileNameAnno(fileName) => (acc, tdir, new File(fileName))
+        case a: BlackBoxHelperAnno => (acc + a, tdir, flistName)
         case _ => (acc, tdir, flistName)
       }
     }

--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -55,8 +55,8 @@ class BlackBoxNotFoundException(fileName: String, e: Throwable = null) extends F
   * set by the execution harness, or directly in the tests
   */
 class BlackBoxSourceHelper extends firrtl.Transform {
+  import BlackBoxSourceHelper._
   private val DefaultTargetDir = new File(".")
-
   override def inputForm: CircuitForm = LowForm
   override def outputForm: CircuitForm = LowForm
 
@@ -64,15 +64,16 @@ class BlackBoxSourceHelper extends firrtl.Transform {
     * @param annos a list of generic annotations for this transform
     * @return BlackBoxHelperAnnos and target directory
     */
-  def collectAnnos(annos: Seq[Annotation]): (ListSet[BlackBoxHelperAnno], File) =
-    annos.foldLeft((ListSet.empty[BlackBoxHelperAnno], DefaultTargetDir)) {
-      case ((acc, tdir), anno) => anno match {
+  def collectAnnos(annos: Seq[Annotation]): (ListSet[BlackBoxHelperAnno], File, File) =
+    annos.foldLeft((ListSet.empty[BlackBoxHelperAnno], DefaultTargetDir, new File(defaultFileListName))) {
+      case ((acc, tdir, flistName), anno) => anno match {
         case BlackBoxTargetDirAnno(dir) =>
           val targetDir = new File(dir)
           if (!targetDir.exists()) { FileUtils.makeDirectory(targetDir.getAbsolutePath) }
-          (acc, targetDir)
-        case a: BlackBoxHelperAnno => (acc + a, tdir)
-        case _ => (acc, tdir)
+          (acc, targetDir, flistName)
+        case a: BlackBoxHelperAnno => (acc + a, tdir, flistName)
+        case BlackBoxResourceFileNameAnno(fileName) => (acc, tdir, new File(fileName))
+        case _ => (acc, tdir, flistName)
       }
     }
 
@@ -84,25 +85,21 @@ class BlackBoxSourceHelper extends firrtl.Transform {
     * @throws BlackBoxNotFoundException if a Verilog source cannot be found
     */
   override def execute(state: CircuitState): CircuitState = {
-    val (annos, targetDir) = collectAnnos(state.annotations)
+    val (annos, targetDir, flistName) = collectAnnos(state.annotations)
 
     val resourceFiles: ListSet[File] = annos.collect {
       case BlackBoxResourceAnno(_, resourceId) =>
-        BlackBoxSourceHelper.writeResourceToDirectory(resourceId, targetDir)
+        writeResourceToDirectory(resourceId, targetDir)
       case BlackBoxPathAnno(_, path) =>
         val fileName = path.split("/").last
         val fromFile = new File(path)
         val toFile = new File(targetDir, fileName)
 
-        val inputStream = BlackBoxSourceHelper.safeFile(fromFile.toString)(new FileInputStream(fromFile).getChannel)
+        val inputStream = safeFile(fromFile.toString)(new FileInputStream(fromFile).getChannel)
         val outputStream = new FileOutputStream(toFile).getChannel
         outputStream.transferFrom(inputStream, 0, Long.MaxValue)
 
         toFile
-    }
-
-    val resourceFileName = annos.collectFirst {
-      case BlackBoxResourceFileNameAnno(fileName) => fileName
     }
 
     val inlineFiles: ListSet[File] = annos.collect {
@@ -110,13 +107,23 @@ class BlackBoxSourceHelper extends firrtl.Transform {
         val outFile = new File(targetDir, name)
         (text, outFile)
     }.map { case (text, file) =>
-      BlackBoxSourceHelper.writeTextToFile(text, file)
+      writeTextToFile(text, file)
       file
     }
 
     // Issue #917 - We don't want to list Verilog header files ("*.vh") in our file list - they will automatically be included by reference.
     val verilogSourcesOnly = (resourceFiles ++ inlineFiles).filterNot( _.getName().endsWith(".vh"))
-    BlackBoxSourceHelper.writeFileList(verilogSourcesOnly, targetDir, resourceFileName)
+    val filelistFile = if (flistName.isAbsolute()) flistName else new File(targetDir, flistName.getName())
+
+    // We need the canonical path here, so verilator will create a path to the file that works from the targetDir,
+    //  and, so we can compare the list of files automatically included, with an explicit list provided by the client
+    //  and reject duplicates.
+    // If the path isn't canonical, when make tries to determine dependencies based on the *__ver.d file, we end up with errors like:
+    //  make[1]: *** No rule to make target `test_run_dir/examples.AccumBlackBox_PeekPokeTest_Verilator345491158/AccumBlackBox.v', needed by `.../chisel-testers/test_run_dir/examples.AccumBlackBox_PeekPokeTest_Verilator345491158/VAccumBlackBoxWrapper.h'.  Stop.
+    //  or we end up including the same file multiple times.
+    if (verilogSourcesOnly.nonEmpty) {
+      writeTextToFile(verilogSourcesOnly.map(_.getCanonicalPath).mkString("\n"), filelistFile)
+    }
 
     state
   }
@@ -163,19 +170,6 @@ object BlackBoxSourceHelper {
 
   @deprecated("Renamed to defaultFileListName, as the file list name may now be changed with an annotation", "1.3")
   def fileListName = defaultFileListName
-
-  def writeFileList(files: ListSet[File], targetDir: File, outputFileName: Option[String]): Unit = {
-    if (files.nonEmpty) {
-      // We need the canonical path here, so verilator will create a path to the file that works from the targetDir,
-      //  and, so we can compare the list of files automatically included, with an explicit list provided by the client
-      //  and reject duplicates.
-      // If the path isn't canonical, when make tries to determine dependencies based on the *__ver.d file, we end up with errors like:
-      //  make[1]: *** No rule to make target `test_run_dir/examples.AccumBlackBox_PeekPokeTest_Verilator345491158/AccumBlackBox.v', needed by `.../chisel-testers/test_run_dir/examples.AccumBlackBox_PeekPokeTest_Verilator345491158/VAccumBlackBoxWrapper.h'.  Stop.
-      //  or we end up including the same file multiple times.
-      val outputFile = outputFileName.map(new File(_)).getOrElse(new File(targetDir, defaultFileListName))
-      writeTextToFile(files.map(_.getCanonicalPath).mkString("\n"), outputFile)
-    }
-  }
 
   def writeTextToFile(text: String, file: File): Unit = {
     val out = new PrintWriter(file)

--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -161,6 +161,9 @@ object BlackBoxSourceHelper {
 
   val defaultFileListName = "firrtl_black_box_resource_files.f"
 
+  @deprecated("Renamed to defaultFileListName, as the file list name may now be changed with an annotation", "1.3")
+  def fileListName = defaultFileListName
+
   def writeFileList(files: ListSet[File], targetDir: File, outputFileName: Option[String]): Unit = {
     if (files.nonEmpty) {
       // We need the canonical path here, so verilator will create a path to the file that works from the targetDir,

--- a/src/test/scala/firrtlTests/transforms/BlackBoxSourceHelperSpec.scala
+++ b/src/test/scala/firrtlTests/transforms/BlackBoxSourceHelperSpec.scala
@@ -60,7 +60,7 @@ class BlacklBoxSourceHelperTransformSpec extends LowTransformSpec {
     execute(input, output, annos)
 
     val module = new java.io.File("test_run_dir/AdderExtModule.v")
-    val fileList = new java.io.File(s"test_run_dir/${BlackBoxSourceHelper.fileListName}")
+    val fileList = new java.io.File(s"test_run_dir/${BlackBoxSourceHelper.defaultFileListName}")
 
     module.exists should be (true)
     fileList.exists should be (true)
@@ -79,7 +79,7 @@ class BlacklBoxSourceHelperTransformSpec extends LowTransformSpec {
     execute(input, output, annos)
 
     val module = new java.io.File("test_run_dir/AdderExtModule.v")
-    val fileList = new java.io.File(s"test_run_dir/${BlackBoxSourceHelper.fileListName}")
+    val fileList = new java.io.File(s"test_run_dir/${BlackBoxSourceHelper.defaultFileListName}")
 
     module.exists should be (true)
     fileList.exists should be (true)
@@ -98,7 +98,7 @@ class BlacklBoxSourceHelperTransformSpec extends LowTransformSpec {
     execute(input, output, annos)
 
     new java.io.File("test_run_dir/AdderExtModule.v").exists should be (true)
-    new java.io.File(s"test_run_dir/${BlackBoxSourceHelper.fileListName}").exists should be (true)
+    new java.io.File(s"test_run_dir/${BlackBoxSourceHelper.defaultFileListName}").exists should be (true)
   }
 
   "verilog compiler" should "have BlackBoxSourceHelper transform" in {
@@ -130,7 +130,7 @@ class BlacklBoxSourceHelperTransformSpec extends LowTransformSpec {
       new java.io.File("test_run_dir/" + n).exists should be (true)
 
     //  but our file list should not include the verilog header file.
-    val fileListFile = new java.io.File(s"test_run_dir/${BlackBoxSourceHelper.fileListName}")
+    val fileListFile = new java.io.File(s"test_run_dir/${BlackBoxSourceHelper.defaultFileListName}")
     fileListFile.exists should be (true)
     val fileListFileSource = io.Source.fromFile(fileListFile)
     val fileList = fileListFileSource.getLines.mkString


### PR DESCRIPTION
Currently, the `.f` resource file gets generated with the constant filename of `firrtl_black_box_resource_files.f`. This PR keeps that as a default, but allows the user to override this filename with an optional annotation. The only other visibility outside of the transform is that a new parameter is added to `verilogToCpp` to enable sourcing a renamed file (but the default filename is used by default).

This is helpful to manage multiple `.f` files, which has come up as an issue in Chipyard.
 