### PR TITLE
[Mergify] Automatically merge backport PRs when ready

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -43,10 +43,8 @@ pull_request_rules:
   - name: automatic squash-and-merge of backport PRs
     conditions:
       - status-success=continuous-integration/travis-ci/pr
-      - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - base=1.2.x
-      - label="Please Merge"
       - label="Backport"
       - label!="DO NOT MERGE"
     actions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -39,3 +39,18 @@ pull_request_rules:
     actions:
       label:
         add: [Backport]
+
+  - name: automatic squash-and-merge of backport PRs
+    conditions:
+      - status-success=continuous-integration/travis-ci/pr
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+      - base=1.2.x
+      - label="Please Merge"
+      - label="Backport"
+      - label!="DO NOT MERGE"
+    actions:
+      merge:
+        method: squash
+        strict: smart
+        strict_method: merge


### PR DESCRIPTION
@jackkoenig 

Mergify can merge backports now. This rule could be generalized for more backport branches in the future, but I thought it would be good to keep it separate from master by checking for a) a backport branch and b) the label.

We could even drop the review requirement for these.

### Type of Improvement: repo metadata
### API Impact: none
### Backend Code Generation Impact: none
### Desired Merge Strategy: squash