### PR TITLE
Make "build" the default make target rather than "clean"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ SBT_FLAGS ?= -Dsbt.log.noformat=true
 scala_jar ?= $(install_dir)/firrtl.jar
 scala_src := $(shell find src -type f \( -name "*.scala" -o -path "*/resources/*" \))
 
+build:	build-scala
+
 clean:
 	$(MAKE) -C $(root_dir)/spec clean
 	rm -f $(install_dir)/firrtl.jar
@@ -16,8 +18,6 @@ clean:
 .PHONY : specification
 specification:
 	$(MAKE) -C $(root_dir)/spec all
-
-build:	build-scala
 
 regress: $(scala_jar)
 	cd $(regress_dir) && $(install_dir)/firrtl -i rocket.fir -o rocket.v -X verilog


### PR DESCRIPTION
It's a little surprising that typing "make" in the firrtl directory deletes firrtl :)