### PR TITLE
Cleanup testing console

### DIFF
--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -485,7 +485,7 @@ trait Compiler extends LazyLogging {
       }
     }
 
-    logger.error(f"Total FIRRTL Compile Time: $timeMillis%.1f ms")
+    logger.warn(f"Total FIRRTL Compile Time: $timeMillis%.1f ms")
 
     finalState
   }

--- a/src/test/scala/firrtlTests/CustomTransformSpec.scala
+++ b/src/test/scala/firrtlTests/CustomTransformSpec.scala
@@ -79,7 +79,7 @@ class CustomTransformSpec extends FirrtlFlatSpec {
       def inputForm = HighForm
       def outputForm = HighForm
       def execute(s: CircuitState) = {
-        println(name)
+        assert(name.endsWith("A"))
         s
       }
     }

--- a/src/test/scala/firrtlTests/DriverSpec.scala
+++ b/src/test/scala/firrtlTests/DriverSpec.scala
@@ -498,8 +498,8 @@ class VcdSuppressionSpec extends FirrtlFlatSpec {
       val harness = new File(testDir, s"top.cpp")
       copyResourceToFile(cppHarnessResourceName, harness)
 
-      verilogToCpp(prefix, testDir, Seq.empty, harness, suppress).!
-      cppToExe(prefix, testDir).!
+      verilogToCpp(prefix, testDir, Seq.empty, harness, suppress) #&&
+      cppToExe(prefix, testDir) ! loggingProcessLogger
 
       assert(executeExpectingSuccess(prefix, testDir))
 

--- a/src/test/scala/firrtlTests/DriverSpec.scala
+++ b/src/test/scala/firrtlTests/DriverSpec.scala
@@ -76,21 +76,21 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
       val optionsManager = new ExecutionOptionsManager("test")
 
       optionsManager.parse(Array("--top-name", "dog", "fox", "tardigrade", "stomatopod")) should be(true)
-      println(s"programArgs ${optionsManager.commonOptions.programArgs}")
+      info(s"programArgs ${optionsManager.commonOptions.programArgs}")
       optionsManager.commonOptions.programArgs.length should be(3)
       optionsManager.commonOptions.programArgs should be("fox" :: "tardigrade" :: "stomatopod" :: Nil)
 
       optionsManager.commonOptions = CommonOptions()
       optionsManager.parse(
         Array("dog", "stomatopod")) should be(true)
-      println(s"programArgs ${optionsManager.commonOptions.programArgs}")
+      info(s"programArgs ${optionsManager.commonOptions.programArgs}")
       optionsManager.commonOptions.programArgs.length should be(2)
       optionsManager.commonOptions.programArgs should be("dog" :: "stomatopod" :: Nil)
 
       optionsManager.commonOptions = CommonOptions()
       optionsManager.parse(
         Array("fox", "--top-name", "dog", "tardigrade", "stomatopod")) should be(true)
-      println(s"programArgs ${optionsManager.commonOptions.programArgs}")
+      info(s"programArgs ${optionsManager.commonOptions.programArgs}")
       optionsManager.commonOptions.programArgs.length should be(3)
       optionsManager.commonOptions.programArgs should be("fox" :: "tardigrade" :: "stomatopod" :: Nil)
 
@@ -504,7 +504,6 @@ class VcdSuppressionSpec extends FirrtlFlatSpec {
       assert(executeExpectingSuccess(prefix, testDir))
 
       val vcdFile = new File(s"$testDir/dump.vcd")
-      println(s"file ${vcdFile.getAbsolutePath} ${vcdFile.exists()}")
       vcdFile.exists() should be(! suppress)
     }
 

--- a/src/test/scala/firrtlTests/FirrtlSpec.scala
+++ b/src/test/scala/firrtlTests/FirrtlSpec.scala
@@ -7,18 +7,16 @@ import java.security.Permission
 
 import logger.LazyLogging
 
-import scala.sys.process._
 import org.scalatest._
 import org.scalatest.prop._
 
 import firrtl._
 import firrtl.ir._
-import firrtl.Parser.{IgnoreInfo, UseInfo}
-import firrtl.analyses.{GetNamespace, InstanceGraph, ModuleNamespaceAnnotation}
+import firrtl.Parser.UseInfo
+import firrtl.analyses.{GetNamespace, ModuleNamespaceAnnotation}
 import firrtl.annotations._
 import firrtl.transforms.{DontTouchAnnotation, NoDedupAnnotation, RenameModules}
 import firrtl.util.BackendCompilationUtilities
-import scala.collection.mutable
 
 class CheckLowForm extends SeqTransform {
   def inputForm = LowForm
@@ -146,8 +144,9 @@ trait FirrtlRunners extends BackendCompilationUtilities {
       file
     }
 
-    verilogToCpp(prefix, testDir, verilogFiles, harness).!
-    cppToExe(prefix, testDir).!
+    verilogToCpp(prefix, testDir, verilogFiles, harness) #&&
+    cppToExe(prefix, testDir) !
+    loggingProcessLogger
     assert(executeExpectingSuccess(prefix, testDir))
   }
 }

