### PR TITLE
Updates for sbt usage of scalafmt

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,4 @@
+version = "2.2.2"
 maxColumn = 120
 align = most
 continuationIndent.defnSite = 2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,4 +22,6 @@ addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.5")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.7")
 
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.2.0")
+
 libraryDependencies += "com.github.os72" % "protoc-jar" % "3.5.1.1"


### PR DESCRIPTION
I tried to run the `formatted-1` branch locally, but `sbt` wanted these modifications. Specifically, it wants the file to be called `.scalafmt.conf` not `.scalafmt.config`. Also, the config needs a version string and this adds `scalafmt` as a plugin. I expect that IntelliJ already has all this so it's superfluous there.