### PR TITLE
Add explicit EOF to top-level parser rule

### DIFF
--- a/src/main/antlr4/FIRRTL.g4
+++ b/src/main/antlr4/FIRRTL.g4
@@ -29,7 +29,7 @@ import firrtl.LexerHelper;
 
 // Does there have to be at least one module?
 circuit
-  : 'circuit' id ':' info? INDENT module* DEDENT
+  : 'circuit' id ':' info? INDENT module* DEDENT EOF
   ;
 
 module

--- a/src/test/scala/firrtlTests/ParserSpec.scala
+++ b/src/test/scala/firrtlTests/ParserSpec.scala
@@ -169,6 +169,29 @@ class ParserSpec extends FirrtlFlatSpec {
       Driver.execute(manager)
     }
   }
+
+  "Trailing syntax errors" should "be caught in the parser" in {
+    val input = s"""
+      |circuit Foo:
+      |  module Bar:
+      |    input a: UInt<1>
+      |output b: UInt<1>
+      |    b <- a
+      |
+      |  module Foo:
+      |    input a: UInt<1>
+      |    output b: UInt<1>
+      |    inst bar of Bar
+      |    bar.a <- a
+      |    b <- bar.b
+      """.stripMargin
+    val manager = new ExecutionOptionsManager("test") with HasFirrtlOptions {
+      firrtlOptions = FirrtlExecutionOptions(firrtlSource = Some(input))
+    }
+    a [SyntaxErrorsException] shouldBe thrownBy {
+      Driver.execute(manager)
+    }
+  }
 }
 
 class ParserPropSpec extends FirrtlPropSpec {


### PR DESCRIPTION
* Fixes #1154
* Generally helps catch trailing syntax errors
* Performance-neutral relative to previous grammar
* Recommended by antlr4 devs, can help performance in some cases
* See [antlr4 issue](https://github.com/antlr/antlr4/issues/1540#issuecomment-268738030)