### PR TITLE
clean up spacing in inline test

### DIFF
--- a/src/test/scala/firrtlTests/InlineInstancesTests.scala
+++ b/src/test/scala/firrtlTests/InlineInstancesTests.scala
@@ -19,11 +19,10 @@ import logger.LogLevel.Debug
  */
 class InlineInstancesTests extends LowTransformSpec {
   def transform = new InlineInstances
-	def inline(mod: String): Annotation = {
-	  val parts = mod.split('.')
-		val modName = ModuleName(parts.head, CircuitName("Top")) // If this fails, bad input
-		val name = if (parts.size == 1) modName
-							 else ComponentName(parts.tail.mkString("."), modName)
+  def inline(mod: String): Annotation = {
+    val parts = mod.split('.')
+    val modName = ModuleName(parts.head, CircuitName("Top")) // If this fails, bad input
+    val name = if (parts.size == 1) modName else ComponentName(parts.tail.mkString("."), modName)
     InlineAnnotation(name)
   }
    // Set this to debug, this will apply to all tests


### PR DESCRIPTION
Small spacing fixes in the `InlineInstancesTest`. This matches the way the function is used for the `Flatten` tests.