### PR TITLE
Supply a trait to allow user annotations to provide JsonProtocol type hints

### DIFF
--- a/src/main/scala/firrtl/annotations/JsonProtocol.scala
+++ b/src/main/scala/firrtl/annotations/JsonProtocol.scala
@@ -124,7 +124,7 @@ object JsonProtocol {
     }).distinct
 
     val classes = findTypeHints(annos, true)
-    val loaded = classes.map(Class.forName(_).asInstanceOf[Class[_]])
+    val loaded = classes.map(Class.forName(_))
     implicit val formats = jsonFormat(loaded)
     read[List[Annotation]](in)
   }).recoverWith {

--- a/src/main/scala/firrtl/annotations/JsonProtocol.scala
+++ b/src/main/scala/firrtl/annotations/JsonProtocol.scala
@@ -10,7 +10,7 @@ import org.json4s.native.Serialization
 import org.json4s.native.Serialization.{read, writePretty}
 
 trait HasSerializationHints {
-  // For serialization of complicated constuctor arguments, let the annotation
+  // For serialization of complicated constructor arguments, let the annotation
   // writer specify additional type hints for relevant classes that might be
   // contained within
   def typeHints: Seq[Class[_]]
@@ -93,10 +93,10 @@ object JsonProtocol {
   def serialize(annos: Seq[Annotation]): String = serializeTry(annos).get
 
   def serializeTry(annos: Seq[Annotation]): Try[String] = {
-    val tags = annos.collect({
+    val tags = annos.flatMap({
       case anno: HasSerializationHints => anno.getClass +: anno.typeHints
       case anno => Seq(anno.getClass)
-    }).flatten.distinct
+    }).distinct
 
     implicit val formats = jsonFormat(tags)
     Try(writePretty(annos))

--- a/src/main/scala/firrtl/annotations/JsonProtocol.scala
+++ b/src/main/scala/firrtl/annotations/JsonProtocol.scala
@@ -13,7 +13,7 @@ trait HasSerializationHints {
   // For serialization of complicated constuctor arguments, let the annotation
   // writer specify additional type hints for relevant classes that might be
   // contained within
-  def typeHints(): Seq[Class[_]]
+  def typeHints: Seq[Class[_]]
 }
 
 object JsonProtocol {

--- a/src/test/scala/firrtl/JsonProtocolSpec.scala
+++ b/src/test/scala/firrtl/JsonProtocolSpec.scala
@@ -1,0 +1,62 @@
+// See LICENSE for license details.
+
+package firrtlTests
+
+import org.scalatest.FlatSpec
+import org.json4s._
+import org.json4s.native.JsonMethods._
+
+import firrtl.annotations.{NoTargetAnnotation, JsonProtocol, InvalidAnnotationJSONException, HasSerializationHints, Annotation}
+
+object JsonProtocolTestClasses {
+  trait Parent
+
+  case class ChildA(foo: Int) extends Parent
+  case class ChildB(bar: String) extends Parent
+  case class PolymorphicParameterAnnotation(param: Parent) extends NoTargetAnnotation
+  case class PolymorphicParameterAnnotationWithTypeHints(param: Parent) extends NoTargetAnnotation with HasSerializationHints {
+    def typeHints = Seq(param.getClass)
+  }
+
+  case class TypeParameterizedAnnotation[T](param: T) extends NoTargetAnnotation
+  case class TypeParameterizedAnnotationWithTypeHints[T](param: T) extends NoTargetAnnotation with HasSerializationHints {
+    def typeHints = Seq(param.getClass)
+  }
+}
+
+import JsonProtocolTestClasses._
+
+class JsonProtocolSpec extends FlatSpec {
+  def serializeAndDeserialize(anno: Annotation): Annotation = {
+    val serializedAnno = JsonProtocol.serialize(Seq(anno))
+    JsonProtocol.deserialize(serializedAnno).head
+  }
+
+  "Annotations with polymorphic parameters" should "not serialize and deserialize without type hints" in {
+    val anno = PolymorphicParameterAnnotation(ChildA(1))
+    assertThrows[InvalidAnnotationJSONException] {
+      serializeAndDeserialize(anno)
+    }
+  }
+
+  it should "serialize and deserialize with type hints" in {
+    val anno = PolymorphicParameterAnnotationWithTypeHints(ChildA(1))
+    val deserAnno = serializeAndDeserialize(anno)
+    assert(anno == deserAnno)
+
+    val anno2 = PolymorphicParameterAnnotationWithTypeHints(ChildB("Test"))
+    val deserAnno2 = serializeAndDeserialize(anno2)
+    assert(anno2 == deserAnno2)
+  }
+
+  "Annotations with non-primitive type parameters" should "not serialize and deserialize without type hints" in {
+    val anno = TypeParameterizedAnnotation(ChildA(1))
+    val deserAnno = serializeAndDeserialize(anno)
+    assert (anno != deserAnno)
+  }
+  it should "serialize and deserialize with type hints" in {
+    val anno = TypeParameterizedAnnotationWithTypeHints(ChildA(1))
+    val deserAnno = serializeAndDeserialize(anno)
+    assert (anno == deserAnno)
+  }
+}


### PR DESCRIPTION
This is one sketch of a solution to permit more flexible serialization and deserialization of user annotations defined outside of FIRRTL. Currently in FireSim, we use a hacked up version of the JsonProtocol to do precisely what's included in this PR.

I think it would be very easy to add an extra member to supply a custom serializer/deserializer but Json4s does a pretty good job by itself assuming you give it sufficient type hints. It can for instance handle type-parameterized case classes (see #1207), without needing to write a serializer.