### PR TITLE
RFC: Enhance support for singleton transforms

### DIFF
--- a/src/main/scala/firrtl/AddDescriptionNodes.scala
+++ b/src/main/scala/firrtl/AddDescriptionNodes.scala
@@ -67,7 +67,7 @@ private case class DescribedMod(description: Description,
   * @note should only be used by VerilogEmitter, described nodes will
   *       break other transforms.
   */
-class AddDescriptionNodes extends Transform {
+object AddDescriptionNodes extends Transform {
   def inputForm = LowForm
   def outputForm = LowForm
 

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -430,7 +430,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
   def getRenderer(descriptions: Seq[DescriptionAnnotation],
                   m: Module,
                   moduleMap: Map[String, DefModule])(implicit writer: Writer): VerilogRender = {
-    val newMod = new AddDescriptionNodes().executeModule(m, descriptions)
+    val newMod = AddDescriptionNodes.executeModule(m, descriptions)
 
     newMod match {
       case DescribedMod(d, pds, m: Module) => new VerilogRender(d, pds, m, moduleMap)(writer)
@@ -966,7 +966,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
     passes.VerilogModulusCleanup,
     new VerilogRename,
     passes.VerilogPrep,
-    new AddDescriptionNodes)
+    AddDescriptionNodes)
 
   def emit(state: CircuitState, writer: Writer): Unit = {
     val circuit = runTransforms(state).circuit

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -116,7 +116,7 @@ class LowFirrtlOptimization extends CoreTransform {
     passes.memlib.VerilogMemDelays, // TODO move to Verilog emitter
     firrtl.transforms.ConstantPropagation,
     passes.SplitExpressions,
-    new firrtl.transforms.CombineCats,
+    firrtl.transforms.CombineCats,
     passes.CommonSubexpressionElimination,
     new firrtl.transforms.DeadCodeElimination)
 }

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -97,7 +97,7 @@ class MiddleFirrtlToLowFirrtl extends CoreTransform {
     firrtl.transforms.RemoveReset,
     firrtl.transforms.CheckCombLoops,
     checks.CheckResets,
-    new firrtl.transforms.RemoveWires)
+    firrtl.transforms.RemoveWires)
 }
 
 /** Runs a series of optimization passes on LowFirrtl

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -49,7 +49,7 @@ class ResolveAndCheck extends CoreTransform {
     passes.TrimIntervals,
     passes.InferWidths,
     passes.CheckWidths,
-    new firrtl.transforms.InferResets)
+    firrtl.transforms.InferResets)
 }
 
 /** Expands aggregate connects, removes dynamic accesses, and when

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -46,7 +46,7 @@ class ResolveAndCheck extends CoreTransform {
     passes.ResolveFlows,
     passes.CheckFlows,
     passes.InferBinaryPoints,
-    new passes.TrimIntervals(),
+    passes.TrimIntervals,
     new passes.InferWidths,
     passes.CheckWidths,
     new firrtl.transforms.InferResets)

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -95,7 +95,7 @@ class MiddleFirrtlToLowFirrtl extends CoreTransform {
     passes.InferWidths,
     passes.Legalize,
     new firrtl.transforms.RemoveReset,
-    new firrtl.transforms.CheckCombLoops,
+    firrtl.transforms.CheckCombLoops,
     new checks.CheckResets,
     new firrtl.transforms.RemoveWires)
 }

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -47,7 +47,7 @@ class ResolveAndCheck extends CoreTransform {
     passes.CheckFlows,
     passes.InferBinaryPoints,
     passes.TrimIntervals,
-    new passes.InferWidths,
+    passes.InferWidths,
     passes.CheckWidths,
     new firrtl.transforms.InferResets)
 }
@@ -72,7 +72,7 @@ class HighFirrtlToMiddleFirrtl extends CoreTransform {
     passes.InferTypes,
     passes.CheckTypes,
     passes.ResolveFlows,
-    new passes.InferWidths,
+    passes.InferWidths,
     passes.CheckWidths,
     passes.RemoveIntervals,
     passes.ConvertFixedToSInt,
@@ -92,7 +92,7 @@ class MiddleFirrtlToLowFirrtl extends CoreTransform {
     passes.ResolveKinds,
     passes.InferTypes,
     passes.ResolveFlows,
-    new passes.InferWidths,
+    passes.InferWidths,
     passes.Legalize,
     new firrtl.transforms.RemoveReset,
     new firrtl.transforms.CheckCombLoops,

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -96,7 +96,7 @@ class MiddleFirrtlToLowFirrtl extends CoreTransform {
     passes.Legalize,
     firrtl.transforms.RemoveReset,
     firrtl.transforms.CheckCombLoops,
-    new checks.CheckResets,
+    checks.CheckResets,
     new firrtl.transforms.RemoveWires)
 }
 

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -94,7 +94,7 @@ class MiddleFirrtlToLowFirrtl extends CoreTransform {
     passes.ResolveFlows,
     passes.InferWidths,
     passes.Legalize,
-    new firrtl.transforms.RemoveReset,
+    firrtl.transforms.RemoveReset,
     firrtl.transforms.CheckCombLoops,
     new checks.CheckResets,
     new firrtl.transforms.RemoveWires)

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -45,7 +45,7 @@ class ResolveAndCheck extends CoreTransform {
     passes.InferTypes,
     passes.ResolveFlows,
     passes.CheckFlows,
-    new passes.InferBinaryPoints(),
+    passes.InferBinaryPoints,
     new passes.TrimIntervals(),
     new passes.InferWidths,
     passes.CheckWidths,

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -74,7 +74,7 @@ class HighFirrtlToMiddleFirrtl extends CoreTransform {
     passes.ResolveFlows,
     new passes.InferWidths,
     passes.CheckWidths,
-    new passes.RemoveIntervals(),
+    passes.RemoveIntervals,
     passes.ConvertFixedToSInt,
     passes.ZeroWidth,
     passes.InferTypes)

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -109,12 +109,12 @@ class LowFirrtlOptimization extends CoreTransform {
   def outputForm = LowForm
   def transforms = Seq(
     passes.RemoveValidIf,
-    new firrtl.transforms.ConstantPropagation,
+    firrtl.transforms.ConstantPropagation,
     passes.PadWidths,
-    new firrtl.transforms.ConstantPropagation,
+    firrtl.transforms.ConstantPropagation,
     passes.Legalize,
     passes.memlib.VerilogMemDelays, // TODO move to Verilog emitter
-    new firrtl.transforms.ConstantPropagation,
+    firrtl.transforms.ConstantPropagation,
     passes.SplitExpressions,
     new firrtl.transforms.CombineCats,
     passes.CommonSubexpressionElimination,

--- a/src/main/scala/firrtl/checks/CheckResets.scala
+++ b/src/main/scala/firrtl/checks/CheckResets.scala
@@ -10,7 +10,13 @@ import firrtl.WrappedExpression._
 
 import scala.collection.mutable
 
-object CheckResets {
+// Must run after ExpandWhens
+// Requires
+//   - static single connections of ground types
+object CheckResets extends Transform {
+  def inputForm: CircuitForm = MidForm
+  def outputForm: CircuitForm = MidForm
+
   class NonLiteralAsyncResetValueException(info: Info, mname: String, reg: String, init: String) extends PassException(
     s"$info: [module $mname] AsyncReset Reg '$reg' reset to non-literal '$init'")
 
@@ -19,17 +25,6 @@ object CheckResets {
   // Record driving for literal propagation
   // Indicates *driven by*
   private type DirectDriverMap = mutable.HashMap[WrappedExpression, Expression]
-
-}
-
-// Must run after ExpandWhens
-// Requires
-//   - static single connections of ground types
-class CheckResets extends Transform {
-  def inputForm: CircuitForm = MidForm
-  def outputForm: CircuitForm = MidForm
-
-  import CheckResets._
 
   private def onStmt(regCheck: RegCheckList, drivers: DirectDriverMap)(stmt: Statement): Unit = {
     stmt match {
@@ -72,4 +67,3 @@ class CheckResets extends Transform {
     state
   }
 }
-

--- a/src/main/scala/firrtl/passes/InferWidths.scala
+++ b/src/main/scala/firrtl/passes/InferWidths.scala
@@ -12,12 +12,6 @@ import firrtl.Implicits.width2constraint
 import firrtl.annotations.{CircuitTarget, ModuleTarget, ReferenceTarget, Target}
 import firrtl.constraint.{ConstraintSolver, IsMax}
 
-object InferWidths {
-  def apply(): InferWidths = new InferWidths()
-  def run(c: Circuit): Circuit = new InferWidths().run(c)
-  def execute(state: CircuitState): CircuitState = new InferWidths().execute(state)
-}
-
 case class WidthGeqConstraintAnnotation(loc: ReferenceTarget, exp: ReferenceTarget) extends Annotation {
   def update(renameMap: RenameMap): Seq[WidthGeqConstraintAnnotation] = {
     val newLoc :: newExp :: Nil = Seq(loc, exp).map { target =>
@@ -60,127 +54,129 @@ case class WidthGeqConstraintAnnotation(loc: ReferenceTarget, exp: ReferenceTarg
   *
   * Uses firrtl.constraint package to infer widths
   */
-class InferWidths extends Transform with ResolvedAnnotationPaths {
+object InferWidths extends Transform with ResolvedAnnotationPaths {
   def inputForm: CircuitForm = UnknownForm
   def outputForm: CircuitForm = UnknownForm
 
-  private val constraintSolver = new ConstraintSolver()
 
   val annotationClasses = Seq(classOf[WidthGeqConstraintAnnotation])
 
-  private def addTypeConstraints(r1: ReferenceTarget, r2: ReferenceTarget)(t1: Type, t2: Type): Unit = (t1,t2) match {
-    case (UIntType(w1), UIntType(w2)) => constraintSolver.addGeq(w1, w2, r1.prettyPrint(""), r2.prettyPrint(""))
-    case (SIntType(w1), SIntType(w2)) => constraintSolver.addGeq(w1, w2, r1.prettyPrint(""), r2.prettyPrint(""))
-    case (ClockType, ClockType) =>
-    case (FixedType(w1, p1), FixedType(w2, p2)) =>
-      constraintSolver.addGeq(p1, p2, r1.prettyPrint(""), r2.prettyPrint(""))
-      constraintSolver.addGeq(w1, w2, r1.prettyPrint(""), r2.prettyPrint(""))
-    case (IntervalType(l1, u1, p1), IntervalType(l2, u2, p2)) =>
-      constraintSolver.addGeq(p1, p2, r1.prettyPrint(""), r2.prettyPrint(""))
-      constraintSolver.addLeq(l1, l2, r1.prettyPrint(""), r2.prettyPrint(""))
-      constraintSolver.addGeq(u1, u2, r1.prettyPrint(""), r2.prettyPrint(""))
-    case (AnalogType(w1), AnalogType(w2)) =>
-      constraintSolver.addGeq(w1, w2, r1.prettyPrint(""), r2.prettyPrint(""))
-      constraintSolver.addGeq(w2, w1, r1.prettyPrint(""), r2.prettyPrint(""))
-    case (t1: BundleType, t2: BundleType) =>
-      (t1.fields zip t2.fields) foreach { case (f1, f2) =>
-        (f1.flip, f2.flip) match {
-          case (Default, Default) => addTypeConstraints(r1.field(f1.name), r2.field(f2.name))(f1.tpe, f2.tpe)
-          case (Flip, Flip) => addTypeConstraints(r2.field(f2.name), r1.field(f1.name))(f2.tpe, f1.tpe)
-          case _ => sys.error("Shouldn't be here")
-        }
-      }
-    case (t1: VectorType, t2: VectorType) => addTypeConstraints(r1.index(0), r2.index(0))(t1.tpe, t2.tpe)
-    case (AsyncResetType, AsyncResetType) => Nil
-    case (ResetType, _) => Nil
-    case (_, ResetType) => Nil
-  }
-
-  private def addExpConstraints(e: Expression): Expression = e map addExpConstraints match {
-    case m@Mux(p, tVal, fVal, t) =>
-      constraintSolver.addGeq(getWidth(p), Closed(1), "mux predicate", "1.W")
-      m
-    case other => other
-  }
-
-  private def addStmtConstraints(mt: ModuleTarget)(s: Statement): Statement = s map addExpConstraints match {
-    case c: Connect =>
-      val n = get_size(c.loc.tpe)
-      val locs = create_exps(c.loc)
-      val exps = create_exps(c.expr)
-      (locs zip exps).foreach { case (loc, exp) =>
-        to_flip(flow(loc)) match {
-          case Default => addTypeConstraints(Target.asTarget(mt)(loc), Target.asTarget(mt)(exp))(loc.tpe, exp.tpe)
-          case Flip => addTypeConstraints(Target.asTarget(mt)(exp), Target.asTarget(mt)(loc))(exp.tpe, loc.tpe)
-        }
-      }
-      c
-    case pc: PartialConnect =>
-      val ls = get_valid_points(pc.loc.tpe, pc.expr.tpe, Default, Default)
-      val locs = create_exps(pc.loc)
-      val exps = create_exps(pc.expr)
-      ls foreach { case (x, y) =>
-        val loc = locs(x)
-        val exp = exps(y)
-        to_flip(flow(loc)) match {
-          case Default => addTypeConstraints(Target.asTarget(mt)(loc), Target.asTarget(mt)(exp))(loc.tpe, exp.tpe)
-          case Flip => addTypeConstraints(Target.asTarget(mt)(exp), Target.asTarget(mt)(loc))(exp.tpe, loc.tpe)
-        }
-      }
-      pc
-    case r: DefRegister =>
-      if (r.reset.tpe != AsyncResetType ) {
-        addTypeConstraints(Target.asTarget(mt)(r.reset), mt.ref("1"))(r.reset.tpe, UIntType(IntWidth(1)))
-      }
-      addTypeConstraints(mt.ref(r.name), Target.asTarget(mt)(r.init))(r.tpe, r.init.tpe)
-      r
-    case a@Attach(_, exprs) =>
-      val widths = exprs map (e => (e, getWidth(e.tpe)))
-      val maxWidth = IsMax(widths.map(x => width2constraint(x._2)))
-      widths.foreach { case (e, w) =>
-        constraintSolver.addGeq(w, CalcWidth(maxWidth), Target.asTarget(mt)(e).prettyPrint(""), mt.ref(a.serialize).prettyPrint(""))
-      }
-      a
-    case c: Conditionally =>
-       addTypeConstraints(Target.asTarget(mt)(c.pred), mt.ref("1.W"))(c.pred.tpe, UIntType(IntWidth(1)))
-       c map addStmtConstraints(mt)
-    case x => x map addStmtConstraints(mt)
-  }
-  private def fixWidth(w: Width): Width = constraintSolver.get(w) match {
-    case Some(Closed(x)) if trim(x).isWhole => IntWidth(x.toBigInt)
-    case None => w
-    case _ => sys.error("Shouldn't be here")
-  }
-  private def fixType(t: Type): Type = t map fixType map fixWidth match {
-    case IntervalType(l, u, p) => 
-      val (lx, ux) = (constraintSolver.get(l), constraintSolver.get(u)) match {
-        case (Some(x: Bound), Some(y: Bound)) => (x, y)
-        case (None, None) => (l, u)
-        case x => sys.error(s"Shouldn't be here: $x")
-
-
-      }
-      IntervalType(lx, ux, fixWidth(p))
-    case FixedType(w, p) => FixedType(w, fixWidth(p))
-    case x => x
-  }
-  private def fixStmt(s: Statement): Statement = s map fixStmt map fixType
-  private def fixPort(p: Port): Port = {
-    Port(p.info, p.name, p.direction, fixType(p.tpe))
-  }
-
-  def run (c: Circuit): Circuit = {
-    val ct = CircuitTarget(c.main)
-    c.modules foreach ( m => m map addStmtConstraints(ct.module(m.name)))
-    constraintSolver.solve()
-    val ret = InferTypes.run(c.copy(modules = c.modules map (_
-      map fixPort
-      map fixStmt)))
-    constraintSolver.clear()
-    ret
-  }
-
   def execute(state: CircuitState): CircuitState = {
+
+    val constraintSolver = new ConstraintSolver()
+
+    def addTypeConstraints(r1: ReferenceTarget, r2: ReferenceTarget)(t1: Type, t2: Type): Unit = (t1,t2) match {
+      case (UIntType(w1), UIntType(w2)) => constraintSolver.addGeq(w1, w2, r1.prettyPrint(""), r2.prettyPrint(""))
+      case (SIntType(w1), SIntType(w2)) => constraintSolver.addGeq(w1, w2, r1.prettyPrint(""), r2.prettyPrint(""))
+      case (ClockType, ClockType) =>
+      case (FixedType(w1, p1), FixedType(w2, p2)) =>
+        constraintSolver.addGeq(p1, p2, r1.prettyPrint(""), r2.prettyPrint(""))
+        constraintSolver.addGeq(w1, w2, r1.prettyPrint(""), r2.prettyPrint(""))
+      case (IntervalType(l1, u1, p1), IntervalType(l2, u2, p2)) =>
+        constraintSolver.addGeq(p1, p2, r1.prettyPrint(""), r2.prettyPrint(""))
+        constraintSolver.addLeq(l1, l2, r1.prettyPrint(""), r2.prettyPrint(""))
+        constraintSolver.addGeq(u1, u2, r1.prettyPrint(""), r2.prettyPrint(""))
+      case (AnalogType(w1), AnalogType(w2)) =>
+        constraintSolver.addGeq(w1, w2, r1.prettyPrint(""), r2.prettyPrint(""))
+        constraintSolver.addGeq(w2, w1, r1.prettyPrint(""), r2.prettyPrint(""))
+      case (t1: BundleType, t2: BundleType) =>
+        (t1.fields zip t2.fields) foreach { case (f1, f2) =>
+          (f1.flip, f2.flip) match {
+            case (Default, Default) => addTypeConstraints(r1.field(f1.name), r2.field(f2.name))(f1.tpe, f2.tpe)
+            case (Flip, Flip) => addTypeConstraints(r2.field(f2.name), r1.field(f1.name))(f2.tpe, f1.tpe)
+            case _ => sys.error("Shouldn't be here")
+          }
+        }
+      case (t1: VectorType, t2: VectorType) => addTypeConstraints(r1.index(0), r2.index(0))(t1.tpe, t2.tpe)
+      case (AsyncResetType, AsyncResetType) => Nil
+      case (ResetType, _) => Nil
+      case (_, ResetType) => Nil
+    }
+
+    def addExpConstraints(e: Expression): Expression = e map addExpConstraints match {
+      case m@Mux(p, tVal, fVal, t) =>
+        constraintSolver.addGeq(getWidth(p), Closed(1), "mux predicate", "1.W")
+        m
+      case other => other
+    }
+
+    def addStmtConstraints(mt: ModuleTarget)(s: Statement): Statement = s map addExpConstraints match {
+      case c: Connect =>
+        val n = get_size(c.loc.tpe)
+        val locs = create_exps(c.loc)
+        val exps = create_exps(c.expr)
+        (locs zip exps).foreach { case (loc, exp) =>
+          to_flip(flow(loc)) match {
+            case Default => addTypeConstraints(Target.asTarget(mt)(loc), Target.asTarget(mt)(exp))(loc.tpe, exp.tpe)
+            case Flip => addTypeConstraints(Target.asTarget(mt)(exp), Target.asTarget(mt)(loc))(exp.tpe, loc.tpe)
+          }
+        }
+        c
+      case pc: PartialConnect =>
+        val ls = get_valid_points(pc.loc.tpe, pc.expr.tpe, Default, Default)
+        val locs = create_exps(pc.loc)
+        val exps = create_exps(pc.expr)
+        ls foreach { case (x, y) =>
+          val loc = locs(x)
+          val exp = exps(y)
+          to_flip(flow(loc)) match {
+            case Default => addTypeConstraints(Target.asTarget(mt)(loc), Target.asTarget(mt)(exp))(loc.tpe, exp.tpe)
+            case Flip => addTypeConstraints(Target.asTarget(mt)(exp), Target.asTarget(mt)(loc))(exp.tpe, loc.tpe)
+          }
+        }
+        pc
+      case r: DefRegister =>
+        if (r.reset.tpe != AsyncResetType ) {
+          addTypeConstraints(Target.asTarget(mt)(r.reset), mt.ref("1"))(r.reset.tpe, UIntType(IntWidth(1)))
+        }
+        addTypeConstraints(mt.ref(r.name), Target.asTarget(mt)(r.init))(r.tpe, r.init.tpe)
+        r
+      case a@Attach(_, exprs) =>
+        val widths = exprs map (e => (e, getWidth(e.tpe)))
+        val maxWidth = IsMax(widths.map(x => width2constraint(x._2)))
+        widths.foreach { case (e, w) =>
+          constraintSolver.addGeq(w, CalcWidth(maxWidth), Target.asTarget(mt)(e).prettyPrint(""), mt.ref(a.serialize).prettyPrint(""))
+        }
+        a
+      case c: Conditionally =>
+         addTypeConstraints(Target.asTarget(mt)(c.pred), mt.ref("1.W"))(c.pred.tpe, UIntType(IntWidth(1)))
+         c map addStmtConstraints(mt)
+      case x => x map addStmtConstraints(mt)
+    }
+    def fixWidth(w: Width): Width = constraintSolver.get(w) match {
+      case Some(Closed(x)) if trim(x).isWhole => IntWidth(x.toBigInt)
+      case None => w
+      case _ => sys.error("Shouldn't be here")
+    }
+    def fixType(t: Type): Type = t map fixType map fixWidth match {
+      case IntervalType(l, u, p) =>
+        val (lx, ux) = (constraintSolver.get(l), constraintSolver.get(u)) match {
+          case (Some(x: Bound), Some(y: Bound)) => (x, y)
+          case (None, None) => (l, u)
+          case x => sys.error(s"Shouldn't be here: $x")
+
+
+        }
+        IntervalType(lx, ux, fixWidth(p))
+      case FixedType(w, p) => FixedType(w, fixWidth(p))
+      case x => x
+    }
+    def fixStmt(s: Statement): Statement = s map fixStmt map fixType
+    def fixPort(p: Port): Port = {
+      Port(p.info, p.name, p.direction, fixType(p.tpe))
+    }
+
+    def run (c: Circuit): Circuit = {
+      val ct = CircuitTarget(c.main)
+      c.modules foreach ( m => m map addStmtConstraints(ct.module(m.name)))
+      constraintSolver.solve()
+      val ret = InferTypes.run(c.copy(modules = c.modules map (_
+        map fixPort
+        map fixStmt)))
+      constraintSolver.clear()
+      ret
+    }
+
     val circuitName = state.circuit.main
     val typeMap = new collection.mutable.HashMap[ReferenceTarget, Type]
 
@@ -229,5 +225,4 @@ class InferWidths extends Transform with ResolvedAnnotationPaths {
 
     state.copy(circuit = run(state.circuit))
   }
-
 }

--- a/src/main/scala/firrtl/passes/RemoveIntervals.scala
+++ b/src/main/scala/firrtl/passes/RemoveIntervals.scala
@@ -35,7 +35,7 @@ class WrapWithRemainder(info: Info, mname: String, wrap: DoPrim)
   *      c. replace with SIntType
   * 3) Run InferTypes
   */
-class RemoveIntervals extends Pass {
+object RemoveIntervals extends Pass {
 
   def run(c: Circuit): Circuit = {
     val alignedCircuit = c

--- a/src/main/scala/firrtl/passes/TrimIntervals.scala
+++ b/src/main/scala/firrtl/passes/TrimIntervals.scala
@@ -2,7 +2,6 @@
 
 package firrtl.passes
 
-import scala.collection.mutable
 import firrtl.PrimOps._
 import firrtl.ir._
 import firrtl._
@@ -22,7 +21,7 @@ import firrtl.constraint.{IsFloor, IsKnown, IsMul}
   *      c. replace with SIntType
   * 3) Run InferTypes
   */
-class TrimIntervals extends Pass {
+object TrimIntervals extends Pass {
   def run(c: Circuit): Circuit = {
     // Open -> closed
     val firstPass = InferTypes.run(c map replaceModuleInterval)

--- a/src/main/scala/firrtl/transforms/CheckCombLoops.scala
+++ b/src/main/scala/firrtl/transforms/CheckCombLoops.scala
@@ -48,16 +48,6 @@ object LogicNode {
   }
 }
 
-object CheckCombLoops {
-  type AbstractConnMap = DiGraph[LogicNode]
-  type ConnMap = DiGraph[LogicNode] with EdgeData[LogicNode, Info]
-  type MutableConnMap = MutableDiGraph[LogicNode] with MutableEdgeData[LogicNode, Info]
-
-
-  class CombLoopException(info: Info, mname: String, cycle: Seq[String]) extends PassException(
-    s"$info: [module $mname] Combinational loop detected:\n" + cycle.mkString("\n"))
-}
-
 case object DontCheckCombLoopsAnnotation extends NoTargetAnnotation
 
 case class ExtModulePathAnnotation(source: ReferenceTarget, sink: ReferenceTarget) extends Annotation {
@@ -95,11 +85,16 @@ case class CombinationalPath(sink: ReferenceTarget, sources: Seq[ReferenceTarget
   * @note The pass relies on ExtModulePathAnnotations to find loops through ExtModules
   * @note The pass will throw exceptions on "false paths"
   */
-class CheckCombLoops extends Transform with RegisteredTransform {
+object CheckCombLoops extends Transform with RegisteredTransform {
   def inputForm = LowForm
   def outputForm = LowForm
 
-  import CheckCombLoops._
+  type AbstractConnMap = DiGraph[LogicNode]
+  type ConnMap = DiGraph[LogicNode] with EdgeData[LogicNode, Info]
+  type MutableConnMap = MutableDiGraph[LogicNode] with MutableEdgeData[LogicNode, Info]
+
+  class CombLoopException(info: Info, mname: String, cycle: Seq[String]) extends PassException(
+    s"$info: [module $mname] Combinational loop detected:\n" + cycle.mkString("\n"))
 
   val options = Seq(
     new ShellOption[Unit](

--- a/src/main/scala/firrtl/transforms/CombineCats.scala
+++ b/src/main/scala/firrtl/transforms/CombineCats.scala
@@ -12,7 +12,19 @@ import scala.collection.mutable
 
 case class MaxCatLenAnnotation(maxCatLen: Int) extends NoTargetAnnotation
 
-object CombineCats {
+/** Combine Cat DoPrims
+  *
+  * Expands the arguments of any Cat DoPrims if they are references to other Cat DoPrims.
+  * Operates only on Cat DoPrims that are node values.
+  *
+  * Use [[MaxCatLenAnnotation]] to limit the number of elements that can be concatenated.
+  * The default maximum number of elements is 10.
+  */
+object CombineCats extends Transform {
+  def inputForm: LowForm.type = LowForm
+  def outputForm: LowForm.type = LowForm
+  val defaultMaxCatLen = 10
+
   /** Mapping from references to the [[firrtl.ir.Expression Expression]]s that drive them paired with their Cat length */
   type Netlist = mutable.HashMap[WrappedExpression, (Int, Expression)]
 
@@ -41,20 +53,6 @@ object CombineCats {
   }
 
   def onMod(maxCatLen: Int)(mod: DefModule): DefModule = mod.map(onStmt(maxCatLen, new Netlist))
-}
-
-/** Combine Cat DoPrims
-  *
-  * Expands the arguments of any Cat DoPrims if they are references to other Cat DoPrims.
-  * Operates only on Cat DoPrims that are node values.
-  *
-  * Use [[MaxCatLenAnnotation]] to limit the number of elements that can be concatenated.
-  * The default maximum number of elements is 10.
-  */
-class CombineCats extends Transform {
-  def inputForm: LowForm.type = LowForm
-  def outputForm: LowForm.type = LowForm
-  val defaultMaxCatLen = 10
 
   def execute(state: CircuitState): CircuitState = {
     val maxCatLen = state.annotations.collectFirst {

--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -17,7 +17,12 @@ import firrtl.annotations.TargetToken.Ref
 import annotation.tailrec
 import collection.mutable
 
-object ConstantPropagation {
+object ConstantPropagation extends Transform with ResolvedAnnotationPaths {
+  def inputForm = LowForm
+  def outputForm = LowForm
+
+  override val annotationClasses: Traversable[Class[_]] = Seq(classOf[DontTouchAnnotation])
+
   private def asUInt(e: Expression, t: Type) = DoPrim(AsUInt, Seq(e), Seq(), t)
 
   /** Pads e to the width of t */
@@ -88,15 +93,6 @@ object ConstantPropagation {
   private case class RegCPEntry(r: ConstPropBinding[String], l: ConstPropBinding[Literal]) {
     def resolve(that: RegCPEntry) = RegCPEntry(r.resolve(that.r), l.resolve(that.l))
   }
-
-}
-
-class ConstantPropagation extends Transform with ResolvedAnnotationPaths {
-  import ConstantPropagation._
-  def inputForm = LowForm
-  def outputForm = LowForm
-
-  override val annotationClasses: Traversable[Class[_]] = Seq(classOf[DontTouchAnnotation])
 
   trait FoldCommutativeOp {
     def fold(c1: Literal, c2: Literal): Expression

--- a/src/main/scala/firrtl/transforms/RemoveReset.scala
+++ b/src/main/scala/firrtl/transforms/RemoveReset.scala
@@ -14,7 +14,7 @@ import scala.collection.{immutable, mutable}
   *
   * @note This pass must run after LowerTypes
   */
-class RemoveReset extends Transform {
+object RemoveReset extends Transform {
   def inputForm = MidForm
   def outputForm = MidForm
 

--- a/src/main/scala/firrtl/transforms/RemoveWires.scala
+++ b/src/main/scala/firrtl/transforms/RemoveWires.scala
@@ -19,7 +19,7 @@ import scala.util.{Try, Success, Failure}
   *  wires have multiple connections that may be impossible to order in a
   *  flow-foward way
   */
-class RemoveWires extends Transform {
+object RemoveWires extends Transform {
   def inputForm = LowForm
   def outputForm = LowForm
 

--- a/src/test/scala/firrtlTests/AttachSpec.scala
+++ b/src/test/scala/firrtlTests/AttachSpec.scala
@@ -411,7 +411,7 @@ class AttachAnalogSpec extends FirrtlFlatSpec {
       ResolveKinds,
       InferTypes,
       CheckTypes,
-      new InferWidths,
+      InferWidths,
       CheckWidths)
     val input =
       """circuit Unit :

--- a/src/test/scala/firrtlTests/CInferMDirSpec.scala
+++ b/src/test/scala/firrtlTests/CInferMDirSpec.scala
@@ -39,7 +39,7 @@ class CInferMDir extends LowTransformSpec {
   def transform = new SeqTransform {
     def inputForm = LowForm
     def outputForm = LowForm
-    def transforms = Seq(new ConstantPropagation, CInferMDirCheckPass)
+    def transforms = Seq(ConstantPropagation, CInferMDirCheckPass)
   }
 
   "Memory" should "have correct mem port directions" in {

--- a/src/test/scala/firrtlTests/CheckInitializationSpec.scala
+++ b/src/test/scala/firrtlTests/CheckInitializationSpec.scala
@@ -18,7 +18,7 @@ class CheckInitializationSpec extends FirrtlFlatSpec {
      CheckTypes,
      ResolveFlows,
      CheckFlows,
-     new InferWidths,
+     InferWidths,
      CheckWidths,
      PullMuxes,
      ExpandConnects,

--- a/src/test/scala/firrtlTests/CheckSpec.scala
+++ b/src/test/scala/firrtlTests/CheckSpec.scala
@@ -178,7 +178,7 @@ class CheckSpec extends FlatSpec with Matchers {
       CheckTypes,
       ResolveFlows,
       CheckFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths)
     val input =
       """

--- a/src/test/scala/firrtlTests/ChirrtlMemSpec.scala
+++ b/src/test/scala/firrtlTests/ChirrtlMemSpec.scala
@@ -56,7 +56,7 @@ class ChirrtlMemSpec extends LowTransformSpec {
   def transform = new SeqTransform {
     def inputForm = LowForm
     def outputForm = LowForm
-    def transforms = Seq(new ConstantPropagation, MemEnableCheckPass)
+    def transforms = Seq(ConstantPropagation, MemEnableCheckPass)
   }
 
   "Sequential Memory" should "have correct enable signals" in {

--- a/src/test/scala/firrtlTests/ChirrtlSpec.scala
+++ b/src/test/scala/firrtlTests/ChirrtlSpec.scala
@@ -18,7 +18,7 @@ class ChirrtlSpec extends FirrtlFlatSpec {
     CheckTypes,
     ResolveFlows,
     CheckFlows,
-    new InferWidths,
+    InferWidths,
     CheckWidths,
     PullMuxes,
     ExpandConnects,

--- a/src/test/scala/firrtlTests/ClockListTests.scala
+++ b/src/test/scala/firrtlTests/ClockListTests.scala
@@ -25,7 +25,7 @@ class ClockListTests extends FirrtlFlatSpec {
     ResolveKinds,
     InferTypes,
     ResolveFlows,
-    new InferWidths
+    InferWidths
   )
 
   "Getting clock list" should "work" in {

--- a/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+++ b/src/test/scala/firrtlTests/ConstantPropagationTests.scala
@@ -14,7 +14,7 @@ class ConstantPropagationSpec extends FirrtlFlatSpec {
       ResolveKinds,
       InferTypes,
       ResolveFlows,
-      new InferWidths,
+      InferWidths,
       new ConstantPropagation)
   protected def exec(input: String) = {
     transforms.foldLeft(CircuitState(parse(input), UnknownForm)) {

--- a/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+++ b/src/test/scala/firrtlTests/ConstantPropagationTests.scala
@@ -15,7 +15,7 @@ class ConstantPropagationSpec extends FirrtlFlatSpec {
       InferTypes,
       ResolveFlows,
       InferWidths,
-      new ConstantPropagation)
+      ConstantPropagation)
   protected def exec(input: String) = {
     transforms.foldLeft(CircuitState(parse(input), UnknownForm)) {
       (c: CircuitState, t: Transform) => t.runTransform(c)
@@ -1279,7 +1279,7 @@ class ConstantPropagationIntegrationSpec extends LowTransformSpec {
 
 class ConstantPropagationEquivalenceSpec extends FirrtlFlatSpec {
   private val srcDir = "/constant_propagation_tests"
-  private val transforms = Seq(new ConstantPropagation)
+  private val transforms = Seq(ConstantPropagation)
 
   "anything added to zero" should "be equal to itself" in {
     val input =

--- a/src/test/scala/firrtlTests/ExpandWhensSpec.scala
+++ b/src/test/scala/firrtlTests/ExpandWhensSpec.scala
@@ -22,7 +22,7 @@ class ExpandWhensSpec extends FirrtlFlatSpec {
     InferTypes,
     ResolveFlows,
     CheckFlows,
-    new InferWidths,
+    InferWidths,
     CheckWidths,
     PullMuxes,
     ExpandConnects,

--- a/src/test/scala/firrtlTests/LowerTypesSpec.scala
+++ b/src/test/scala/firrtlTests/LowerTypesSpec.scala
@@ -28,7 +28,7 @@ class LowerTypesSpec extends FirrtlFlatSpec {
     ExpandWhens,
     CheckInitialization,
     Legalize,
-    new ConstantPropagation,
+    ConstantPropagation,
     ResolveKinds,
     InferTypes,
     ResolveFlows,

--- a/src/test/scala/firrtlTests/LowerTypesSpec.scala
+++ b/src/test/scala/firrtlTests/LowerTypesSpec.scala
@@ -20,7 +20,7 @@ class LowerTypesSpec extends FirrtlFlatSpec {
     CheckTypes,
     ResolveFlows,
     CheckFlows,
-    new InferWidths,
+    InferWidths,
     CheckWidths,
     PullMuxes,
     ExpandConnects,
@@ -32,7 +32,7 @@ class LowerTypesSpec extends FirrtlFlatSpec {
     ResolveKinds,
     InferTypes,
     ResolveFlows,
-    new InferWidths,
+    InferWidths,
     LowerTypes)
 
   private def executeTest(input: String, expected: Seq[String]) = {

--- a/src/test/scala/firrtlTests/ReplSeqMemTests.scala
+++ b/src/test/scala/firrtlTests/ReplSeqMemTests.scala
@@ -24,7 +24,7 @@ class ReplSeqMemSpec extends SimpleTransformSpec {
     new SeqTransform {
       def inputForm = LowForm
       def outputForm = LowForm
-      def transforms = Seq(new ConstantPropagation, CommonSubexpressionElimination, new DeadCodeElimination, RemoveEmpty)
+      def transforms = Seq(ConstantPropagation, CommonSubexpressionElimination, new DeadCodeElimination, RemoveEmpty)
     }
   )
 

--- a/src/test/scala/firrtlTests/ReplaceAccessesSpec.scala
+++ b/src/test/scala/firrtlTests/ReplaceAccessesSpec.scala
@@ -14,7 +14,7 @@ class ReplaceAccessesSpec extends FirrtlFlatSpec {
     ResolveKinds,
     InferTypes,
     ResolveFlows,
-    new InferWidths,
+    InferWidths,
     ReplaceAccesses)
   protected def exec(input: String) = {
     transforms.foldLeft(CircuitState(parse(input), UnknownForm)) {

--- a/src/test/scala/firrtlTests/UnitTests.scala
+++ b/src/test/scala/firrtlTests/UnitTests.scala
@@ -158,7 +158,7 @@ class UnitTests extends FirrtlFlatSpec {
       ResolveKinds,
       InferTypes,
       ResolveFlows,
-      new InferWidths,
+      InferWidths,
       SplitExpressions
     )
     val input =
@@ -182,7 +182,7 @@ class UnitTests extends FirrtlFlatSpec {
       ResolveKinds,
       InferTypes,
       ResolveFlows,
-      new InferWidths,
+      InferWidths,
       PadWidths
     )
     val input =
@@ -203,7 +203,7 @@ class UnitTests extends FirrtlFlatSpec {
       ResolveKinds,
       InferTypes,
       ResolveFlows,
-      new InferWidths,
+      InferWidths,
       PullMuxes,
       ExpandConnects,
       RemoveAccesses,
@@ -243,7 +243,7 @@ class UnitTests extends FirrtlFlatSpec {
       ResolveKinds,
       InferTypes,
       ResolveFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths)
     val input =
       """circuit Unit :
@@ -262,7 +262,7 @@ class UnitTests extends FirrtlFlatSpec {
       ResolveKinds,
       InferTypes,
       ResolveFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths)
     val input =
       """circuit Unit :
@@ -281,7 +281,7 @@ class UnitTests extends FirrtlFlatSpec {
       ResolveKinds,
       InferTypes,
       ResolveFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths)
     val input =
       """circuit Unit :
@@ -389,7 +389,7 @@ class UnitTests extends FirrtlFlatSpec {
       ResolveKinds,
       InferTypes,
       ResolveFlows,
-      new InferWidths,
+      InferWidths,
       PullMuxes,
       ExpandConnects,
       RemoveAccesses,

--- a/src/test/scala/firrtlTests/UnitTests.scala
+++ b/src/test/scala/firrtlTests/UnitTests.scala
@@ -207,7 +207,7 @@ class UnitTests extends FirrtlFlatSpec {
       PullMuxes,
       ExpandConnects,
       RemoveAccesses,
-      new ConstantPropagation
+      ConstantPropagation
     )
     val input =
       """circuit AssignViaDeref :
@@ -394,7 +394,7 @@ class UnitTests extends FirrtlFlatSpec {
       ExpandConnects,
       RemoveAccesses,
       ResolveFlows,
-      new ConstantPropagation
+      ConstantPropagation
     )
     val input =
       """circuit Top :

--- a/src/test/scala/firrtlTests/VerilogEmitterTests.scala
+++ b/src/test/scala/firrtlTests/VerilogEmitterTests.scala
@@ -117,7 +117,7 @@ class DoPrimVerilog extends FirrtlFlatSpec {
         |endmodule
         |""".stripMargin.split("\n") map normalized
 
-    val finalState = compiler.compileAndEmit(CircuitState(parse(input), ChirrtlForm), Seq(new CombineCats()))
+    val finalState = compiler.compileAndEmit(CircuitState(parse(input), ChirrtlForm), Seq(CombineCats))
     val lines = finalState.getEmittedCircuit.value split "\n" map normalized
     for (e <- check) {
       lines should contain (e)

--- a/src/test/scala/firrtlTests/WidthSpec.scala
+++ b/src/test/scala/firrtlTests/WidthSpec.scala
@@ -54,7 +54,7 @@ class WidthSpec extends FirrtlFlatSpec {
       InferTypes,
       CheckTypes,
       ResolveFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths)
     val input =
       """circuit Unit :
@@ -77,7 +77,7 @@ class WidthSpec extends FirrtlFlatSpec {
       InferTypes,
       CheckTypes,
       ResolveFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths)
     val input =
      s"""circuit Unit :
@@ -96,7 +96,7 @@ class WidthSpec extends FirrtlFlatSpec {
       InferTypes,
       CheckTypes,
       ResolveFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths)
     val input =
       """circuit Unit :
@@ -121,7 +121,7 @@ class WidthSpec extends FirrtlFlatSpec {
       InferTypes,
       CheckTypes,
       ResolveFlows,
-      new InferWidths)
+      InferWidths)
     val input =
       """circuit Unit :
         |  module Unit :
@@ -143,7 +143,7 @@ class WidthSpec extends FirrtlFlatSpec {
       InferTypes,
       CheckTypes,
       ResolveFlows,
-      new InferWidths)
+      InferWidths)
     val input =
       """circuit Unit :
         |  module Unit :
@@ -166,7 +166,7 @@ class WidthSpec extends FirrtlFlatSpec {
       InferTypes,
       CheckTypes,
       ResolveFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths)
     val input =
       """|circuit Foo :

--- a/src/test/scala/firrtlTests/WiringTests.scala
+++ b/src/test/scala/firrtlTests/WiringTests.scala
@@ -34,7 +34,7 @@ class WiringTests extends FirrtlFlatSpec {
     ResolveKinds,
     InferTypes,
     ResolveFlows,
-    new InferWidths
+    InferWidths
   )
 
   it should "wire from a register source (r) to multiple extmodule sinks (X)" in {

--- a/src/test/scala/firrtlTests/ZeroWidthTests.scala
+++ b/src/test/scala/firrtlTests/ZeroWidthTests.scala
@@ -16,7 +16,7 @@ class ZeroWidthTests extends FirrtlFlatSpec {
       ResolveKinds,
       InferTypes,
       ResolveFlows,
-      new InferWidths,
+      InferWidths,
       ZeroWidth)
   private def exec (input: String) = {
     val circuit = parse(input)

--- a/src/test/scala/firrtlTests/fixed/FixedTypeInferenceSpec.scala
+++ b/src/test/scala/firrtlTests/fixed/FixedTypeInferenceSpec.scala
@@ -30,7 +30,7 @@ class FixedTypeInferenceSpec extends FirrtlFlatSpec {
       CheckTypes,
       ResolveFlows,
       CheckFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths)
     val input =
       """circuit Unit :
@@ -60,7 +60,7 @@ class FixedTypeInferenceSpec extends FirrtlFlatSpec {
       CheckTypes,
       ResolveFlows,
       CheckFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths)
     val input =
       """circuit Unit :
@@ -90,7 +90,7 @@ class FixedTypeInferenceSpec extends FirrtlFlatSpec {
       CheckTypes,
       ResolveFlows,
       CheckFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths)
     val input =
       """circuit Unit :
@@ -116,7 +116,7 @@ class FixedTypeInferenceSpec extends FirrtlFlatSpec {
       CheckTypes,
       ResolveFlows,
       CheckFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths)
     val input =
       """circuit Unit :
@@ -142,7 +142,7 @@ class FixedTypeInferenceSpec extends FirrtlFlatSpec {
       CheckTypes,
       ResolveFlows,
       CheckFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths)
     val input =
       """circuit Unit :
@@ -168,7 +168,7 @@ class FixedTypeInferenceSpec extends FirrtlFlatSpec {
       CheckTypes,
       ResolveFlows,
       CheckFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths)
     val input =
       """circuit Unit :
@@ -194,7 +194,7 @@ class FixedTypeInferenceSpec extends FirrtlFlatSpec {
       CheckTypes,
       ResolveFlows,
       CheckFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths)
     val input =
       """circuit Unit :
@@ -220,7 +220,7 @@ class FixedTypeInferenceSpec extends FirrtlFlatSpec {
       CheckTypes,
       ResolveFlows,
       CheckFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths)
     val input =
       """circuit Unit :
@@ -260,7 +260,7 @@ class FixedTypeInferenceSpec extends FirrtlFlatSpec {
       CheckTypes,
       ResolveFlows,
       CheckFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths)
     val input =
       """circuit Unit :
@@ -286,7 +286,7 @@ class FixedTypeInferenceSpec extends FirrtlFlatSpec {
       CheckTypes,
       ResolveFlows,
       CheckFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths,
       ConvertFixedToSInt)
     val input =

--- a/src/test/scala/firrtlTests/fixed/RemoveFixedTypeSpec.scala
+++ b/src/test/scala/firrtlTests/fixed/RemoveFixedTypeSpec.scala
@@ -29,7 +29,7 @@ class RemoveFixedTypeSpec extends FirrtlFlatSpec {
       CheckTypes,
       ResolveFlows,
       CheckFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths,
       ConvertFixedToSInt)
     val input =
@@ -59,7 +59,7 @@ class RemoveFixedTypeSpec extends FirrtlFlatSpec {
       CheckTypes,
       ResolveFlows,
       CheckFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths,
       ConvertFixedToSInt)
     val input =
@@ -90,7 +90,7 @@ class RemoveFixedTypeSpec extends FirrtlFlatSpec {
       CheckTypes,
       ResolveFlows,
       CheckFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths,
       ConvertFixedToSInt)
     val input =
@@ -117,7 +117,7 @@ class RemoveFixedTypeSpec extends FirrtlFlatSpec {
       CheckTypes,
       ResolveFlows,
       CheckFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths,
       ConvertFixedToSInt)
     val input =
@@ -144,7 +144,7 @@ class RemoveFixedTypeSpec extends FirrtlFlatSpec {
       CheckTypes,
       ResolveFlows,
       CheckFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths,
       ConvertFixedToSInt)
     val input =
@@ -196,7 +196,7 @@ class RemoveFixedTypeSpec extends FirrtlFlatSpec {
       CheckTypes,
       ResolveFlows,
       CheckFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths,
       ConvertFixedToSInt)
     val input =

--- a/src/test/scala/firrtlTests/interval/IntervalSpec.scala
+++ b/src/test/scala/firrtlTests/interval/IntervalSpec.scala
@@ -64,7 +64,7 @@ class IntervalSpec extends FirrtlFlatSpec {
   }
 
   "Interval types" should "trim known intervals correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, new TrimIntervals())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, TrimIntervals)
     val input =
       """circuit Unit :
         |  module Unit :
@@ -85,7 +85,7 @@ class IntervalSpec extends FirrtlFlatSpec {
   }
 
   "Interval types" should "infer intervals correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, new TrimIntervals(), new InferWidths())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, TrimIntervals, new InferWidths())
     val input =
       """circuit Unit :
         |  module Unit :
@@ -106,7 +106,7 @@ class IntervalSpec extends FirrtlFlatSpec {
   }
 
   "Interval types" should "be removed correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, new TrimIntervals(), new InferWidths(), new RemoveIntervals())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, TrimIntervals, new InferWidths(), new RemoveIntervals())
     val input =
       """circuit Unit :
         |  module Unit :
@@ -135,7 +135,7 @@ class IntervalSpec extends FirrtlFlatSpec {
   }
 
 "Interval types" should "infer multiplication by zero correctly" in {
-  val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, new TrimIntervals(), new InferWidths())
+  val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, TrimIntervals, new InferWidths())
     val input =
       s"""circuit Unit :
       |  module Unit :
@@ -149,7 +149,7 @@ class IntervalSpec extends FirrtlFlatSpec {
 }
 
   "Interval types" should "infer muxes correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, new TrimIntervals(), new InferWidths())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, TrimIntervals, new InferWidths())
       val input =
         s"""circuit Unit :
         |  module Unit :
@@ -163,7 +163,7 @@ class IntervalSpec extends FirrtlFlatSpec {
     executeTest(input, check.split("\n") map normalized, passes)
   }
   "Interval types" should "infer dshl correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveKinds, ResolveGenders, InferBinaryPoints, new TrimIntervals, new InferWidths())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveKinds, ResolveGenders, InferBinaryPoints, TrimIntervals, new InferWidths())
       val input =
         s"""circuit Unit :
         |  module Unit :
@@ -320,7 +320,7 @@ class IntervalSpec extends FirrtlFlatSpec {
     executeTest(input, check.split("\n") map normalized, passes)
   }
   "Interval types" should "remove negative binary points" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, new TrimIntervals(), new InferWidths(), new RemoveIntervals())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, TrimIntervals, new InferWidths(), new RemoveIntervals())
       val input =
         s"""circuit Unit :
         |  module Unit :

--- a/src/test/scala/firrtlTests/interval/IntervalSpec.scala
+++ b/src/test/scala/firrtlTests/interval/IntervalSpec.scala
@@ -43,7 +43,7 @@ class IntervalSpec extends FirrtlFlatSpec {
   }
 
   "Interval types" should "infer bp correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, new InferBinaryPoints())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints)
     val input =
       """circuit Unit :
         |  module Unit :
@@ -64,7 +64,7 @@ class IntervalSpec extends FirrtlFlatSpec {
   }
 
   "Interval types" should "trim known intervals correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, new InferBinaryPoints(), new TrimIntervals())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, new TrimIntervals())
     val input =
       """circuit Unit :
         |  module Unit :
@@ -85,7 +85,7 @@ class IntervalSpec extends FirrtlFlatSpec {
   }
 
   "Interval types" should "infer intervals correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, new InferBinaryPoints(), new TrimIntervals(), new InferWidths())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, new TrimIntervals(), new InferWidths())
     val input =
       """circuit Unit :
         |  module Unit :
@@ -106,7 +106,7 @@ class IntervalSpec extends FirrtlFlatSpec {
   }
 
   "Interval types" should "be removed correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, new InferBinaryPoints(), new TrimIntervals(), new InferWidths(), new RemoveIntervals())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, new TrimIntervals(), new InferWidths(), new RemoveIntervals())
     val input =
       """circuit Unit :
         |  module Unit :
@@ -135,7 +135,7 @@ class IntervalSpec extends FirrtlFlatSpec {
   }
 
 "Interval types" should "infer multiplication by zero correctly" in {
-  val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, new InferBinaryPoints(), new TrimIntervals(), new InferWidths())
+  val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, new TrimIntervals(), new InferWidths())
     val input =
       s"""circuit Unit :
       |  module Unit :
@@ -149,7 +149,7 @@ class IntervalSpec extends FirrtlFlatSpec {
 }
 
   "Interval types" should "infer muxes correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, new InferBinaryPoints(), new TrimIntervals(), new InferWidths())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, new TrimIntervals(), new InferWidths())
       val input =
         s"""circuit Unit :
         |  module Unit :
@@ -163,7 +163,7 @@ class IntervalSpec extends FirrtlFlatSpec {
     executeTest(input, check.split("\n") map normalized, passes)
   }
   "Interval types" should "infer dshl correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveKinds, ResolveGenders, new InferBinaryPoints(), new TrimIntervals, new InferWidths())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveKinds, ResolveGenders, InferBinaryPoints, new TrimIntervals, new InferWidths())
       val input =
         s"""circuit Unit :
         |  module Unit :
@@ -320,7 +320,7 @@ class IntervalSpec extends FirrtlFlatSpec {
     executeTest(input, check.split("\n") map normalized, passes)
   }
   "Interval types" should "remove negative binary points" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, new InferBinaryPoints(), new TrimIntervals(), new InferWidths(), new RemoveIntervals())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, new TrimIntervals(), new InferWidths(), new RemoveIntervals())
       val input =
         s"""circuit Unit :
         |  module Unit :

--- a/src/test/scala/firrtlTests/interval/IntervalSpec.scala
+++ b/src/test/scala/firrtlTests/interval/IntervalSpec.scala
@@ -85,7 +85,7 @@ class IntervalSpec extends FirrtlFlatSpec {
   }
 
   "Interval types" should "infer intervals correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, TrimIntervals, new InferWidths())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, TrimIntervals, InferWidths)
     val input =
       """circuit Unit :
         |  module Unit :
@@ -106,7 +106,7 @@ class IntervalSpec extends FirrtlFlatSpec {
   }
 
   "Interval types" should "be removed correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, TrimIntervals, new InferWidths(), RemoveIntervals)
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, TrimIntervals, InferWidths, RemoveIntervals)
     val input =
       """circuit Unit :
         |  module Unit :
@@ -135,7 +135,7 @@ class IntervalSpec extends FirrtlFlatSpec {
   }
 
 "Interval types" should "infer multiplication by zero correctly" in {
-  val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, TrimIntervals, new InferWidths())
+  val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, TrimIntervals, InferWidths)
     val input =
       s"""circuit Unit :
       |  module Unit :
@@ -149,7 +149,7 @@ class IntervalSpec extends FirrtlFlatSpec {
 }
 
   "Interval types" should "infer muxes correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, TrimIntervals, new InferWidths())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, TrimIntervals, InferWidths)
       val input =
         s"""circuit Unit :
         |  module Unit :
@@ -163,7 +163,7 @@ class IntervalSpec extends FirrtlFlatSpec {
     executeTest(input, check.split("\n") map normalized, passes)
   }
   "Interval types" should "infer dshl correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveKinds, ResolveGenders, InferBinaryPoints, TrimIntervals, new InferWidths())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveKinds, ResolveGenders, InferBinaryPoints, TrimIntervals, InferWidths)
       val input =
         s"""circuit Unit :
         |  module Unit :
@@ -176,7 +176,7 @@ class IntervalSpec extends FirrtlFlatSpec {
     executeTest(input, check.split("\n") map normalized, passes)
   }
   "Interval types" should "infer asInterval correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, new InferWidths())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferWidths)
       val input =
         s"""circuit Unit :
         |  module Unit :
@@ -320,7 +320,7 @@ class IntervalSpec extends FirrtlFlatSpec {
     executeTest(input, check.split("\n") map normalized, passes)
   }
   "Interval types" should "remove negative binary points" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, TrimIntervals, new InferWidths(), RemoveIntervals)
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, TrimIntervals, InferWidths, RemoveIntervals)
       val input =
         s"""circuit Unit :
         |  module Unit :

--- a/src/test/scala/firrtlTests/interval/IntervalSpec.scala
+++ b/src/test/scala/firrtlTests/interval/IntervalSpec.scala
@@ -106,7 +106,7 @@ class IntervalSpec extends FirrtlFlatSpec {
   }
 
   "Interval types" should "be removed correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, TrimIntervals, new InferWidths(), new RemoveIntervals())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, TrimIntervals, new InferWidths(), RemoveIntervals)
     val input =
       """circuit Unit :
         |  module Unit :
@@ -244,7 +244,7 @@ class IntervalSpec extends FirrtlFlatSpec {
     executeTest(input, check.split("\n") map normalized, passes)
   }
   "Interval types" should "remove wrap/clip correctly" in {
-    val passes = Seq(ToWorkingIR, new ResolveAndCheck(), new RemoveIntervals())
+    val passes = Seq(ToWorkingIR, new ResolveAndCheck(), RemoveIntervals)
       val input =
         s"""circuit Unit :
         |  module Unit :
@@ -287,7 +287,7 @@ class IntervalSpec extends FirrtlFlatSpec {
     executeTest(input, check.split("\n") map normalized, passes)
   }
   "Interval types" should "shift wrap/clip correctly" in {
-    val passes = Seq(ToWorkingIR, new ResolveAndCheck, new RemoveIntervals())
+    val passes = Seq(ToWorkingIR, new ResolveAndCheck, RemoveIntervals)
       val input =
         s"""circuit Unit :
         |  module Unit :
@@ -320,7 +320,7 @@ class IntervalSpec extends FirrtlFlatSpec {
     executeTest(input, check.split("\n") map normalized, passes)
   }
   "Interval types" should "remove negative binary points" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, TrimIntervals, new InferWidths(), new RemoveIntervals())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, InferBinaryPoints, TrimIntervals, new InferWidths(), RemoveIntervals)
       val input =
         s"""circuit Unit :
         |  module Unit :
@@ -377,7 +377,7 @@ class IntervalSpec extends FirrtlFlatSpec {
     executeTest(input, check.split("\n") map normalized, passes)
   }
   "Interval types" should "lower squz properly" in {
-    val passes = Seq(ToWorkingIR, new ResolveAndCheck, new RemoveIntervals)
+    val passes = Seq(ToWorkingIR, new ResolveAndCheck, RemoveIntervals)
     val input =
       s"""circuit Unit :
          |  module Unit :
@@ -418,7 +418,7 @@ class IntervalSpec extends FirrtlFlatSpec {
     executeTest(input, check.split("\n") map normalized, passes)
   }
   "Assigning a larger interval to a smaller interval" should "error!" in {
-    val passes = Seq(ToWorkingIR, new ResolveAndCheck, new RemoveIntervals)
+    val passes = Seq(ToWorkingIR, new ResolveAndCheck, RemoveIntervals)
     val input =
       s"""circuit Unit :
          |  module Unit :
@@ -431,7 +431,7 @@ class IntervalSpec extends FirrtlFlatSpec {
     }
   }
   "Assigning a more precise interval to a less precise interval" should "error!" in {
-    val passes = Seq(ToWorkingIR, new ResolveAndCheck, new RemoveIntervals)
+    val passes = Seq(ToWorkingIR, new ResolveAndCheck, RemoveIntervals)
     val input =
       s"""circuit Unit :
          |  module Unit :

--- a/src/test/scala/firrtlTests/stage/FirrtlCliSpec.scala
+++ b/src/test/scala/firrtlTests/stage/FirrtlCliSpec.scala
@@ -20,7 +20,7 @@ class FirrtlCliSpec extends FlatSpec with Matchers {
       "--custom-transforms", "firrtl.transforms.ConstantPropagation" )
     val expected = Seq(
       classOf[firrtl.transforms.BlackBoxSourceHelper],
-      classOf[firrtl.transforms.CheckCombLoops],
+      firrtl.transforms.CheckCombLoops.getClass,
       classOf[firrtl.transforms.CombineCats],
       firrtl.transforms.ConstantPropagation.getClass )
 

--- a/src/test/scala/firrtlTests/stage/FirrtlCliSpec.scala
+++ b/src/test/scala/firrtlTests/stage/FirrtlCliSpec.scala
@@ -22,7 +22,7 @@ class FirrtlCliSpec extends FlatSpec with Matchers {
       classOf[firrtl.transforms.BlackBoxSourceHelper],
       classOf[firrtl.transforms.CheckCombLoops],
       classOf[firrtl.transforms.CombineCats],
-      classOf[firrtl.transforms.ConstantPropagation] )
+      firrtl.transforms.ConstantPropagation.getClass )
 
     shell
       .parse(args)

--- a/src/test/scala/firrtlTests/stage/FirrtlCliSpec.scala
+++ b/src/test/scala/firrtlTests/stage/FirrtlCliSpec.scala
@@ -21,7 +21,7 @@ class FirrtlCliSpec extends FlatSpec with Matchers {
     val expected = Seq(
       classOf[firrtl.transforms.BlackBoxSourceHelper],
       firrtl.transforms.CheckCombLoops.getClass,
-      classOf[firrtl.transforms.CombineCats],
+      firrtl.transforms.CombineCats.getClass,
       firrtl.transforms.ConstantPropagation.getClass )
 
     shell

--- a/src/test/scala/firrtlTests/transforms/CombineCatsSpec.scala
+++ b/src/test/scala/firrtlTests/transforms/CombineCatsSpec.scala
@@ -10,7 +10,7 @@ import firrtlTests.FirrtlFlatSpec
 import firrtlTests.FirrtlCheckers._
 
 class CombineCatsSpec extends FirrtlFlatSpec {
-  private val transforms = Seq(new IRToWorkingIR, new CombineCats)
+  private val transforms = Seq(new IRToWorkingIR, CombineCats)
   private val annotations = Seq(new MaxCatLenAnnotation(12))
 
   private def execute(input: String, transforms: Seq[Transform], annotations: AnnotationSeq): CircuitState = {

--- a/src/test/scala/firrtlTests/transforms/InferWidthsWithAnnosSpec.scala
+++ b/src/test/scala/firrtlTests/transforms/InferWidthsWithAnnosSpec.scala
@@ -36,7 +36,7 @@ class InferWidthsWithAnnosSpec extends FirrtlFlatSpec {
       InferTypes,
       CheckTypes,
       ResolveFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths)
 
     val input =
@@ -65,7 +65,7 @@ class InferWidthsWithAnnosSpec extends FirrtlFlatSpec {
       InferTypes,
       CheckTypes,
       ResolveFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths)
 
     val annos = Seq(WidthGeqConstraintAnnotation(
@@ -108,7 +108,7 @@ class InferWidthsWithAnnosSpec extends FirrtlFlatSpec {
       InferTypes,
       CheckTypes,
       ResolveFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths)
 
     val tokenLists = Seq(
@@ -157,7 +157,7 @@ class InferWidthsWithAnnosSpec extends FirrtlFlatSpec {
       ResolveKinds,
       InferTypes,
       ResolveFlows,
-      new InferWidths,
+      InferWidths,
       CheckWidths,
       new WiringTransform,
       new ResolveAndCheck


### PR DESCRIPTION
Currently, passes and transforms in FIRRTL are a mix of singletons and regular classes. Since I would like to see us move to the robust graph of passes that can be expressed in the Dependency API, I think there are compelling reasons to use singletons.

* The `TransformLike` interface defines a transform as a mathematical operation. Executing its operation with a _static_ execute method provides at least some documentation of programmer intent to adhere to this requirement.
* Transform determinism has been an ongoing issue (more-or-less restating the previous bullet). When the user makes a transform a singleton, they are more likely to be in the mindset of respecting determinism.
* Internally, the `DependencyManager` relies on single reference instance per dependency. This makes the transform ordering analysis robust, but it further incentivizes avoiding multiple instances of a transform.
* Automatically-ordered transforms cannot have constructor arguments.

Many of the early FIRRTL transforms/passes were singletons, but the prevalence dropped for a few reasons:
* Non-referentially transparent mutable state present at the top level of the transform. I would consider this harmful given the idea of "transform as mathematical operation."
* One of the more interesting reasons was in #1057, where a referentially transparent cache was breaking in a threaded context. I fixed this by using thread-safe collections when restoring `RemoveAccesses` to an object.
* APIs like `RunFirrtlTransformAnnotation` support instantiating classes based on command line options.
* The Dependency API is expressed in terms of `Class`es that get instantiated, which currently breaks support for singleton transforms.

I would like to avoid dropping support for singleton transforms in 1.3, since they are prevalent and have nice properties.

The first two commits of this PR fix technical barriers to full support of singleton transforms. These are mostly meant to be a prototype idea for consideration, since they modify some code from @seldridge that would break some downstream PRs.
 
This involves two main changes:
* Changing the type of dependencies to an `Either` that can accept a `Class` or a `Singleton` (Scala built-in type since 2.10 that all singletons comply with). This involves some convenience methods to wrap dependency list creation and object creation, which can be seen in use in the first commit.
