### PR TITLE
Guard initial blocks in emitted Verilog with `ifndef SYNTHESIS

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -878,6 +878,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
           emit(Seq(s"  reg [$width:0] initvar;"))
         }
         emit(Seq("`endif"))
+        emit(Seq("`ifndef SYNTHESIS"))
         emit(Seq("initial begin"))
         emit(Seq("  `ifdef RANDOMIZE"))
         emit(Seq("    `ifdef INIT_RANDOM"))
@@ -897,7 +898,8 @@ class VerilogEmitter extends SeqTransform with Emitter {
         for (x <- initials) emit(Seq(tab, x))
         emit(Seq("  `endif // RANDOMIZE"))
         for (x <- asyncInitials) emit(Seq(tab, x))
-        emit(Seq("end"))
+        emit(Seq("end // initial"))
+        emit(Seq("`endif // SYNTHESIS"))
       }
 
       for ((clk, content) <- noResetAlwaysBlocks if content.nonEmpty) {

--- a/src/test/scala/firrtlTests/VerilogEmitterTests.scala
+++ b/src/test/scala/firrtlTests/VerilogEmitterTests.scala
@@ -267,6 +267,24 @@ class VerilogEmitterSpec extends FirrtlFlatSpec {
     }
   }
 
+  "Initial Blocks" should "be guarded by ifndef SYNTHESIS" in {
+    val input =
+      """circuit Test :
+        |  module Test :
+        |    input clock : Clock
+        |    input reset : AsyncReset
+        |    input in : UInt<8>
+        |    output out : UInt<8>
+        |    reg r : UInt<8>, clock with : (reset => (reset, UInt(0)))
+        |    r <= in
+        |    out <= r
+        """.stripMargin
+    val state = CircuitState(parse(input), ChirrtlForm)
+    val result = (new VerilogCompiler).compileAndEmit(state, List())
+    result should containLines ("`ifndef SYNTHESIS", "initial begin")
+    result should containLines ("end // initial", "`endif // SYNTHESIS")
+  }
+
   "Verilog name conflicts" should "be resolved" in {
     val input =
       """|circuit parameter:


### PR DESCRIPTION
Fixes #1213 

With bump in rocket-chip, fixes https://github.com/chipsalliance/rocket-chip/issues/2168

Note that this is branched from the common ancestor of master and v1.2.0 so that it can be merged into both (rather than cherry-picked, although I don't know how much it matters).