### PR TITLE
Add ExpandConnects to TopWiringTransform fixup

### DIFF
--- a/src/main/scala/firrtl/transforms/TopWiring.scala
+++ b/src/main/scala/firrtl/transforms/TopWiring.scala
@@ -7,7 +7,8 @@ import firrtl.ir._
 import firrtl.passes.{Pass,
       InferTypes,
       ResolveKinds,
-      ResolveGenders
+      ResolveGenders,
+      ExpandConnects
       }
 import firrtl.annotations._
 import firrtl.Mappers._
@@ -224,6 +225,10 @@ class TopWiringTransform extends Transform {
   /** Run passes to fix up the circuit of making the new connections  */
   private def fixupCircuit(circuit: Circuit): Circuit = {
     val passes = Seq(
+      InferTypes,
+      ResolveKinds,
+      ResolveGenders,
+      ExpandConnects,
       InferTypes,
       ResolveKinds,
       ResolveGenders

--- a/src/test/scala/firrtlTests/transforms/TopWiringTest.scala
+++ b/src/test/scala/firrtlTests/transforms/TopWiringTest.scala
@@ -648,13 +648,15 @@ class AggregateTopWiringTests extends MiddleTransformSpec with TopWiringTestsCom
            |  module Top :
            |    output topwiring_a1_myAgg: { a: UInt<1>, b: SInt<8> }
            |    inst a1 of A
-           |    topwiring_a1_myAgg <= a1.topwiring_myAgg
+           |    topwiring_a1_myAgg.a <= a1.topwiring_myAgg.a
+           |    topwiring_a1_myAgg.b <= a1.topwiring_myAgg.b
            |  module A :
            |    output topwiring_myAgg: { a: UInt<1>, b: SInt<8> }
            |    wire myAgg: { a: UInt<1>, b: SInt<8> }
            |    myAgg.a <= UInt(0)
            |    myAgg.b <= SInt(-1)
-           |    topwiring_myAgg <= myAgg
+           |    topwiring_myAgg.a <= myAgg.a
+           |    topwiring_myAgg.b <= myAgg.b
            """.stripMargin
       execute(input, check, topwiringannos)
    }
@@ -685,22 +687,28 @@ class AggregateTopWiringTests extends MiddleTransformSpec with TopWiringTestsCom
            |    output topwiring_b_a2_myAgg: { a: UInt<1>, b: SInt<8> }
            |    inst a1 of A
            |    inst b of B
-           |    topwiring_a1_myAgg <= a1.topwiring_myAgg
-           |    topwiring_b_a1_myAgg <= b.topwiring_a1_myAgg
-           |    topwiring_b_a2_myAgg <= b.topwiring_a2_myAgg
+           |    topwiring_a1_myAgg.a <= a1.topwiring_myAgg.a
+           |    topwiring_a1_myAgg.b <= a1.topwiring_myAgg.b
+           |    topwiring_b_a1_myAgg.a <= b.topwiring_a1_myAgg.a
+           |    topwiring_b_a1_myAgg.b <= b.topwiring_a1_myAgg.b
+           |    topwiring_b_a2_myAgg.a <= b.topwiring_a2_myAgg.a
+           |    topwiring_b_a2_myAgg.b <= b.topwiring_a2_myAgg.b
            |  module B:
            |    output topwiring_a1_myAgg: { a: UInt<1>, b: SInt<8> }
            |    output topwiring_a2_myAgg: { a: UInt<1>, b: SInt<8> }
            |    inst a1 of A
            |    inst a2 of A
-           |    topwiring_a1_myAgg <= a1.topwiring_myAgg
-           |    topwiring_a2_myAgg <= a2.topwiring_myAgg
+           |    topwiring_a1_myAgg.a <= a1.topwiring_myAgg.a
+           |    topwiring_a1_myAgg.b <= a1.topwiring_myAgg.b
+           |    topwiring_a2_myAgg.a <= a2.topwiring_myAgg.a
+           |    topwiring_a2_myAgg.b <= a2.topwiring_myAgg.b
            |  module A :
            |    output topwiring_myAgg: { a: UInt<1>, b: SInt<8> }
            |    wire myAgg: { a: UInt<1>, b: SInt<8> }
            |    myAgg.a <= UInt(0)
            |    myAgg.b <= SInt(-1)
-           |    topwiring_myAgg <= myAgg
+           |    topwiring_myAgg.a <= myAgg.a
+           |    topwiring_myAgg.b <= myAgg.b
            """.stripMargin
       execute(input, check, topwiringannos)
    }


### PR DESCRIPTION
This fixes a bug in the `TopWiringTransform` when wiring aggregates by
adding `ExpandConnects` to its list of fixup passes. `TopWiringTransform`
is `MidForm => MidForm`, but when wiring aggregates, it will output bulk
connects. This violates the `MidForm` prerequisite that `ExpandConnects`
has run. Symptomatically, this will manifest as match errors in
`LowerTypes` if a user tries to use the `TopWiringTransform` on
aggregates.

An alternative solution would be to change to `MidForm => HighForm`.

A mid-term help here would be the frequently brought up `MidFormChecks` and `LowFormChecks` that would help indicate what's wrong here as opposed to match errors.