### PR TITLE
Fix "since" deprecation, should be "1.3" not "1.2"

### DIFF
--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -168,7 +168,7 @@ object BlackBoxSourceHelper {
 
   val defaultFileListName = "firrtl_black_box_resource_files.f"
 
-  @deprecated("Renamed to defaultFileListName, as the file list name may now be changed with an annotation", "1.3")
+  @deprecated("Renamed to defaultFileListName, as the file list name may now be changed with an annotation", "1.2")
   def fileListName = defaultFileListName
 
   def writeTextToFile(text: String, file: File): Unit = {


### PR DESCRIPTION
The deprecation here should be since `1.2` and not since `1.3`, I believe.

This look okay @albert-magyar?