### PR TITLE
Make WriteEmitted an Identity Phase

### DIFF
--- a/src/main/scala/firrtl/stage/package.scala
+++ b/src/main/scala/firrtl/stage/package.scala
@@ -2,7 +2,6 @@
 
 package firrtl
 
-import firrtl.annotations.DeletedAnnotation
 import firrtl.options.{OptionsView, Viewer}
 import firrtl.stage.phases.WriteEmitted
 
@@ -43,7 +42,7 @@ package object stage {
     def view(options: AnnotationSeq): FirrtlExecutionResult = {
       val fopts = Viewer[FirrtlOptions].view(options)
       val emittedRes = options
-        .collect{ case DeletedAnnotation(dummyWriteEmitted.name, a: EmittedAnnotation[_]) => a.value.value }
+        .collect{ case a: EmittedAnnotation[_] => a.value.value }
         .mkString("\n")
 
       options.collectFirst{ case a: FirrtlCircuitAnnotation => a.circuit } match {

--- a/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
+++ b/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
@@ -22,29 +22,29 @@ import java.io.PrintWriter
   * This does no sanity checking of the input [[AnnotationSeq]]. This simply writes any modules or circuits it sees to
   * files. If you need additional checking, then you should stack an appropriate checking phase before this.
   *
-  * Any annotations written to files will be deleted.
+  * Any [[EmittedAnnotation]]s are *not* deleted. Running this more than once will result in the same file being written
+  * multiple times.
   */
 class WriteEmitted extends Phase {
 
-  /** Write any [[EmittedAnnotation]]s in an [[AnnotationSeq]] to files. Written [[EmittedAnnotation]]s are deleted. */
+  /** Write any [[EmittedAnnotation]]s in an [[AnnotationSeq]] to files. */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {
     val fopts = Viewer[FirrtlOptions].view(annotations)
     val sopts = Viewer[StageOptions].view(annotations)
 
-    annotations.flatMap {
+    annotations.foreach {
       case a: EmittedModuleAnnotation[_] =>
         val pw = new PrintWriter(sopts.getBuildFileName(a.value.name, Some(a.value.outputSuffix)))
         pw.write(a.value.value)
         pw.close()
-        None
       case a: EmittedCircuitAnnotation[_] =>
         val pw = new PrintWriter(
           sopts.getBuildFileName(fopts.outputFileName.getOrElse(a.value.name), Some(a.value.outputSuffix)))
         pw.write(a.value.value)
         pw.close()
-        None
-      case a => Some(a)
+      case a =>
     }
 
+    annotations
   }
 }

--- a/src/test/scala/firrtlTests/stage/phases/WriteEmittedSpec.scala
+++ b/src/test/scala/firrtlTests/stage/phases/WriteEmittedSpec.scala
@@ -14,11 +14,6 @@ import firrtl.stage.phases.WriteEmitted
 
 class WriteEmittedSpec extends FlatSpec with Matchers {
 
-  def removeEmitted(a: AnnotationSeq): AnnotationSeq = a.flatMap {
-    case a: EmittedAnnotation[_] => None
-    case a => Some(a)
-  }
-
   class Fixture { val phase: Phase = new WriteEmitted }
 
   behavior of classOf[WriteEmitted].toString
@@ -33,7 +28,7 @@ class WriteEmittedSpec extends FlatSpec with Matchers {
       .map(a => new File(s"test_run_dir/WriteEmittedSpec/$a"))
 
     info("annotations are unmodified")
-    phase.transform(annotations).toSeq should be (removeEmitted(annotations).toSeq)
+    phase.transform(annotations).toSeq should be (annotations)
 
     expected.foreach{ a =>
       info(s"$a was written")
@@ -50,7 +45,7 @@ class WriteEmittedSpec extends FlatSpec with Matchers {
     val expected = new File("test_run_dir/WriteEmittedSpec/quux.quxcircuit")
 
     info("annotations are unmodified")
-    phase.transform(annotations).toSeq should be (removeEmitted(annotations).toSeq)
+    phase.transform(annotations).toSeq should be (annotations)
 
     info(s"$expected was written")
     expected should (exist)
@@ -66,8 +61,8 @@ class WriteEmittedSpec extends FlatSpec with Matchers {
     val expected = Seq("foo.foomodule", "bar.barmodule", "baz.bazmodule")
       .map(a => new File(s"test_run_dir/WriteEmittedSpec/$a"))
 
-    info("EmittedComponent annotations are deleted")
-    phase.transform(annotations).toSeq should be (removeEmitted(annotations).toSeq)
+    info("annotations are unmodified")
+    phase.transform(annotations).toSeq should be (annotations)
 
     expected.foreach{ a =>
       info(s"$a was written")


### PR DESCRIPTION
### Checklist

- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

The `WriteEmitted` phase, used to write any `EmitedAnnotation`s by the FIRRTL stage, currently deletes any annotations it writes. This changes that such that `WriteEmitted` will preserve the annotation sequence.

Previously, `WriteEmitted` was idempotent in terms of side effects. After this PR, it will repeatedly write the same `EmittedAnnotation` to a file every time its written.

<!-- Choose one or more from the following: -->
- bug fix
- code cleanup
- backend code generation
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - new feature/API                    -->

Fixes #1261 

### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

This changes the output annotation sequence. Any downstream phases that are expecting to either not see an `EmittedAnnotation` or to see a `DeletedAnnotation` (which arguably is not a supported API) will now see an `EmittedAnnotation`. This has potential API implications for testers, treadle, and firrtl-interpreter if they are looking for a `DeletedAnnotation`.

### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

This does not affect Verilog, but it does affect the output annotation sequence.

### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
