### PR TITLE
Remove incorrect short option for --info-mode

### DIFF
--- a/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
+++ b/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
@@ -109,7 +109,7 @@ object InfoModeAnnotation extends HasShellOptions {
       longOption      = "info-mode",
       toAnnotationSeq = a => Seq(InfoModeAnnotation(a)),
       helpText        = s"Source file info handling mode (default: ${apply().modeName})",
-      shortOption     = Some("<ignore|use|gen|append>") ) )
+      helpValueName   = Some("<ignore|use|gen|append>") ) )
 
 }
 


### PR DESCRIPTION
This corrects a mistake in the info mode option. A `shortOption` was used in place of a `helpValueName`. Technically, this means that on master you can specify the info mode like: 
```
./firrtl -<ignore|use|gen|append> ignore
```

Oops.

Help text before:
```txt
  -<ignore|use|gen|append>, --info-mode <value>
                           Source file info handling mode (default: use)
```

Help text after:
```txt
  --info-mode <ignore|use|gen|append>
                           Source file info handling mode (default: use)
```