### PR TITLE
Add DontSerialize / --write-dont-serialize

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -15,7 +15,7 @@ import firrtl.PrimOps._
 import firrtl.WrappedExpression._
 import Utils._
 import MemPortUtils.{memPortField, memType}
-import firrtl.options.{HasShellOptions, ShellOption, StageUtils, PhaseException}
+import firrtl.options.{DontSerialize, HasShellOptions, ShellOption, StageUtils, PhaseException}
 import firrtl.stage.RunFirrtlTransformAnnotation
 // Datastructures
 import scala.collection.mutable.ArrayBuffer
@@ -93,7 +93,7 @@ final case class EmittedFirrtlModule(name: String, value: String, outputSuffix: 
 final case class EmittedVerilogModule(name: String, value: String, outputSuffix: String) extends EmittedModule
 
 /** Traits for Annotations containing emitted components */
-sealed trait EmittedAnnotation[T <: EmittedComponent] extends NoTargetAnnotation {
+sealed trait EmittedAnnotation[T <: EmittedComponent] extends NoTargetAnnotation with DontSerialize {
   val value: T
 }
 sealed trait EmittedCircuitAnnotation[T <: EmittedCircuit] extends EmittedAnnotation[T]

--- a/src/main/scala/firrtl/options/Shell.scala
+++ b/src/main/scala/firrtl/options/Shell.scala
@@ -66,6 +66,7 @@ class Shell(val applicationName: String) {
   Seq( TargetDirAnnotation,
        InputAnnotationFileAnnotation,
        OutputAnnotationFileAnnotation,
+       WriteDontSerializeAnnotation,
        NoCircuitDedupAnnotation)
     .foreach(_.addOptions(parser))
 

--- a/src/main/scala/firrtl/options/StageAnnotations.scala
+++ b/src/main/scala/firrtl/options/StageAnnotations.scala
@@ -14,6 +14,17 @@ sealed trait StageOption { this: Annotation => }
   */
 trait Unserializable { this: Annotation => }
 
+/** [[Annotation]] mixin that indicates that an annotation should not be serialized during WriteOutputAnnotations.
+  *
+  * Mixing this in would indicate that this is an annotation has some attribute that makes it undesirable to serialize,
+  * e.g., it's very large like [[FirrtlCircuitAnnotation]].
+  *
+  * @note Mixing this into an annotation that is used for inter-stage communication will prevent those stages from
+  * running serially and communicating only using annotations.
+  * @see [[Unserializable]] for annotations that *cannot* be serialized
+  */
+trait DontSerialize { this: Annotation => }
+
 /** Holds the name of the target directory
   *  - set with `-td/--target-dir`
   *  - if unset, a [[TargetDirAnnotation]] will be generated with the
@@ -89,6 +100,7 @@ object OutputAnnotationFileAnnotation extends HasShellOptions {
   * [[firrtl.options.phase.WriteOutputAnnotations WriteOutputAnnotations]] will include
   * [[firrtl.annotations.DeletedAnnotation DeletedAnnotation]]s when it writes to a file.
   *  - set with '--write-deleted'
+  * @see [[WritedontSerializeAnnotation]]
   */
 case object WriteDeletedAnnotation extends NoTargetAnnotation with StageOption with HasShellOptions {
 
@@ -97,5 +109,21 @@ case object WriteDeletedAnnotation extends NoTargetAnnotation with StageOption w
       longOption = "write-deleted",
       toAnnotationSeq = (_: Unit) => Seq(WriteDeletedAnnotation),
       helpText = "Include deleted annotations in the output annotation file" ) )
+
+}
+
+/** if this [[firrtl.annotations.Annotation Annotation]] exists in an [[firrtl.AnnotationSeq AnnotationSeq]], then any
+  * annotation sthat mixing [[DontSerialize]] will be included in the output annotation file for a
+  * [[firrtl.options.Stage Stage]].
+  *  - set with '--write-dont-serialize'
+  * @see [[WriteDontSerializeAnnotation]]
+  */
+case object WriteDontSerializeAnnotation extends NoTargetAnnotation with StageOption with HasShellOptions {
+
+  val options = Seq(
+    new ShellOption[Unit](
+      longOption = "write-dont-serialize",
+      toAnnotationSeq = (_: Unit) => Seq(WriteDontSerializeAnnotation),
+      helpText = "Include 'DontSerialize' annotations in the output annotation file") )
 
 }

--- a/src/main/scala/firrtl/options/StageOptions.scala
+++ b/src/main/scala/firrtl/options/StageOptions.scala
@@ -11,25 +11,28 @@ import java.io.File
   * @param outputAnnotationFileName an output annotation filename
   */
 class StageOptions private [firrtl] (
-  val targetDir:         String         = TargetDirAnnotation().directory,
-  val annotationFilesIn: Seq[String]    = Seq.empty,
-  val annotationFileOut: Option[String] = None,
-  val programArgs:       Seq[String]    = Seq.empty,
-  val writeDeleted:      Boolean        = false ) {
+  val targetDir:          String         = TargetDirAnnotation().directory,
+  val annotationFilesIn:  Seq[String]    = Seq.empty,
+  val annotationFileOut:  Option[String] = None,
+  val programArgs:        Seq[String]    = Seq.empty,
+  val writeDeleted:       Boolean        = false,
+  val writeDontSerialize: Boolean        = false) {
 
   private [options] def copy(
-    targetDir:         String         = targetDir,
-    annotationFilesIn: Seq[String]    = annotationFilesIn,
-    annotationFileOut: Option[String] = annotationFileOut,
-    programArgs:       Seq[String]    = programArgs,
-    writeDeleted:      Boolean        = writeDeleted ): StageOptions = {
+    targetDir:          String         = targetDir,
+    annotationFilesIn:  Seq[String]    = annotationFilesIn,
+    annotationFileOut:  Option[String] = annotationFileOut,
+    programArgs:        Seq[String]    = programArgs,
+    writeDeleted:       Boolean        = writeDeleted,
+    writeDontSerialize: Boolean        = writeDontSerialize): StageOptions = {
 
     new StageOptions(
       targetDir = targetDir,
       annotationFilesIn = annotationFilesIn,
       annotationFileOut = annotationFileOut,
       programArgs = programArgs,
-      writeDeleted = writeDeleted )
+      writeDeleted = writeDeleted,
+      writeDontSerialize = writeDontSerialize )
 
   }
 

--- a/src/main/scala/firrtl/options/package.scala
+++ b/src/main/scala/firrtl/options/package.scala
@@ -16,6 +16,7 @@ package object options {
           /* Do NOT reorder program args. The order may matter. */
           case ProgramArgsAnnotation(a) => c.copy(programArgs = c.programArgs :+ a)
           case WriteDeletedAnnotation => c.copy(writeDeleted = true)
+          case WriteDontSerializeAnnotation => c.copy(writeDontSerialize = true)
         }
       )
   }