--- a/src/test/scala/firrtlTests/FirrtlSpec.scala
+++ b/src/test/scala/firrtlTests/FirrtlSpec.scala
@@ -13,6 +13,7 @@ import org.scalatest.prop._
 import firrtl._
 import firrtl.ir._
 import firrtl.Parser.UseInfo
+import firrtl.stage.{FirrtlFileAnnotation, InfoModeAnnotation, RunFirrtlTransformAnnotation}
 import firrtl.analyses.{GetNamespace, ModuleNamespaceAnnotation}
 import firrtl.annotations._
 import firrtl.transforms.{DontTouchAnnotation, NoDedupAnnotation, RenameModules}
@@ -107,16 +108,17 @@ trait FirrtlRunners extends BackendCompilationUtilities {
       customTransforms: Seq[Transform] = Seq.empty,
       annotations: AnnotationSeq = Seq.empty): File = {
     val testDir = createTestDirectory(prefix)
-    copyResourceToFile(s"${srcDir}/${prefix}.fir", new File(testDir, s"${prefix}.fir"))
+    val inputFile = new File(testDir, s"${prefix}.fir")
+    copyResourceToFile(s"${srcDir}/${prefix}.fir", inputFile)
 
-    val optionsManager = new ExecutionOptionsManager(prefix) with HasFirrtlOptions {
-      commonOptions = CommonOptions(topName = prefix, targetDirName = testDir.getPath)
-      firrtlOptions = FirrtlExecutionOptions(
-                        infoModeName = "ignore",
-                        customTransforms = customTransforms ++ extraCheckTransforms,
-                        annotations = annotations.toList)
-    }
-    firrtl.Driver.execute(optionsManager)
+    val annos =
+      FirrtlFileAnnotation(inputFile.toString) +:
+      TargetDirAnnotation(testDir.toString) +:
+      InfoModeAnnotation("ignore") +:
+      annotations ++:
+      (customTransforms ++ extraCheckTransforms).map(RunFirrtlTransformAnnotation(_))
+
+    (new firrtl.stage.FirrtlStage).run(annos)
 
     testDir
   }

--- a/src/test/scala/firrtlTests/IntegrationSpec.scala
+++ b/src/test/scala/firrtlTests/IntegrationSpec.scala
@@ -42,8 +42,8 @@ class GCDSplitEmissionExecutionTest extends FirrtlFlatSpec {
     copyResourceToFile(cppHarnessResourceName, harness)
 
     // topFile will be compiled by Verilator command by default but we need to also include dutFile
-    verilogToCpp(top, testDir, Seq(dutFile), harness).!
-    cppToExe(top, testDir).!
+    verilogToCpp(top, testDir, Seq(dutFile), harness) #&&
+    cppToExe(top, testDir) ! loggingProcessLogger
     assert(executeExpectingSuccess(top, testDir))
   }
 }

