### PR TITLE
Add explicit hline instead of phantom h1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![FIRRTL](https://raw.githubusercontent.com/freechipsproject/firrtl/master/doc/images/firrtl_logo.svg?sanitize=true)
 
-#
+---
 
 [![Join the chat at https://gitter.im/freechipsproject/firrtl](https://badges.gitter.im/freechipsproject/firrtl.svg)](https://gitter.im/freechipsproject/firrtl?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/freechipsproject/firrtl.svg?branch=master)](https://travis-ci.org/freechipsproject/firrtl)


### PR DESCRIPTION
The use of a phantom Header 1 doesn't render correctly on the website. This uses an explicit hline.