### PR TITLE
Make the member 'logger' added by the trait LazyLogging protected.

### DIFF
--- a/src/main/scala/logger/Logger.scala
+++ b/src/main/scala/logger/Logger.scala
@@ -46,7 +46,7 @@ object LogLevel extends Enumeration {
   * extend this trait to enable logging in a class you are implementing
   */
 trait LazyLogging {
-  val logger = new Logger(this.getClass.getName)
+  protected val logger = new Logger(this.getClass.getName)
 }
 
 /**


### PR DESCRIPTION
The switch to using our own Logger triggered a latent bug, described in comments to #1258. Make the `val logger` introduced by the `trait LazyLogging` protected.

### Checklist

- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

   - bug fix 

### API Impact

This fixes API breakage inadvertently introduced by #1258 

### Backend Code Generation Impact

No impact on code generation.

### Desired Merge Strategy

   - Squash: The PR will be squashed and merged (choose this if you have no preference.