--- a/src/test/scala/firrtlTests/RenameMapSpec.scala
+++ b/src/test/scala/firrtlTests/RenameMapSpec.scala
@@ -161,7 +161,6 @@ class RenameMapSpec extends FirrtlFlatSpec {
         t.instOf("a", "A" + idx)
       }.ref("ref")
       val (millis, rename) = firrtl.Utils.time(renames.get(deepTarget))
-      println(s"${(deepTarget.tokens.size - 1) / 2} -> $millis")
       //rename should be(None)
     }
   }
@@ -281,7 +280,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
     renames.record(top.module("E").instOf("f", "F"), top.module("E").ref("g"))
 
     a [IllegalRenameException] shouldBe thrownBy {
-      println(renames.get(top.module("E").instOf("f", "F").ref("g")))
+      renames.get(top.module("E").instOf("f", "F").ref("g"))
     }
   }
 

--- a/src/test/scala/firrtlTests/StringSpec.scala
+++ b/src/test/scala/firrtlTests/StringSpec.scala
@@ -23,8 +23,8 @@ class PrintfSpec extends FirrtlPropSpec {
     val harness = new File(testDir, s"top.cpp")
     copyResourceToFile(cppHarnessResourceName, harness)
 
-    verilogToCpp(prefix, testDir, Seq(), harness).!
-    cppToExe(prefix, testDir).!
+    verilogToCpp(prefix, testDir, Seq(), harness) #&&
+    cppToExe(prefix, testDir) ! loggingProcessLogger
 
     // Check for correct Printf:
     // Count up from 0, match decimal, hex, and binary

--- a/src/test/scala/firrtlTests/annotationTests/TargetSpec.scala
+++ b/src/test/scala/firrtlTests/annotationTests/TargetSpec.scala
@@ -9,7 +9,6 @@ import firrtlTests.FirrtlPropSpec
 class TargetSpec extends FirrtlPropSpec {
   def check(comp: Target): Unit = {
     val named = Target.convertTarget2Named(comp)
-    println(named)
     val comp2 = Target.convertNamed2Target(named)
     assert(comp.toGenericTarget.complete == comp2)
   }
@@ -43,7 +42,6 @@ class TargetSpec extends FirrtlPropSpec {
     val x_reg0_data = top.instOf("x", "X").ref("reg0").field("data")
     top.instOf("x", "x")
     top.ref("y")
-    println(x_reg0_data)
   }
   property("Should serialize and deserialize") {
     val circuit = CircuitTarget("Circuit")

--- a/src/test/scala/firrtlTests/execution/VerilogExecution.scala
+++ b/src/test/scala/firrtlTests/execution/VerilogExecution.scala
@@ -25,8 +25,8 @@ trait VerilogExecution extends TestExecution {
     copyResourceToFile(cppHarnessResourceName, harness)
 
     // Make and run Verilog simulation
-    verilogToCpp(c.main, testDir, Nil, harness).!
-    cppToExe(c.main, testDir).!
+    verilogToCpp(c.main, testDir, Nil, harness) #&&
+    cppToExe(c.main, testDir) ! loggingProcessLogger
     assert(executeExpectingSuccess(c.main, testDir))
   }
 }


### PR DESCRIPTION
Built on top of https://github.com/freechipsproject/firrtl/pull/1258 so requires that to be merged first.

Because of the dependency on #1258, it cannot be backported. It doesn't really matter though, this is for testing/debugging which we generally do against master.

### Checklist

- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

Code refactoring/cleanup.

This PR makes the console for running tests *much* cleaner by not printing the shell commands and output of Verilator and stuff by default. Instead, these processes use LogLevel.Info for Stdout and LogLevel.Warn for Stderr. I also lowered the level for printing total FIRRTL compile time from error to warn.

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

### API Impact

Some people may not see the total FIRRTL compile time by default any more, this is easily fixed by using log-level warn.
<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

### Backend Code Generation Impact

No effect
<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

### Desired Merge Strategy

Merge commit, I'll take care of rebasing as necessary.

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
