### PR TITLE
Move CheckResets after CheckCombLoops

### DIFF
--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -71,7 +71,6 @@ class HighFirrtlToMiddleFirrtl extends CoreTransform {
     passes.ResolveKinds,
     passes.InferTypes,
     passes.CheckTypes,
-    new checks.CheckResets,
     passes.ResolveFlows,
     new passes.InferWidths,
     passes.CheckWidths,
@@ -97,6 +96,7 @@ class MiddleFirrtlToLowFirrtl extends CoreTransform {
     passes.Legalize,
     new firrtl.transforms.RemoveReset,
     new firrtl.transforms.CheckCombLoops,
+    new checks.CheckResets,
     new firrtl.transforms.RemoveWires)
 }
 

--- a/src/test/scala/firrtlTests/AsyncResetSpec.scala
+++ b/src/test/scala/firrtlTests/AsyncResetSpec.scala
@@ -231,6 +231,22 @@ class AsyncResetSpec extends FirrtlFlatSpec {
     result should containLine ("always @(posedge clock or posedge reset) begin")
   }
 
+  "CheckResets" should "NOT raise StackOverflow Exception on Combinational Loops (should be caught by firrtl.transforms.CheckCombLoops)" in {
+    an [firrtl.transforms.CheckCombLoops.CombLoopException] shouldBe thrownBy {
+      compileBody(s"""
+        |input clock : Clock
+        |input reset : AsyncReset
+        |wire x : UInt<1>
+        |wire y : UInt<2>
+        |x <= UInt<1>("h01")
+        |node ad = add(x, y)
+        |node adt = tail(ad, 1)
+        |y <= adt
+        |reg r : UInt, clock with : (reset => (reset, y))
+        |""".stripMargin
+      )
+    }
+  }
 
   "Every async reset reg" should "generate its own always block" in {
     val result = compileBody(s"""


### PR DESCRIPTION
Recursive literal lookup needs to be guarded against combinational loops
Added a test-case to illustrate the issue when CheckResets is run before CheckCombLoops

Cherry-pick of patch from https://github.com/freechipsproject/firrtl/pull/1201

As stated in #1201, we should fix `CheckResets` to not require this, but the patch fixes the problem and the test is great to include.