### PR TITLE
Fix PrimOp of Literals reported as NonLiteralAsyncResetValue

### DIFF
--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -69,7 +69,6 @@ class HighFirrtlToMiddleFirrtl extends CoreTransform {
     passes.ResolveKinds,
     passes.InferTypes,
     passes.CheckTypes,
-    new checks.CheckResets,
     passes.ResolveFlows,
     new passes.InferWidths,
     passes.CheckWidths,
@@ -94,6 +93,7 @@ class MiddleFirrtlToLowFirrtl extends CoreTransform {
     passes.Legalize,
     new firrtl.transforms.RemoveReset,
     new firrtl.transforms.CheckCombLoops,
+    new checks.CheckResets,
     new firrtl.transforms.RemoveWires)
 }
 

--- a/src/main/scala/firrtl/checks/CheckResets.scala
+++ b/src/main/scala/firrtl/checks/CheckResets.scala
@@ -39,7 +39,11 @@ class CheckResets extends Transform {
           case prim @ DoPrim(_, args, _, _) => drivers += we(prim) -> args
           case _ => // Do nothing
         }
-      case Connect(_, lhs, rhs) => drivers += we(lhs) -> Seq(rhs)
+      case Connect(_, lhs, rhs) => 
+        lhs match {
+          case WRef(_,_,RegKind, _) => // registers are never to be literals
+          case _ => drivers += we(lhs) -> Seq(rhs)
+        }
       case reg @ DefRegister(_,_,_,_, reset, init) if reset.tpe == AsyncResetType =>
         regCheck += init -> reg
       case _ => // Do nothing

--- a/src/test/scala/firrtlTests/AsyncResetSpec.scala
+++ b/src/test/scala/firrtlTests/AsyncResetSpec.scala
@@ -279,6 +279,22 @@ class AsyncResetSpec extends FirrtlFlatSpec {
       )
     }
   }
+  "CheckResets" should "NOT raise StackOverflow Exception on Combinational Loops (should be caught by firrtl.transforms.CheckCombLoops)" in {
+    an [firrtl.transforms.CheckCombLoops.CombLoopException] shouldBe thrownBy {
+      compileBody(s"""    
+        |input clock : Clock
+        |input reset : AsyncReset
+        |wire x : UInt<1>
+        |wire y : UInt<2>
+        |x <= UInt<1>("h01")
+        |node ad = add(x, y)
+        |node adt = tail(ad, 1)
+        |y <= adt
+        |reg r : UInt, clock with : (reset => (reset, y))
+        |""".stripMargin
+      )
+    }
+  }
 
   "Every async reset reg" should "generate its own always block" in {
     val result = compileBody(s"""

--- a/src/test/scala/firrtlTests/AsyncResetSpec.scala
+++ b/src/test/scala/firrtlTests/AsyncResetSpec.scala
@@ -262,6 +262,23 @@ class AsyncResetSpec extends FirrtlFlatSpec {
       )
     }
   }
+  "Register output" should "NOT be allowed as reset values for AsyncReset" in {
+    an [checks.CheckResets.NonLiteralAsyncResetValueException] shouldBe thrownBy {
+      compileBody(s"""    
+        |input clock : Clock
+        |input areset : AsyncReset
+        |input reset : UInt<1>
+        |wire x : UInt
+        |x <= UInt<1>("h01")
+        |reg z : UInt<2>, clock with : (reset => (reset, UInt<2>("h00")))
+        |node ad = add(x, z)
+        |node adt = tail(ad, 1)
+        |z <= adt
+        |reg r : UInt, clock with : (reset => (areset, z))
+        |""".stripMargin
+      )
+    }
+  }
 
   "Every async reset reg" should "generate its own always block" in {
     val result = compileBody(s"""


### PR DESCRIPTION
**Type of issue**: bug report

**Impact**: no functional change

**Development Phase**: proposal

**If the current behavior is a bug, please provide the steps to reproduce the problem:**
### FIRRTL 

```scala
input clock : Clock
input reset : AsyncReset
output o : {field0 : UInt<1>, field1 : UInt<1>}
wire bundleInit : {field0 : UInt<1>, field1 : UInt<1>}
wire uintInit : UInt<2>
uintInit <= UInt<1>("h00")
node field0Init = bits(uintInit, 0, 0)
bundleInit.field0 <= field0Init
node field1Init = bits(uintInit, 1, 1)
bundleInit.field1 <= field1Init

reg bundle : {field0 : UInt<1>, field1 : UInt<1>}, clock with : (reset => (reset, bundleInit)) 
o <= bundle
```

### Chisel
Chisel use-case triggering the bug is the following:
```scala
val bundle = new Bundle {
  val field0 = Bool()
  val field1 = Bool()
}
val r = RegInit(0.U.asTypeOf(bundle)) 

```

**What is the current behavior?**
Any `PrimOp` of `Literal` (typically bit select `bits`) used as `AsyncReset` Init Value throw an `checks.CheckResets.NonLiteralAsyncResetValueException`

**What is the expected behavior?**
No error

**Please tell us about your environment:**
    - version: `master`
    - OS: `Darwin Kernel Version 17.7.0: Sun Jun  2 20:31:42 PDT 2019; root:xnu-4570.71.46~1/RELEASE_X86_64`

**What is the use case for changing the behavior?**
Better support of `AsyncReset` init values towards #1050 =)