### PR TITLE
Remove Stage-global --no-dedup Option

### DIFF
--- a/src/main/scala/firrtl/options/Shell.scala
+++ b/src/main/scala/firrtl/options/Shell.scala
@@ -3,7 +3,6 @@
 package firrtl.options
 
 import firrtl.AnnotationSeq
-import firrtl.transforms.NoCircuitDedupAnnotation
 
 import logger.{LogLevelAnnotation, ClassLogLevelAnnotation, LogFileAnnotation, LogClassNamesAnnotation}
 
@@ -65,8 +64,7 @@ class Shell(val applicationName: String) {
   ProgramArgsAnnotation.addOptions(parser)
   Seq( TargetDirAnnotation,
        InputAnnotationFileAnnotation,
-       OutputAnnotationFileAnnotation,
-       NoCircuitDedupAnnotation)
+       OutputAnnotationFileAnnotation )
     .foreach(_.addOptions(parser))
 
   parser.opt[Unit]("show-registrations")

--- a/src/main/scala/firrtl/stage/FirrtlCli.scala
+++ b/src/main/scala/firrtl/stage/FirrtlCli.scala
@@ -3,6 +3,7 @@
 package firrtl.stage
 
 import firrtl.options.Shell
+import firrtl.transforms.NoCircuitDedupAnnotation
 
 /** [[firrtl.options.Shell Shell]] mixin that provides command line options for FIRRTL. This does not include any
   * [[firrtl.options.RegisteredLibrary RegisteredLibrary]] or [[firrtl.options.RegisteredTransform RegisteredTransform]]
@@ -17,7 +18,8 @@ trait FirrtlCli { this: Shell =>
        CompilerAnnotation,
        RunFirrtlTransformAnnotation,
        firrtl.EmitCircuitAnnotation,
-       firrtl.EmitAllModulesAnnotation )
+       firrtl.EmitAllModulesAnnotation,
+       NoCircuitDedupAnnotation )
     .map(_.addOptions(parser))
 
   phases.DriverCompatibility.TopNameAnnotation.addOptions(parser)


### PR DESCRIPTION
### Checklist

- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix                 

### API Impact

This removes the `--no-dedup` option from all stages which are not FIRRTL. Technically this was leaking in ChiselStage, but it should be safe to remove that. Users can always prevent deduplication with an annotation.

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

### Backend Code Generation Impact

No impact.

### Desired Merge Strategy

- Squash