--- a/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
+++ b/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
@@ -4,7 +4,7 @@ package firrtl.options.phases
 
 import firrtl.AnnotationSeq
 import firrtl.annotations.{DeletedAnnotation, JsonProtocol}
-import firrtl.options.{Phase, StageOptions, Unserializable, Viewer}
+import firrtl.options.{DontSerialize, Phase, StageOptions, Unserializable, Viewer}
 
 import java.io.PrintWriter
 
@@ -19,6 +19,7 @@ class WriteOutputAnnotations extends Phase {
     val serializable = annotations.filter{
       case _: Unserializable    => false
       case _: DeletedAnnotation => sopts.writeDeleted
+      case _: DontSerialize     => sopts.writeDontSerialize
       case _                    => true
     }
 

--- a/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
+++ b/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
@@ -5,7 +5,7 @@ package firrtl.stage
 import firrtl._
 import firrtl.ir.Circuit
 import firrtl.annotations.{Annotation, NoTargetAnnotation}
-import firrtl.options.{HasShellOptions, OptionsException, ShellOption}
+import firrtl.options.{DontSerialize, HasShellOptions, OptionsException, ShellOption}
 
 
 import java.io.FileNotFoundException
@@ -117,7 +117,7 @@ object InfoModeAnnotation extends HasShellOptions {
   *  - set with `--firrtl-source`
   * @param value FIRRTL source as a [[scala.Predef.String String]]
   */
-case class FirrtlSourceAnnotation(source: String) extends NoTargetAnnotation with CircuitOption {
+case class FirrtlSourceAnnotation(source: String) extends NoTargetAnnotation with CircuitOption with DontSerialize {
 
   def toCircuit(info: Parser.InfoMode): FirrtlCircuitAnnotation =
     FirrtlCircuitAnnotation(Parser.parseString(source, info))
@@ -200,7 +200,7 @@ object RunFirrtlTransformAnnotation extends HasShellOptions {
 /** Holds a FIRRTL [[firrtl.ir.Circuit Circuit]]
   * @param circuit a circuit
   */
-case class FirrtlCircuitAnnotation(circuit: Circuit) extends NoTargetAnnotation with FirrtlOption {
+case class FirrtlCircuitAnnotation(circuit: Circuit) extends NoTargetAnnotation with FirrtlOption with DontSerialize {
   /* Caching the hashCode for a large circuit is necessary due to repeated queries, e.g., in
    * [[Compiler.propagateAnnotations]]. Not caching the hashCode will cause severe performance degredations for large
    * [[Annotations]].


### PR DESCRIPTION
### Checklist

- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

This adds a `DontSerialize` annotation mix-in that is intended to indicate that an annotation should not be serialized to JSON. This fixes a bug where large annotations (e.g., `FirrtlCircuitAnnotation`) serialized to JSON would cause Java to die (see: #1272).

This behavior can be disabled with `--write-dont-serialize`/`WriteDontSerializeAnnotation`.

`FirrtlCircuitAnnotation`, `FirrtlSourceAnnotation`, and `EmittedAnnotation` now mix-in `DontSerialize`. 

This includes tests that serialization is enabled/disabled with `WriteDontSerializeAnnotation`.

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
- new feature/API

### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

This adds the `--write-dont-serialize` API to all stages.

This changes the output annotation JSON file to strip `FirrtlCircuitAnnotation` and `FirrtlSourceAnnotation` which reverts to pre-3.2 behavior. **This is an API change if I pedantically define the output annotation JSON as an API.** However, I don't view the output annotation *JSON* as an API. I only view the internal `AnnotationSeq` as an API.

Because this fixes a bug that is hitting large designs (see #1272), I would like to get this into 1.2.2 even though it's pedantically API breaking for someone who is writing a downstream tool/stage that is consuming the annotation JSON (I expect that such users do not exist).

If the API addition is problematic for 1.2.2, I can both (1) remove the `--write-dont-serialize` option and (2) make the `DontSerialize` mixin `private[firrtl]`. If the change to the output annotation *JSON* is problematic, this can be retargeted for 1.3.0.

#### Broader Discussions

This is starting to hint at the following three lemmas:

> (1): An `AnnotationSeq` can be converted to `(annoJSON: File, other: Seq[File])`.

> (2): The information encoded by `annoJSON` and `other` are mutually exclusive.

> (3): The `AnnotationSeq` may contain extra information not included in the files.

What does this mean? 

It means that I can have tools that communicate through either an `AnnotationSeq` or through files. The `AnnotationSeq` can be broken up into three types of information: information not serialized (e.g., `DeletedAnnotation`/junk, `Unserializable`/internal use only), information serialized in some special way (e.g., `DontSerialize`/a FIRRTL circuit written to a file), and anything else which is serialized to JSON. Information should not both be written to JSON and to a separate file as downstream tools will deserialize this to duplicate copies. Additionally, things not serialized are either junk left around or things which are not of any utility for downstream tools. 

### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

No impact on FIRRTL or Verilog emitter output. Serialized annotation JSON will not include the FIRRTL circuit or the FIRRTL source.

### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!-- Squash: The PR will be squashed and merged (choose this if you have no preference. -->
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

### Related Discussions

Fixes #1272 