### PR TITLE
Remove scala-logging fully in favor of our own logger

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,10 +55,6 @@ javacOptions ++= javacOptionsVersion(scalaVersion.value)
 
 libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value
 
-libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0"
-
-libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"
-
 // sbt 1.2.6 fails with `Symbol 'term org.junit' is missing from the classpath`
 // when compiling tests under 2.11.12
 // An explicit dependency on junit seems to alleviate this.

--- a/src/main/scala/firrtl/ExecutionOptionsManager.scala
+++ b/src/main/scala/firrtl/ExecutionOptionsManager.scala
@@ -2,14 +2,14 @@
 
 package firrtl
 
+import logger.LogLevel
+import logger.{ClassLogLevelAnnotation, LogClassNamesAnnotation, LogFileAnnotation, LogLevelAnnotation}
 import firrtl.annotations._
-import firrtl.Parser._
+import firrtl.Parser.{InfoMode, UseInfo, IgnoreInfo, GenInfo, AppendInfo}
 import firrtl.ir.Circuit
 import firrtl.passes.memlib.{InferReadWriteAnnotation, ReplSeqMemAnnotation}
 import firrtl.passes.clocklist.ClockListAnnotation
 import firrtl.transforms.NoCircuitDedupAnnotation
-import logger.LogLevel
-import logger.{ClassLogLevelAnnotation, LogClassNamesAnnotation, LogFileAnnotation, LogLevelAnnotation}
 import scopt.OptionParser
 import firrtl.stage.{CompilerAnnotation, FirrtlCircuitAnnotation, FirrtlFileAnnotation, FirrtlSourceAnnotation,
   InfoModeAnnotation, OutputFileAnnotation, RunFirrtlTransformAnnotation}

--- a/src/main/scala/firrtl/Parser.scala
+++ b/src/main/scala/firrtl/Parser.scala
@@ -4,7 +4,7 @@ package firrtl
 
 import org.antlr.v4.runtime._
 import org.antlr.v4.runtime.atn._
-import com.typesafe.scalalogging.LazyLogging
+import logger.LazyLogging
 import firrtl.ir._
 import firrtl.Utils.time
 import firrtl.antlr.{FIRRTLParser, _}

--- a/src/main/scala/firrtl/PrimOps.scala
+++ b/src/main/scala/firrtl/PrimOps.scala
@@ -2,8 +2,8 @@
 
 package firrtl
 
+import logger.LazyLogging
 import firrtl.ir._
-import com.typesafe.scalalogging.LazyLogging
 import Implicits.{constraint2bound, constraint2width, width2constraint}
 import firrtl.constraint._
 

--- a/src/test/scala/firrtlTests/FirrtlSpec.scala
+++ b/src/test/scala/firrtlTests/FirrtlSpec.scala
@@ -5,7 +5,7 @@ package firrtlTests
 import java.io._
 import java.security.Permission
 
-import com.typesafe.scalalogging.LazyLogging
+import logger.LazyLogging
 
 import scala.sys.process._
 import org.scalatest._


### PR DESCRIPTION
There was some vestigial logging that conflicts with the homebrewed
logger used by most of the codebase

### Checklist

- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

Code cleanup to remove a vestigial dependency. This is definitely 1.3, it should **not** be included in 1.2.X

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

### API Impact

This is unlikely to conflict with anything, but technically changes the types of `object Parser` and `object PrimOps` in that they are now `logger.LazyLogging` instead of `com.typesafe.scalalogging.LazyLogging`. Furthermore, any codebases relying on depending on FIRRTL to bring in the `scala-logging` dependencies will no longer be getting those dependencies through FIRRTL.

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

### Backend Code Generation Impact

No impact
<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

### Desired Merge Strategy

Don't care
<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
