### PR TITLE
getSimpleName considered harmful

### DIFF
--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -171,7 +171,7 @@ final case object UnknownForm extends CircuitForm(-1) {
 /** The basic unit of operating on a Firrtl AST */
 abstract class Transform extends TransformLike[CircuitState] {
   /** A convenience function useful for debugging and error messages */
-  def name: String = this.getClass.getSimpleName
+  def name: String = this.getClass.getName
   /** The [[firrtl.CircuitForm]] that this transform requires to operate on */
   def inputForm: CircuitForm
   /** The [[firrtl.CircuitForm]] that this transform outputs */

--- a/src/main/scala/firrtl/annotations/JsonProtocol.scala
+++ b/src/main/scala/firrtl/annotations/JsonProtocol.scala
@@ -109,7 +109,7 @@ object JsonProtocol {
     val annos = parsed match {
       case JArray(objs) => objs
       case x => throw new InvalidAnnotationJSONException(
-        s"Annotations must be serialized as a JArray, got ${x.getClass.getSimpleName} instead!")
+        s"Annotations must be serialized as a JArray, got ${x.getClass.getName} instead!")
     }
     // Recursively gather typeHints by pulling the "class" field from JObjects
     // Json4s should emit this as the first field in all serialized classes

--- a/src/main/scala/firrtl/options/DependencyManager.scala
+++ b/src/main/scala/firrtl/options/DependencyManager.scala
@@ -291,7 +291,7 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
     val nodes =
       (prerequisiteGraph + dependentsGraph + invalidateGraph + otherDependents)
         .getVertices
-        .map(v => s"""${transformName(v)} [label="${v.getClass.getSimpleName}"]""")
+        .map(v => s"""${transformName(v)} [label="${v.getClass.getName}"]""")
 
     s"""|digraph DependencyManager {
         |  graph [rankdir=BT]
@@ -315,8 +315,8 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
     def rec(pm: DependencyManager[A, B], cm: Seq[String], tab: String = "", id: Int = 0): (String, Int) = {
       var offset = id
 
-      val targets = pm._targets.toSeq.map(_.getSimpleName).mkString(", ")
-      val state = pm._currentState.toSeq.map(_.getSimpleName).mkString(", ")
+      val targets = pm._targets.toSeq.map(_.getName).mkString(", ")
+      val state = pm._currentState.toSeq.map(_.getName).mkString(", ")
 
       val header = s"""|${tab}subgraph cluster_$id {
                        |$tab  label="targets: $targets\\nstate: $state"
@@ -331,7 +331,7 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
         case a =>
           val name = s"""${transformName(a, "_" + id)}"""
           sorted += name
-          s"""$tab  $name [label="${a.getClass.getSimpleName}"]"""
+          s"""$tab  $name [label="${a.getClass.getName}"]"""
       }.mkString("\n")
 
       (Seq(header, body, s"$tab}").mkString("\n"), offset)

--- a/src/main/scala/firrtl/stage/package.scala
+++ b/src/main/scala/firrtl/stage/package.scala
@@ -49,7 +49,7 @@ package object stage {
       options.collectFirst{ case a: FirrtlCircuitAnnotation => a.circuit } match {
         case None => FirrtlExecutionFailure("No circuit found in AnnotationSeq!")
         case Some(a) => FirrtlExecutionSuccess(
-          emitType = fopts.compiler.getClass.getSimpleName,
+          emitType = fopts.compiler.getClass.getName,
           emitted = emittedRes,
           circuitState = CircuitState(
             circuit = a,


### PR DESCRIPTION
`getSimpleName` can throw stupid exceptions in Java 8. This means that if you define a `Transform` inside an object (or in an environment like a REPL that is wrapping things in objects), if you call the `name` method of a `Transform` (delete an annotation, run with `-ll info`) then you'll wind up with a malformed class name exception.

This changes all usages of `getSimpleName` to use `getName`. This is not super desirable from a readability perspective, but it's actually safe.

Alternatively, we could define a custom method like https://github.com/freechipsproject/chisel3/pull/1224. However, I don't think this is really necessary here as a `Transform` name is intended for printing and debugging, not for Verilog naming.

### Checklist

- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

<!-- Choose one or more from the following: -->
   - bug fix                            

### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

This should have no API impact, but does change the default `name` of all `Transform`s. This may have impact for things relying on `DeletedAnnotation`s or on parsing `-ll info` output. The former matters as some of the Driver Stage/Phase backwards compatibility is relying on `DeletedAnnotation`s. However, Chisel does not use hard-coded strings. Anything that does use a hard-coded string will break due to this PR.

### Backend Code Generation Impact

No impact.

### Desired Merge Strategy

   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

