### PR TITLE
Make TopWiringTransform Idempotent

### DIFF
--- a/src/main/scala/firrtl/transforms/TopWiring.scala
+++ b/src/main/scala/firrtl/transforms/TopWiring.scala
@@ -261,7 +261,13 @@ class TopWiringTransform extends Transform {
       val newCircuit = state.circuit.copy(modules = modulesx)
       val fixedCircuit = fixupCircuit(newCircuit)
       val mappings = sources(state.circuit.main).zipWithIndex
-      (state.copy(circuit = fixedCircuit), mappings)
+
+      val annosx = state.annotations.filter {
+        case _: TopWiringAnnotation => false
+        case _                      => true
+      }
+
+      (state.copy(circuit = fixedCircuit, annotations = annosx), mappings)
     }
     else { (state, List.empty) }
     //Generate output files based on the mapping.

--- a/src/test/scala/firrtlTests/transforms/TopWiringTest.scala
+++ b/src/test/scala/firrtlTests/transforms/TopWiringTest.scala
@@ -17,7 +17,8 @@ import firrtl.annotations.{
    CircuitName,
    ModuleName,
    ComponentName,
-   Annotation
+   Annotation,
+   Target
 }
 import firrtl.transforms.TopWiring._
 
@@ -625,6 +626,24 @@ class TopWiringTests extends MiddleTransformSpec with TopWiringTestsCommon  {
        case FirrtlExecutionSuccess(_, emitted) => parse(emitted) should be (parse(input))
        case _ => fail
      }
+   }
+
+   "TopWiringTransform" should "remove TopWiringAnnotations" in {
+     val input =
+       """|circuit Top:
+          |  module Top:
+          |    wire foo: UInt<1>""".stripMargin
+
+     val bar =
+       Target
+         .deserialize("~Top|Top>foo")
+         .toNamed match { case a: ComponentName => a }
+
+     val annotations = Seq(TopWiringAnnotation(bar, "bar_"))
+     val outputState = (new TopWiringTransform).execute(CircuitState(Parser.parse(input), MidForm, annotations, None))
+
+     outputState.circuit.serialize should include ("output bar_foo")
+     outputState.annotations.toSeq should be (empty)
    }
 }
 


### PR DESCRIPTION
This changes `TopWiringTransform` to remove `TopWiringAnnotation`s. This has the effect of making the transform idempotent where it previously was not. This fixes #1198 where running `TopWiringTransform` multiple times (`-fct TopWiringTransform,TopWiringTransform` or using a Chisel-level annotator that emitted `RunFirrtlTransformAnnotation`s) would cause the same signal to be top wired more than once.