### PR TITLE
FileUtils#getLines was broken in some multi-threading cases

### DIFF
--- a/src/main/scala/firrtl/FileUtils.scala
+++ b/src/main/scala/firrtl/FileUtils.scala
@@ -98,10 +98,7 @@ object FileUtils {
     * @param fileName The file to read
     */
   def getLines(fileName: String): Seq[String] = {
-    val source = scala.io.Source.fromFile(fileName)
-    val lines = source.getLines()
-    source.close()
-    lines.toSeq
+    getText(fileName).split("\n")
   }
 
   /** Read a text file and return it as  a Seq of strings
@@ -110,10 +107,7 @@ object FileUtils {
     * @param file a java File to be read
     */
   def getLines(file: File): Seq[String] = {
-    val source = scala.io.Source.fromFile(file)
-    val lines = source.getLines()
-    source.close()
-    lines.toSeq
+    getText(file).split("\n")
   }
 
   /** Read a text file and return it as  a single string

--- a/src/test/scala/firrtlTests/MultiThreadingSpec.scala
+++ b/src/test/scala/firrtlTests/MultiThreadingSpec.scala
@@ -2,6 +2,8 @@
 
 package firrtlTests
 
+import java.io.{File, PrintWriter}
+
 import firrtl.FileUtils
 import firrtl.{ChirrtlForm, CircuitState}
 
@@ -50,6 +52,41 @@ class MultiThreadingSpec extends FirrtlPropSpec {
       assert(results.flatten reduce (_ && _)) // check all true (ie. success)
     } catch {
       case _: Throwable => fail("The Compiler is not thread safe")
+    }
+  }
+
+  property("getLines should work when multi-threaded") {
+    val targetDir = "test_run_dir/multi_thread_getLines"
+    val fileName = targetDir + "/input_file"
+    FileUtils.makeDirectory(targetDir)
+    val f = new PrintWriter(new File(fileName))
+    f.write((0 to 1000).map { i => f"line $i%08d" }.mkString("\n") )
+    f.close()
+
+    val numberOfLines = FileUtils.getLines(fileName).length
+
+    val inputStrings = FileUtils.getLines(fileName)
+
+    val numThreads = 64 // arbitrary
+
+    import ExecutionContext.Implicits.global
+    try { // Use try-catch because error can manifest in many ways
+
+      val runResults = (0 to 10).map { _ =>
+        Future {
+          val threadFutures = (0 until numThreads) map { i =>
+            Future {
+              inputStrings.length == numberOfLines
+            }
+          }
+          Await.result(Future.sequence(threadFutures), Duration.Inf)
+        }
+      }
+
+      val results = Await.result(Future.sequence(runResults), Duration.Inf)
+      assert(results.flatten reduce (_ && _)) // check all true (ie. success)
+    } catch {
+      case _: Throwable => fail("The getLines is not thread safe")
     }
   }
 }


### PR DESCRIPTION
Fix by forcing file to be processed before returning
Add tests that seems to show if fixed