### PR TITLE
Faster inline renaming

### DIFF
--- a/src/test/scala/firrtlTests/PassTests.scala
+++ b/src/test/scala/firrtlTests/PassTests.scala
@@ -38,6 +38,14 @@ abstract class SimpleTransformSpec extends FlatSpec with FirrtlMatchers with Com
       logger.debug(actual)
       logger.debug(expected)
       (actual) should be (expected)
+
+      annotations.foreach { anno =>
+        logger.debug(anno.serialize)
+      }
+
+      finalState.annotations.toSeq.foreach { anno =>
+        logger.debug(anno.serialize)
+      }
       checkAnnotations.foreach { check =>
         (finalState.annotations.toSeq) should contain (check)
       }


### PR DESCRIPTION
This PR makes some optimizations to `InlineInstances`. Mainly by reducing the number of chained `RenameMap`s. The number of chained `RenameMap`s should now be equal to the length of the longest path in the subgraph of inlined instances whereas before it was equal to the number of inlined instances.