### PR TITLE
Remove incorrect --firrtl-source option

### DIFF
--- a/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
+++ b/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
@@ -131,7 +131,7 @@ object FirrtlSourceAnnotation extends HasShellOptions {
       longOption      = "firrtl-source",
       toAnnotationSeq = a => Seq(FirrtlSourceAnnotation(a)),
       helpText        = "An input FIRRTL circuit string",
-      shortOption     = Some("<string>") ) )
+      helpValueName   = Some("<string>") ) )
 
 }
 


### PR DESCRIPTION
This removes the incorrect short --firrtl-source option. This was
supposed to be the helpValueName.

### Checklist

- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
- documentation        
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

### API Impact

Technically this is an API change as it removes a bad short option.

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

### Backend Code Generation Impact

No impact.

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
