### PR TITLE
Add Block factory from argument list of Statements

### DIFF
--- a/src/main/scala/firrtl/ir/IR.scala
+++ b/src/main/scala/firrtl/ir/IR.scala
@@ -360,6 +360,11 @@ case class Conditionally(
   def foreachString(f: String => Unit): Unit = Unit
   def foreachInfo(f: Info => Unit): Unit = f(info)
 }
+
+object Block {
+  def apply(head: Statement, tail: Statement*): Block = Block(head +: tail)
+}
+
 case class Block(stmts: Seq[Statement]) extends Statement {
   def serialize: String = stmts map (_.serialize) mkString "\n"
   def mapStmt(f: Statement => Statement): Statement = Block(stmts map f)

--- a/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
+++ b/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
@@ -208,7 +208,7 @@ object RemoveCHIRRTL extends Transform {
         remove_chirrtl_e(SinkFlow)(Reference(name, value.tpe))
         has_read_mport match {
           case None => sx
-          case Some(en) => Block(Seq(sx, Connect(info, en, one)))
+          case Some(en) => Block(sx, Connect(info, en, one))
         }
       case Connect(info, loc, expr) =>
         val rocx = remove_chirrtl_e(SourceFlow)(expr)


### PR DESCRIPTION
This can eliminate boilerplate `Block(Seq(...))`. The 2-ary function pattern is necessary to disambiguate it from the default constructor, since a variadic parameter list is indistinguishable from a `Seq` after erasure.