### PR TITLE
Support object transforms

### DIFF
--- a/src/main/scala/firrtl/AddDescriptionNodes.scala
+++ b/src/main/scala/firrtl/AddDescriptionNodes.scala
@@ -5,6 +5,7 @@ package firrtl
 import firrtl.ir._
 import firrtl.annotations._
 import firrtl.Mappers._
+import firrtl.options.DependencyID
 
 case class DescriptionAnnotation(named: Named, description: String) extends Annotation {
   def update(renames: RenameMap): Seq[DescriptionAnnotation] = {
@@ -72,12 +73,12 @@ class AddDescriptionNodes extends Transform {
   def outputForm = LowForm
 
   override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
-    Seq( classOf[firrtl.transforms.BlackBoxSourceHelper],
-         classOf[firrtl.transforms.ReplaceTruncatingArithmetic],
-         classOf[firrtl.transforms.FlattenRegUpdate],
-         classOf[firrtl.passes.VerilogModulusCleanup],
-         classOf[firrtl.transforms.VerilogRename],
-         classOf[firrtl.passes.VerilogPrep] )
+    Seq( DependencyID[firrtl.transforms.BlackBoxSourceHelper],
+         DependencyID[firrtl.transforms.ReplaceTruncatingArithmetic],
+         DependencyID[firrtl.transforms.FlattenRegUpdate],
+         DependencyID[firrtl.passes.VerilogModulusCleanup],
+         DependencyID[firrtl.transforms.VerilogRename],
+         DependencyID[firrtl.passes.VerilogPrep] )
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/AddDescriptionNodes.scala
+++ b/src/main/scala/firrtl/AddDescriptionNodes.scala
@@ -5,7 +5,7 @@ package firrtl
 import firrtl.ir._
 import firrtl.annotations._
 import firrtl.Mappers._
-import firrtl.options.DependencyID
+import firrtl.options.Dependency
 
 case class DescriptionAnnotation(named: Named, description: String) extends Annotation {
   def update(renames: RenameMap): Seq[DescriptionAnnotation] = {
@@ -73,12 +73,12 @@ class AddDescriptionNodes extends Transform {
   def outputForm = LowForm
 
   override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
-    Seq( DependencyID[firrtl.transforms.BlackBoxSourceHelper],
-         DependencyID[firrtl.transforms.ReplaceTruncatingArithmetic],
-         DependencyID[firrtl.transforms.FlattenRegUpdate],
-         DependencyID[firrtl.passes.VerilogModulusCleanup],
-         DependencyID[firrtl.transforms.VerilogRename],
-         DependencyID[firrtl.passes.VerilogPrep] )
+    Seq( Dependency[firrtl.transforms.BlackBoxSourceHelper],
+         Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
+         Dependency[firrtl.transforms.FlattenRegUpdate],
+         Dependency[firrtl.passes.VerilogModulusCleanup],
+         Dependency[firrtl.transforms.VerilogRename],
+         Dependency[firrtl.passes.VerilogPrep] )
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -178,6 +178,7 @@ final case object UnknownForm extends CircuitForm(-1) {
 
 /** The basic unit of operating on a Firrtl AST */
 trait Transform extends TransformLike[CircuitState] with DependencyAPI[Transform] {
+
   /** A convenience function useful for debugging and error messages */
   def name: String = this.getClass.getName
   /** The [[firrtl.CircuitForm]] that this transform requires to operate on */
@@ -208,7 +209,7 @@ trait Transform extends TransformLike[CircuitState] with DependencyAPI[Transform
 
   private def emptySet = new scala.collection.mutable.LinkedHashSet[TransformDependency]
 
-  override def prerequisites: Seq[Dependency] = inputForm match {
+  override def prerequisites: Seq[DependencyID[Transform]] = inputForm match {
     case C => Nil
     case H => Forms.Deduped
     case M => Forms.MidForm
@@ -216,12 +217,12 @@ trait Transform extends TransformLike[CircuitState] with DependencyAPI[Transform
     case U => Nil
   }
 
-  override def optionalPrerequisites: Seq[Dependency] = inputForm match {
+  override def optionalPrerequisites: Seq[DependencyID[Transform]] = inputForm match {
     case L => Forms.LowFormOptimized
     case _ => Seq.empty
   }
 
-  override def dependents: Seq[Dependency] = {
+  override def dependents: Seq[DependencyID[Transform]] = {
     val lowEmitters = DependencyID[LowFirrtlEmitter] :: DependencyID[VerilogEmitter] :: DependencyID[MinimumVerilogEmitter] ::
       DependencyID[SystemVerilogEmitter] :: Nil
 

--- a/src/main/scala/firrtl/Driver.scala
+++ b/src/main/scala/firrtl/Driver.scala
@@ -12,7 +12,7 @@ import firrtl.transforms._
 import firrtl.Utils.throwInternalError
 import firrtl.stage.{FirrtlExecutionResultView, FirrtlStage}
 import firrtl.stage.phases.DriverCompatibility
-import firrtl.options.{Phase, PhaseManager, StageUtils, Viewer}
+import firrtl.options.{DependencyID, Phase, PhaseManager, StageUtils, Viewer}
 import firrtl.options.phases.DeletedWrapper
 import firrtl.FileUtils
 
@@ -214,12 +214,11 @@ object Driver {
     val phases: Seq[Phase] = {
       import DriverCompatibility._
       new PhaseManager(
-        Seq( classOf[AddImplicitFirrtlFile],
-             classOf[AddImplicitAnnotationFile],
-             classOf[AddImplicitOutputFile],
-             classOf[AddImplicitEmitter],
-             classOf[FirrtlStage] )
-          .map(_.asInstanceOf[Class[Phase]]) )
+        Seq( DependencyID[AddImplicitFirrtlFile],
+             DependencyID[AddImplicitAnnotationFile],
+             DependencyID[AddImplicitOutputFile],
+             DependencyID[AddImplicitEmitter],
+             DependencyID[FirrtlStage] ))
         .transformOrder
         .map(DeletedWrapper(_))
     }

--- a/src/main/scala/firrtl/Driver.scala
+++ b/src/main/scala/firrtl/Driver.scala
@@ -12,7 +12,7 @@ import firrtl.transforms._
 import firrtl.Utils.throwInternalError
 import firrtl.stage.{FirrtlExecutionResultView, FirrtlStage}
 import firrtl.stage.phases.DriverCompatibility
-import firrtl.options.{DependencyID, Phase, PhaseManager, StageUtils, Viewer}
+import firrtl.options.{Dependency, Phase, PhaseManager, StageUtils, Viewer}
 import firrtl.options.phases.DeletedWrapper
 import firrtl.FileUtils
 
@@ -214,11 +214,11 @@ object Driver {
     val phases: Seq[Phase] = {
       import DriverCompatibility._
       new PhaseManager(
-        Seq( DependencyID[AddImplicitFirrtlFile],
-             DependencyID[AddImplicitAnnotationFile],
-             DependencyID[AddImplicitOutputFile],
-             DependencyID[AddImplicitEmitter],
-             DependencyID[FirrtlStage] ))
+        Seq( Dependency[AddImplicitFirrtlFile],
+             Dependency[AddImplicitAnnotationFile],
+             Dependency[AddImplicitOutputFile],
+             Dependency[AddImplicitEmitter],
+             Dependency[FirrtlStage] ))
         .transformOrder
         .map(DeletedWrapper(_))
     }

--- a/src/main/scala/firrtl/checks/CheckResets.scala
+++ b/src/main/scala/firrtl/checks/CheckResets.scala
@@ -3,7 +3,7 @@
 package firrtl.checks
 
 import firrtl._
-import firrtl.options.PreservesAll
+import firrtl.options.{DependencyID, PreservesAll}
 import firrtl.passes.{Errors, PassException}
 import firrtl.ir._
 import firrtl.traversals.Foreachers._
@@ -31,11 +31,11 @@ class CheckResets extends Transform with PreservesAll[Transform] {
   def outputForm: CircuitForm = MidForm
 
   override val prerequisites =
-    Seq( classOf[passes.LowerTypes],
-         classOf[passes.Legalize],
-         classOf[firrtl.transforms.RemoveReset] ) ++ firrtl.stage.Forms.MidForm
+    Seq( DependencyID[passes.LowerTypes],
+         DependencyID[passes.Legalize],
+         DependencyID[firrtl.transforms.RemoveReset] ) ++ firrtl.stage.Forms.MidForm
 
-  override val optionalPrerequisites = Seq(classOf[firrtl.transforms.CheckCombLoops])
+  override val optionalPrerequisites = Seq(DependencyID[firrtl.transforms.CheckCombLoops])
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/checks/CheckResets.scala
+++ b/src/main/scala/firrtl/checks/CheckResets.scala
@@ -3,7 +3,7 @@
 package firrtl.checks
 
 import firrtl._
-import firrtl.options.{DependencyID, PreservesAll}
+import firrtl.options.{Dependency, PreservesAll}
 import firrtl.passes.{Errors, PassException}
 import firrtl.ir._
 import firrtl.traversals.Foreachers._
@@ -31,11 +31,11 @@ class CheckResets extends Transform with PreservesAll[Transform] {
   def outputForm: CircuitForm = MidForm
 
   override val prerequisites =
-    Seq( DependencyID(passes.LowerTypes),
-         DependencyID[passes.Legalize],
-         DependencyID[firrtl.transforms.RemoveReset] ) ++ firrtl.stage.Forms.MidForm
+    Seq( Dependency(passes.LowerTypes),
+         Dependency[passes.Legalize],
+         Dependency[firrtl.transforms.RemoveReset] ) ++ firrtl.stage.Forms.MidForm
 
-  override val optionalPrerequisites = Seq(DependencyID[firrtl.transforms.CheckCombLoops])
+  override val optionalPrerequisites = Seq(Dependency[firrtl.transforms.CheckCombLoops])
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/checks/CheckResets.scala
+++ b/src/main/scala/firrtl/checks/CheckResets.scala
@@ -31,7 +31,7 @@ class CheckResets extends Transform with PreservesAll[Transform] {
   def outputForm: CircuitForm = MidForm
 
   override val prerequisites =
-    Seq( DependencyID[passes.LowerTypes],
+    Seq( DependencyID(passes.LowerTypes),
          DependencyID[passes.Legalize],
          DependencyID[firrtl.transforms.RemoveReset] ) ++ firrtl.stage.Forms.MidForm
 

--- a/src/main/scala/firrtl/options/DependencyManager.scala
+++ b/src/main/scala/firrtl/options/DependencyManager.scala
@@ -430,15 +430,6 @@ class PhaseManager(
   val currentState: Seq[PhaseManager.PhaseDependency] = Seq.empty,
   val knownObjects: Set[Phase] = Set.empty) extends DependencyManager[AnnotationSeq, Phase] with Phase {
 
-  // TODO: are these adapter constructors needed?
-  def this(targets: Seq[Class[_ <: Phase]], currentState: Seq[Class[_ <: Phase]]) {
-    this(targets.map(c => DependencyID[Phase](Left(c))), currentState.map(c => DependencyID[Phase](Left(c))))
-  }
-
-  def this(targets: Seq[Class[_ <: Phase]]) {
-    this(targets, Seq.empty)
-  }
-
   protected def copy(a: Seq[Dependency], b: Seq[Dependency], c: ISet[Phase]) = new PhaseManager(a, b, c)
 }
 

--- a/src/main/scala/firrtl/options/DependencyManager.scala
+++ b/src/main/scala/firrtl/options/DependencyManager.scala
@@ -29,15 +29,15 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
   /** Requested [[firrtl.options.TransformLike TransformLike]]s that should be run. Internally, this will be converted to
     * a set based on the ordering defined here.
     */
-  def targets: Seq[Dependency]
-  private lazy val _targets: LinkedHashSet[Dependency] = targets
-    .foldLeft(new LinkedHashSet[Dependency]()){ case (a, b) => a += b }
+  def targets: Seq[DependencyID[B]]
+  private lazy val _targets: LinkedHashSet[DependencyID[B]] = targets
+    .foldLeft(new LinkedHashSet[DependencyID[B]]()){ case (a, b) => a += b }
 
   /** A sequence of [[firrtl.Transform]]s that have been run. Internally, this will be converted to an ordered set.
     */
-  def currentState: Seq[Dependency]
-  private lazy val _currentState: LinkedHashSet[Dependency] = currentState
-    .foldLeft(new LinkedHashSet[Dependency]()){ case (a, b) => a += b }
+  def currentState: Seq[DependencyID[B]]
+  private lazy val _currentState: LinkedHashSet[DependencyID[B]] = currentState
+    .foldLeft(new LinkedHashSet[DependencyID[B]]()){ case (a, b) => a += b }
 
   /** Existing transform objects that have already been constructed */
   def knownObjects: Set[B]
@@ -49,8 +49,8 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
 
   /** Store of conversions between classes and objects. Objects that do not exist in the map will be lazily constructed.
     */
-  protected lazy val dependencyToObject: LinkedHashMap[Dependency, B] = {
-    val init = LinkedHashMap[Dependency, B](knownObjects.map(x => oToD(x) -> x).toSeq: _*)
+  protected lazy val dependencyToObject: LinkedHashMap[DependencyID[B], B] = {
+    val init = LinkedHashMap[DependencyID[B], B](knownObjects.map(x => oToD(x) -> x).toSeq: _*)
     (_targets ++ _currentState)
       .filter(!init.contains(_))
       .map(x => init(x) = x.getObject())
@@ -61,32 +61,32 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
     * requirements. This is used to solve sub-problems arising from invalidations.
     */
   protected def copy(
-    targets: Seq[Dependency],
-    currentState: Seq[Dependency],
+    targets: Seq[DependencyID[B]],
+    currentState: Seq[DependencyID[B]],
     knownObjects: ISet[B] = dependencyToObject.values.toSet): B
 
   /** Implicit conversion from Dependency to B */
-  private implicit def dToO(d: Dependency): B = dependencyToObject.getOrElseUpdate(d, d.getObject())
+  private implicit def dToO(d: DependencyID[B]): B = dependencyToObject.getOrElseUpdate(d, d.getObject())
 
   /** Implicit conversion from B to Dependency */
-  private implicit def oToD(b: B): Dependency = DependencyID.fromTransform(b)
+  private implicit def oToD(b: B): DependencyID[B] = DependencyID.fromTransform(b)
 
   /** Modified breadth-first search that supports multiple starting nodes and a custom extractor that can be used to
     * generate/filter the edges to explore. Additionally, this will include edges to previously discovered nodes.
     */
-  private def bfs( start: LinkedHashSet[Dependency],
-                   blacklist: LinkedHashSet[Dependency],
-                   extractor: B => Set[Dependency] ): LinkedHashMap[B, LinkedHashSet[B]] = {
+  private def bfs( start: LinkedHashSet[DependencyID[B]],
+                   blacklist: LinkedHashSet[DependencyID[B]],
+                   extractor: B => Set[DependencyID[B]] ): LinkedHashMap[B, LinkedHashSet[B]] = {
 
     val (queue, edges) = {
-      val a: Queue[Dependency]                    = Queue(start.toSeq:_*)
+      val a: Queue[DependencyID[B]]                    = Queue(start.toSeq:_*)
       val b: LinkedHashMap[B, LinkedHashSet[B]] = LinkedHashMap[B, LinkedHashSet[B]](
         start.map((dToO(_) -> LinkedHashSet[B]())).toSeq:_*)
       (a, b)
     }
 
     while (queue.nonEmpty) {
-      val u: Dependency = queue.dequeue
+      val u: DependencyID[B] = queue.dequeue
       for (v <- extractor(dependencyToObject(u))) {
         if (!blacklist.contains(v) && !edges.contains(v)) {
           queue.enqueue(v)
@@ -114,7 +114,7 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
     val edges = bfs(
       start = _targets &~ _currentState,
       blacklist = _currentState,
-      extractor = (p: B) => new LinkedHashSet[Dependency]() ++ p.prerequisites &~ _currentState)
+      extractor = (p: B) => new LinkedHashSet[DependencyID[B]]() ++ p.prerequisites &~ _currentState)
     DiGraph(edges)
   }
 
@@ -199,8 +199,8 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
         val v = cyclePossible("invalidates", invalidateGraph){ invalidateGraph.linearize }.reverse
         /* A comparison function that will sort vertices based on the topological sort of the invalidation graph */
         val cmp =
-          (l: B, r: B) => v.foldLeft((Map.empty[B, Dependency => Boolean], Set.empty[Dependency])){
-            case ((m, s), r) => (m + (r -> ((a: Dependency) => !s(a))), s + r) }._1(l)(r)
+          (l: B, r: B) => v.foldLeft((Map.empty[B, DependencyID[B] => Boolean], Set.empty[DependencyID[B]])){
+            case ((m, s), r) => (m + (r -> ((a: DependencyID[B]) => !s(a))), s + r) }._1(l)(r)
         new LinkedHashMap() ++
           v.map(vv => vv -> (new LinkedHashSet() ++ (dependencyGraph.getEdges(vv).toSeq.sortWith(cmp))))
       }
@@ -250,7 +250,7 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
   final override def transform(annotations: A): A = {
 
     /* A local store of each wrapper to it's underlying class. */
-    val wrapperToClass = new HashMap[B, Dependency]
+    val wrapperToClass = new HashMap[B, DependencyID[B]]
 
     /* The determined, flat order of transforms is wrapped with surrounding transforms while populating wrapperToClass so
      * that each wrapped transform object can be dereferenced to its underlying class. Each wrapped transform is then
@@ -430,7 +430,8 @@ class PhaseManager(
   val currentState: Seq[PhaseManager.PhaseDependency] = Seq.empty,
   val knownObjects: Set[Phase] = Set.empty) extends DependencyManager[AnnotationSeq, Phase] with Phase {
 
-  protected def copy(a: Seq[Dependency], b: Seq[Dependency], c: ISet[Phase]) = new PhaseManager(a, b, c)
+  import PhaseManager.PhaseDependency
+  protected def copy(a: Seq[PhaseDependency], b: Seq[PhaseDependency], c: ISet[Phase]) = new PhaseManager(a, b, c)
 }
 
 object PhaseManager {

--- a/src/main/scala/firrtl/options/Phase.scala
+++ b/src/main/scala/firrtl/options/Phase.scala
@@ -97,20 +97,17 @@ trait TransformLike[A] extends LazyLogging {
   */
 trait DependencyAPI[A <: DependencyAPI[A]] { this: TransformLike[_] =>
 
-  /** The type used to express dependencies: a class which itself has dependencies. */
-  type Dependency = DependencyID[A]
-
   /** All transform that must run before this transform
     * $seqNote
     */
-  def prerequisites: Seq[Dependency] = Seq.empty
-  private[options] lazy val _prerequisites: LinkedHashSet[Dependency] = new LinkedHashSet() ++ prerequisites.toSet
+  def prerequisites: Seq[DependencyID[A]] = Seq.empty
+  private[options] lazy val _prerequisites: LinkedHashSet[DependencyID[A]] = new LinkedHashSet() ++ prerequisites.toSet
 
   /** All transforms that, if a prerequisite of *another* transform, will run before this transform.
     * $seqNote
     */
-  def optionalPrerequisites: Seq[Dependency] = Seq.empty
-  private[options] lazy val _optionalPrerquisites: LinkedHashSet[Dependency] =
+  def optionalPrerequisites: Seq[DependencyID[A]] = Seq.empty
+  private[options] lazy val _optionalPrerquisites: LinkedHashSet[DependencyID[A]] =
     new LinkedHashSet() ++ optionalPrerequisites.toSet
 
   /** All transforms that must run ''after'' this transform
@@ -132,8 +129,8 @@ trait DependencyAPI[A <: DependencyAPI[A]] { this: TransformLike[_] =>
     * @see [[firrtl.passes.CheckTypes]] for an example of an optional checking [[firrtl.Transform]]
     * $seqNote
     */
-  def dependents: Seq[Dependency] = Seq.empty
-  private[options] lazy val _dependents: LinkedHashSet[Dependency] = new LinkedHashSet() ++ dependents.toSet
+  def dependents: Seq[DependencyID[A]] = Seq.empty
+  private[options] lazy val _dependents: LinkedHashSet[DependencyID[A]] = new LinkedHashSet() ++ dependents.toSet
 
   /** A function that, given *another* transforms will return true if this transform invalidates/undos the effects of
     * that transform. This function may return any value if given this transform.

--- a/src/main/scala/firrtl/options/Phase.scala
+++ b/src/main/scala/firrtl/options/Phase.scala
@@ -18,7 +18,8 @@ object DependencyID {
   }
 
   def apply[A <: DependencyAPI[_]](c: Class[_ <: A]): DependencyID[A] = {
-    require(!c.getName.contains("$"))
+    // It's forbidden to wrap the class of a singleton as a DependencyID
+    require(c.getName.last != '$')
     DependencyID(Left(c))
   }
 

--- a/src/main/scala/firrtl/options/Phase.scala
+++ b/src/main/scala/firrtl/options/Phase.scala
@@ -8,6 +8,45 @@ import logger.LazyLogging
 
 import scala.collection.mutable.LinkedHashSet
 
+import scala.reflect
+import scala.reflect.ClassTag
+
+object DependencyID {
+  def apply[A : ClassTag]: DependencyID[A] = {
+    val clazz = reflect.classTag[A].runtimeClass
+    DependencyID(Left(clazz.asInstanceOf[Class[A]]))
+  }
+    
+  def apply[A](c: Class[_ <: A]): DependencyID[A] = DependencyID(Left(c))
+
+  def apply[A](o: A with Singleton): DependencyID[A] = DependencyID(Right(o))
+}
+
+case class DependencyID[+A](id: Either[Class[_ <: A], A with Singleton]) {
+  def getObject(): A = id match {
+    case Left(c) => safeConstruct(c)
+    case Right(o) => o
+  }
+
+  def getSimpleName: String = id match {
+    case Left(c) => c.getSimpleName
+    case Right(o) => o.getClass.getSimpleName
+  }
+
+  def getName: String = id match {
+    case Left(c) => c.getName
+    case Right(o) => o.getClass.getName
+  }
+
+  /** Wrap an [[IllegalAccessException]] due to attempted object construction in a [[DependencyManagerException]] */
+  private def safeConstruct[A](a: Class[_ <: A]): A = try { a.newInstance } catch {
+    case e: IllegalAccessException => throw new DependencyManagerException(
+      s"Failed to construct '$a'! (Did you try to construct an object?)", e)
+    case e: InstantiationException => throw new DependencyManagerException(
+      s"Failed to construct '$a'! (Did you try to construct an inner class or a class with parameters?)", e)
+  }
+}
+
 /** A polymorphic mathematical transform
   * @tparam A the transformed type
   */
@@ -43,7 +82,7 @@ trait TransformLike[A] extends LazyLogging {
 trait DependencyAPI[A <: DependencyAPI[A]] { this: TransformLike[_] =>
 
   /** The type used to express dependencies: a class which itself has dependencies. */
-  type Dependency = Class[_ <: A]
+  type Dependency = DependencyID[A]
 
   /** All transform that must run before this transform
     * $seqNote

--- a/src/main/scala/firrtl/options/phases/AddDefaults.scala
+++ b/src/main/scala/firrtl/options/phases/AddDefaults.scala
@@ -3,7 +3,7 @@
 package firrtl.options.phases
 
 import firrtl.AnnotationSeq
-import firrtl.options.{Phase, PreservesAll, TargetDirAnnotation}
+import firrtl.options.{DependencyID, Phase, PreservesAll, TargetDirAnnotation}
 
 /** Add default annotations for a [[Stage]]
   *
@@ -12,7 +12,7 @@ import firrtl.options.{Phase, PreservesAll, TargetDirAnnotation}
   */
 class AddDefaults extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(classOf[GetIncludes], classOf[ConvertLegacyAnnotations])
+  override val prerequisites = Seq(DependencyID[GetIncludes], DependencyID[ConvertLegacyAnnotations])
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/options/phases/AddDefaults.scala
+++ b/src/main/scala/firrtl/options/phases/AddDefaults.scala
@@ -3,7 +3,7 @@
 package firrtl.options.phases
 
 import firrtl.AnnotationSeq
-import firrtl.options.{DependencyID, Phase, PreservesAll, TargetDirAnnotation}
+import firrtl.options.{Dependency, Phase, PreservesAll, TargetDirAnnotation}
 
 /** Add default annotations for a [[Stage]]
   *
@@ -12,7 +12,7 @@ import firrtl.options.{DependencyID, Phase, PreservesAll, TargetDirAnnotation}
   */
 class AddDefaults extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(DependencyID[GetIncludes], DependencyID[ConvertLegacyAnnotations])
+  override val prerequisites = Seq(Dependency[GetIncludes], Dependency[ConvertLegacyAnnotations])
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/options/phases/Checks.scala
+++ b/src/main/scala/firrtl/options/phases/Checks.scala
@@ -5,13 +5,14 @@ package firrtl.options.phases
 import firrtl.AnnotationSeq
 import firrtl.annotations.Annotation
 import firrtl.options.{OptionsException, OutputAnnotationFileAnnotation, Phase, PreservesAll, TargetDirAnnotation}
+import firrtl.options.DependencyID
 
 /** [[firrtl.options.Phase Phase]] that validates an [[AnnotationSeq]]. If successful, views of this [[AnnotationSeq]]
   * as [[StageOptions]] are guaranteed to succeed.
   */
 class Checks extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(classOf[GetIncludes], classOf[ConvertLegacyAnnotations], classOf[AddDefaults])
+  override val prerequisites = Seq(DependencyID[GetIncludes], DependencyID[ConvertLegacyAnnotations], DependencyID[AddDefaults])
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/options/phases/Checks.scala
+++ b/src/main/scala/firrtl/options/phases/Checks.scala
@@ -5,14 +5,14 @@ package firrtl.options.phases
 import firrtl.AnnotationSeq
 import firrtl.annotations.Annotation
 import firrtl.options.{OptionsException, OutputAnnotationFileAnnotation, Phase, PreservesAll, TargetDirAnnotation}
-import firrtl.options.DependencyID
+import firrtl.options.Dependency
 
 /** [[firrtl.options.Phase Phase]] that validates an [[AnnotationSeq]]. If successful, views of this [[AnnotationSeq]]
   * as [[StageOptions]] are guaranteed to succeed.
   */
 class Checks extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(DependencyID[GetIncludes], DependencyID[ConvertLegacyAnnotations], DependencyID[AddDefaults])
+  override val prerequisites = Seq(Dependency[GetIncludes], Dependency[ConvertLegacyAnnotations], Dependency[AddDefaults])
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/options/phases/ConvertLegacyAnnotations.scala
+++ b/src/main/scala/firrtl/options/phases/ConvertLegacyAnnotations.scala
@@ -4,12 +4,12 @@ package firrtl.options.phases
 
 import firrtl.AnnotationSeq
 import firrtl.annotations.LegacyAnnotation
-import firrtl.options.{Phase, PreservesAll}
+import firrtl.options.{DependencyID, Phase, PreservesAll}
 
 /** Convert any [[firrtl.annotations.LegacyAnnotation LegacyAnnotation]]s to non-legacy variants */
 class ConvertLegacyAnnotations extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(classOf[GetIncludes])
+  override val prerequisites = Seq(DependencyID[GetIncludes])
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/options/phases/ConvertLegacyAnnotations.scala
+++ b/src/main/scala/firrtl/options/phases/ConvertLegacyAnnotations.scala
@@ -4,12 +4,12 @@ package firrtl.options.phases
 
 import firrtl.AnnotationSeq
 import firrtl.annotations.LegacyAnnotation
-import firrtl.options.{DependencyID, Phase, PreservesAll}
+import firrtl.options.{Dependency, Phase, PreservesAll}
 
 /** Convert any [[firrtl.annotations.LegacyAnnotation LegacyAnnotation]]s to non-legacy variants */
 class ConvertLegacyAnnotations extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(DependencyID[GetIncludes])
+  override val prerequisites = Seq(Dependency[GetIncludes])
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
+++ b/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
@@ -5,6 +5,7 @@ package firrtl.options.phases
 import firrtl.AnnotationSeq
 import firrtl.annotations.{DeletedAnnotation, JsonProtocol}
 import firrtl.options.{Phase, PreservesAll, StageOptions, Unserializable, Viewer}
+import firrtl.options.DependencyID
 
 import java.io.PrintWriter
 
@@ -14,10 +15,10 @@ import java.io.PrintWriter
 class WriteOutputAnnotations extends Phase with PreservesAll[Phase] {
 
   override val prerequisites =
-    Seq( classOf[GetIncludes],
-         classOf[ConvertLegacyAnnotations],
-         classOf[AddDefaults],
-         classOf[Checks] )
+    Seq( DependencyID[GetIncludes],
+         DependencyID[ConvertLegacyAnnotations],
+         DependencyID[AddDefaults],
+         DependencyID[Checks] )
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
+++ b/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
@@ -5,7 +5,7 @@ package firrtl.options.phases
 import firrtl.AnnotationSeq
 import firrtl.annotations.{DeletedAnnotation, JsonProtocol}
 import firrtl.options.{Phase, PreservesAll, StageOptions, Unserializable, Viewer}
-import firrtl.options.DependencyID
+import firrtl.options.Dependency
 
 import java.io.PrintWriter
 
@@ -15,10 +15,10 @@ import java.io.PrintWriter
 class WriteOutputAnnotations extends Phase with PreservesAll[Phase] {
 
   override val prerequisites =
-    Seq( DependencyID[GetIncludes],
-         DependencyID[ConvertLegacyAnnotations],
-         DependencyID[AddDefaults],
-         DependencyID[Checks] )
+    Seq( Dependency[GetIncludes],
+         Dependency[ConvertLegacyAnnotations],
+         Dependency[AddDefaults],
+         Dependency[Checks] )
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/passes/CheckChirrtl.scala
+++ b/src/main/scala/firrtl/passes/CheckChirrtl.scala
@@ -4,7 +4,7 @@ package firrtl.passes
 
 import firrtl.Transform
 import firrtl.ir._
-import firrtl.options.PreservesAll
+import firrtl.options.{DependencyID, PreservesAll}
 
 object CheckChirrtl extends Pass with CheckHighFormLike with DeprecatedPassObject {
 
@@ -17,9 +17,9 @@ object CheckChirrtl extends Pass with CheckHighFormLike with DeprecatedPassObjec
 class CheckChirrtl extends Pass with CheckHighFormLike with PreservesAll[Transform] {
 
   override val dependents = firrtl.stage.Forms.ChirrtlForm ++
-    Seq( classOf[CInferTypes],
-         classOf[CInferMDir],
-         classOf[RemoveCHIRRTL] )
+    Seq( DependencyID[CInferTypes],
+         DependencyID[CInferMDir],
+         DependencyID[RemoveCHIRRTL] )
 
   def errorOnChirrtl(info: Info, mname: String, s: Statement): Option[PassException] = None
 

--- a/src/main/scala/firrtl/passes/CheckChirrtl.scala
+++ b/src/main/scala/firrtl/passes/CheckChirrtl.scala
@@ -4,7 +4,7 @@ package firrtl.passes
 
 import firrtl.Transform
 import firrtl.ir._
-import firrtl.options.{DependencyID, PreservesAll}
+import firrtl.options.{Dependency, PreservesAll}
 
 object CheckChirrtl extends Pass with CheckHighFormLike with DeprecatedPassObject {
 
@@ -17,9 +17,9 @@ object CheckChirrtl extends Pass with CheckHighFormLike with DeprecatedPassObjec
 class CheckChirrtl extends Pass with CheckHighFormLike with PreservesAll[Transform] {
 
   override val dependents = firrtl.stage.Forms.ChirrtlForm ++
-    Seq( DependencyID[CInferTypes],
-         DependencyID[CInferMDir],
-         DependencyID[RemoveCHIRRTL] )
+    Seq( Dependency[CInferTypes],
+         Dependency[CInferMDir],
+         Dependency[RemoveCHIRRTL] )
 
   def errorOnChirrtl(info: Info, mname: String, s: Statement): Option[PassException] = None
 

--- a/src/main/scala/firrtl/passes/CheckChirrtl.scala
+++ b/src/main/scala/firrtl/passes/CheckChirrtl.scala
@@ -6,15 +6,7 @@ import firrtl.Transform
 import firrtl.ir._
 import firrtl.options.{Dependency, PreservesAll}
 
-object CheckChirrtl extends Pass with CheckHighFormLike with DeprecatedPassObject {
-
-  override protected lazy val underlying = new CheckChirrtl
-
-  def errorOnChirrtl(info: Info, mname: String, s: Statement): Option[PassException] =
-    underlying.errorOnChirrtl(info, mname, s)
-}
-
-class CheckChirrtl extends Pass with CheckHighFormLike with PreservesAll[Transform] {
+object CheckChirrtl extends Pass with CheckHighFormLike with PreservesAll[Transform] {
 
   override val dependents = firrtl.stage.Forms.ChirrtlForm ++
     Seq( Dependency[CInferTypes],
@@ -22,5 +14,4 @@ class CheckChirrtl extends Pass with CheckHighFormLike with PreservesAll[Transfo
          Dependency[RemoveCHIRRTL] )
 
   def errorOnChirrtl(info: Info, mname: String, s: Statement): Option[PassException] = None
-
 }

--- a/src/main/scala/firrtl/passes/CheckWidths.scala
+++ b/src/main/scala/firrtl/passes/CheckWidths.scala
@@ -9,7 +9,7 @@ import firrtl.traversals.Foreachers._
 import firrtl.Utils._
 import firrtl.constraint.IsKnown
 import firrtl.annotations.{CircuitTarget, ModuleTarget, Target, TargetToken}
-import firrtl.options.PreservesAll
+import firrtl.options.{DependencyID, PreservesAll}
 
 object CheckWidths extends Pass with DeprecatedPassObject {
 
@@ -58,9 +58,9 @@ class CheckWidths extends Pass with PreservesAll[Transform] {
 
   import CheckWidths._
 
-  override val prerequisites = classOf[passes.InferWidths] +: firrtl.stage.Forms.WorkingIR
+  override val prerequisites = DependencyID[passes.InferWidths] +: firrtl.stage.Forms.WorkingIR
 
-  override val dependents = Seq(classOf[transforms.InferResets])
+  override val dependents = Seq(DependencyID[transforms.InferResets])
 
   def run(c: Circuit): Circuit = {
     val errors = new Errors()

--- a/src/main/scala/firrtl/passes/CheckWidths.scala
+++ b/src/main/scala/firrtl/passes/CheckWidths.scala
@@ -9,7 +9,7 @@ import firrtl.traversals.Foreachers._
 import firrtl.Utils._
 import firrtl.constraint.IsKnown
 import firrtl.annotations.{CircuitTarget, ModuleTarget, Target, TargetToken}
-import firrtl.options.{DependencyID, PreservesAll}
+import firrtl.options.{Dependency, PreservesAll}
 
 object CheckWidths extends Pass with DeprecatedPassObject {
 
@@ -58,9 +58,9 @@ class CheckWidths extends Pass with PreservesAll[Transform] {
 
   import CheckWidths._
 
-  override val prerequisites = DependencyID[passes.InferWidths] +: firrtl.stage.Forms.WorkingIR
+  override val prerequisites = Dependency[passes.InferWidths] +: firrtl.stage.Forms.WorkingIR
 
-  override val dependents = Seq(DependencyID[transforms.InferResets])
+  override val dependents = Seq(Dependency[transforms.InferResets])
 
   def run(c: Circuit): Circuit = {
     val errors = new Errors()

--- a/src/main/scala/firrtl/passes/Checks.scala
+++ b/src/main/scala/firrtl/passes/Checks.scala
@@ -9,7 +9,7 @@ import firrtl.Utils._
 import firrtl.traversals.Foreachers._
 import firrtl.WrappedType._
 import firrtl.constraint.{Constraint, IsKnown}
-import firrtl.options.PreservesAll
+import firrtl.options.{DependencyID, PreservesAll}
 
 trait CheckHighFormLike { this: Pass =>
   type NameSet = collection.mutable.HashSet[String]
@@ -280,12 +280,12 @@ class CheckHighForm extends Pass with CheckHighFormLike with PreservesAll[Transf
   override val prerequisites = firrtl.stage.Forms.WorkingIR
 
   override val dependents =
-    Seq( classOf[passes.ResolveKinds],
-         classOf[passes.InferTypes],
-         classOf[passes.Uniquify],
-         classOf[passes.ResolveFlows],
-         classOf[passes.InferWidths],
-         classOf[transforms.InferResets] )
+    Seq( DependencyID[passes.ResolveKinds],
+         DependencyID[passes.InferTypes],
+         DependencyID[passes.Uniquify],
+         DependencyID[passes.ResolveFlows],
+         DependencyID[passes.InferWidths],
+         DependencyID[transforms.InferResets] )
 
   def errorOnChirrtl(info: Info, mname: String, s: Statement): Option[PassException] = {
     val memName = s match {
@@ -434,14 +434,14 @@ class CheckTypes extends Pass with PreservesAll[Transform] {
 
   import CheckTypes._
 
-  override val prerequisites = Seq( classOf[InferTypes] ) ++ firrtl.stage.Forms.WorkingIR
+  override val prerequisites = Seq( DependencyID[InferTypes] ) ++ firrtl.stage.Forms.WorkingIR
 
   override val dependents =
-    Seq( classOf[passes.Uniquify],
-         classOf[passes.ResolveFlows],
-         classOf[passes.CheckFlows],
-         classOf[passes.InferWidths],
-         classOf[passes.CheckWidths] )
+    Seq( DependencyID[passes.Uniquify],
+         DependencyID[passes.ResolveFlows],
+         DependencyID[passes.CheckFlows],
+         DependencyID[passes.InferWidths],
+         DependencyID[passes.CheckWidths] )
 
   //;---------------- Helper Functions --------------
   def ut: UIntType = UIntType(UnknownWidth)
@@ -625,13 +625,13 @@ object CheckFlows extends Pass with DeprecatedPassObject {
 
 class CheckFlows extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = classOf[passes.ResolveFlows] +: firrtl.stage.Forms.WorkingIR
+  override val prerequisites = DependencyID[passes.ResolveFlows] +: firrtl.stage.Forms.WorkingIR
 
   override val dependents =
-    Seq( classOf[passes.InferBinaryPoints],
-         classOf[passes.TrimIntervals],
-         classOf[passes.InferWidths],
-         classOf[transforms.InferResets] )
+    Seq( DependencyID[passes.InferBinaryPoints],
+         DependencyID[passes.TrimIntervals],
+         DependencyID[passes.InferWidths],
+         DependencyID[transforms.InferResets] )
 
   type FlowMap = collection.mutable.HashMap[String, Flow]
 

--- a/src/main/scala/firrtl/passes/Checks.scala
+++ b/src/main/scala/firrtl/passes/Checks.scala
@@ -9,7 +9,7 @@ import firrtl.Utils._
 import firrtl.traversals.Foreachers._
 import firrtl.WrappedType._
 import firrtl.constraint.{Constraint, IsKnown}
-import firrtl.options.{DependencyID, PreservesAll}
+import firrtl.options.{Dependency, PreservesAll}
 
 trait CheckHighFormLike { this: Pass =>
   type NameSet = collection.mutable.HashSet[String]
@@ -280,12 +280,12 @@ class CheckHighForm extends Pass with CheckHighFormLike with PreservesAll[Transf
   override val prerequisites = firrtl.stage.Forms.WorkingIR
 
   override val dependents =
-    Seq( DependencyID[passes.ResolveKinds],
-         DependencyID[passes.InferTypes],
-         DependencyID[passes.Uniquify],
-         DependencyID[passes.ResolveFlows],
-         DependencyID[passes.InferWidths],
-         DependencyID[transforms.InferResets] )
+    Seq( Dependency[passes.ResolveKinds],
+         Dependency[passes.InferTypes],
+         Dependency[passes.Uniquify],
+         Dependency[passes.ResolveFlows],
+         Dependency[passes.InferWidths],
+         Dependency[transforms.InferResets] )
 
   def errorOnChirrtl(info: Info, mname: String, s: Statement): Option[PassException] = {
     val memName = s match {
@@ -434,14 +434,14 @@ class CheckTypes extends Pass with PreservesAll[Transform] {
 
   import CheckTypes._
 
-  override val prerequisites = Seq( DependencyID[InferTypes] ) ++ firrtl.stage.Forms.WorkingIR
+  override val prerequisites = Seq( Dependency[InferTypes] ) ++ firrtl.stage.Forms.WorkingIR
 
   override val dependents =
-    Seq( DependencyID[passes.Uniquify],
-         DependencyID[passes.ResolveFlows],
-         DependencyID[passes.CheckFlows],
-         DependencyID[passes.InferWidths],
-         DependencyID[passes.CheckWidths] )
+    Seq( Dependency[passes.Uniquify],
+         Dependency[passes.ResolveFlows],
+         Dependency[passes.CheckFlows],
+         Dependency[passes.InferWidths],
+         Dependency[passes.CheckWidths] )
 
   //;---------------- Helper Functions --------------
   def ut: UIntType = UIntType(UnknownWidth)
@@ -625,13 +625,13 @@ object CheckFlows extends Pass with DeprecatedPassObject {
 
 class CheckFlows extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = DependencyID[passes.ResolveFlows] +: firrtl.stage.Forms.WorkingIR
+  override val prerequisites = Dependency[passes.ResolveFlows] +: firrtl.stage.Forms.WorkingIR
 
   override val dependents =
-    Seq( DependencyID[passes.InferBinaryPoints],
-         DependencyID[passes.TrimIntervals],
-         DependencyID[passes.InferWidths],
-         DependencyID[transforms.InferResets] )
+    Seq( Dependency[passes.InferBinaryPoints],
+         Dependency[passes.TrimIntervals],
+         Dependency[passes.InferWidths],
+         Dependency[transforms.InferResets] )
 
   type FlowMap = collection.mutable.HashMap[String, Flow]
 

--- a/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
+++ b/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
@@ -5,21 +5,20 @@ package firrtl.passes
 import firrtl._
 import firrtl.ir._
 import firrtl.Mappers._
-import firrtl.options.PreservesAll
-
+import firrtl.options.{DependencyID, PreservesAll}
 
 class CommonSubexpressionElimination extends Pass with PreservesAll[Transform] {
 
   override val prerequisites = firrtl.stage.Forms.LowForm ++
-    Seq( classOf[firrtl.passes.RemoveValidIf],
-         classOf[firrtl.transforms.ConstantPropagation],
-         classOf[firrtl.passes.memlib.VerilogMemDelays],
-         classOf[firrtl.passes.SplitExpressions],
-         classOf[firrtl.transforms.CombineCats] )
+    Seq( DependencyID[firrtl.passes.RemoveValidIf],
+         DependencyID[firrtl.transforms.ConstantPropagation],
+         DependencyID[firrtl.passes.memlib.VerilogMemDelays],
+         DependencyID[firrtl.passes.SplitExpressions],
+         DependencyID[firrtl.transforms.CombineCats] )
 
   override val dependents =
-    Seq( classOf[SystemVerilogEmitter],
-         classOf[VerilogEmitter] )
+    Seq( DependencyID[SystemVerilogEmitter],
+         DependencyID[VerilogEmitter] )
 
   private def cse(s: Statement): Statement = {
     val expressions = collection.mutable.HashMap[MemoizedHash[Expression], String]()

--- a/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
+++ b/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
@@ -5,20 +5,20 @@ package firrtl.passes
 import firrtl._
 import firrtl.ir._
 import firrtl.Mappers._
-import firrtl.options.{DependencyID, PreservesAll}
+import firrtl.options.{Dependency, PreservesAll}
 
 class CommonSubexpressionElimination extends Pass with PreservesAll[Transform] {
 
   override val prerequisites = firrtl.stage.Forms.LowForm ++
-    Seq( DependencyID[firrtl.passes.RemoveValidIf],
-         DependencyID[firrtl.transforms.ConstantPropagation],
-         DependencyID[firrtl.passes.memlib.VerilogMemDelays],
-         DependencyID[firrtl.passes.SplitExpressions],
-         DependencyID[firrtl.transforms.CombineCats] )
+    Seq( Dependency[firrtl.passes.RemoveValidIf],
+         Dependency[firrtl.transforms.ConstantPropagation],
+         Dependency[firrtl.passes.memlib.VerilogMemDelays],
+         Dependency[firrtl.passes.SplitExpressions],
+         Dependency[firrtl.transforms.CombineCats] )
 
   override val dependents =
-    Seq( DependencyID[SystemVerilogEmitter],
-         DependencyID[VerilogEmitter] )
+    Seq( Dependency[SystemVerilogEmitter],
+         Dependency[VerilogEmitter] )
 
   private def cse(s: Statement): Statement = {
     val expressions = collection.mutable.HashMap[MemoizedHash[Expression], String]()

--- a/src/main/scala/firrtl/passes/ConvertFixedToSInt.scala
+++ b/src/main/scala/firrtl/passes/ConvertFixedToSInt.scala
@@ -8,19 +8,19 @@ import firrtl.ir._
 import firrtl._
 import firrtl.Mappers._
 import firrtl.Utils.{sub_type, module_type, field_type, max, throwInternalError}
-import firrtl.options.PreservesAll
+import firrtl.options.{DependencyID, PreservesAll}
 
 /** Replaces FixedType with SIntType, and correctly aligns all binary points
   */
 class ConvertFixedToSInt extends Pass with PreservesAll[Transform] {
 
   override val prerequisites =
-    Seq( classOf[PullMuxes],
-         classOf[ReplaceAccesses],
-         classOf[ExpandConnects],
-         classOf[RemoveAccesses],
-         classOf[ExpandWhensAndCheck],
-         classOf[RemoveIntervals] ) ++ firrtl.stage.Forms.Deduped
+    Seq( DependencyID[PullMuxes],
+         DependencyID[ReplaceAccesses],
+         DependencyID[ExpandConnects],
+         DependencyID[RemoveAccesses],
+         DependencyID[ExpandWhensAndCheck],
+         DependencyID[RemoveIntervals] ) ++ firrtl.stage.Forms.Deduped
 
   def alignArg(e: Expression, point: BigInt): Expression = e.tpe match {
     case FixedType(IntWidth(w), IntWidth(p)) => // assert(point >= p)

--- a/src/main/scala/firrtl/passes/ConvertFixedToSInt.scala
+++ b/src/main/scala/firrtl/passes/ConvertFixedToSInt.scala
@@ -8,19 +8,19 @@ import firrtl.ir._
 import firrtl._
 import firrtl.Mappers._
 import firrtl.Utils.{sub_type, module_type, field_type, max, throwInternalError}
-import firrtl.options.{DependencyID, PreservesAll}
+import firrtl.options.{Dependency, PreservesAll}
 
 /** Replaces FixedType with SIntType, and correctly aligns all binary points
   */
 class ConvertFixedToSInt extends Pass with PreservesAll[Transform] {
 
   override val prerequisites =
-    Seq( DependencyID[PullMuxes],
-         DependencyID[ReplaceAccesses],
-         DependencyID[ExpandConnects],
-         DependencyID[RemoveAccesses],
-         DependencyID[ExpandWhensAndCheck],
-         DependencyID[RemoveIntervals] ) ++ firrtl.stage.Forms.Deduped
+    Seq( Dependency[PullMuxes],
+         Dependency[ReplaceAccesses],
+         Dependency[ExpandConnects],
+         Dependency[RemoveAccesses],
+         Dependency[ExpandWhensAndCheck],
+         Dependency[RemoveIntervals] ) ++ firrtl.stage.Forms.Deduped
 
   def alignArg(e: Expression, point: BigInt): Expression = e.tpe match {
     case FixedType(IntWidth(w), IntWidth(p)) => // assert(point >= p)

--- a/src/main/scala/firrtl/passes/ExpandWhens.scala
+++ b/src/main/scala/firrtl/passes/ExpandWhens.scala
@@ -8,7 +8,7 @@ import firrtl.Utils._
 import firrtl.Mappers._
 import firrtl.PrimOps._
 import firrtl.WrappedExpression._
-import firrtl.options.PreservesAll
+import firrtl.options.{DependencyID, PreservesAll}
 
 import annotation.tailrec
 import collection.mutable
@@ -27,11 +27,11 @@ import collection.mutable
 class ExpandWhens extends Pass {
 
   override val prerequisites =
-    Seq( classOf[PullMuxes],
-         classOf[ReplaceAccesses],
-         classOf[ExpandConnects],
-         classOf[RemoveAccesses],
-         classOf[Uniquify] ) ++ firrtl.stage.Forms.Resolved
+    Seq( DependencyID[PullMuxes],
+         DependencyID[ReplaceAccesses],
+         DependencyID[ExpandConnects],
+         DependencyID[RemoveAccesses],
+         DependencyID[Uniquify] ) ++ firrtl.stage.Forms.Resolved
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: CheckInitialization | _: ResolveKinds | _: InferTypes => true
@@ -311,11 +311,11 @@ object ExpandWhens extends Pass with DeprecatedPassObject {
 class ExpandWhensAndCheck extends SeqTransform {
 
   override val prerequisites =
-    Seq( classOf[PullMuxes],
-         classOf[ReplaceAccesses],
-         classOf[ExpandConnects],
-         classOf[RemoveAccesses],
-         classOf[Uniquify] ) ++ firrtl.stage.Forms.Deduped
+    Seq( DependencyID[PullMuxes],
+         DependencyID[ReplaceAccesses],
+         DependencyID[ExpandConnects],
+         DependencyID[RemoveAccesses],
+         DependencyID[Uniquify] ) ++ firrtl.stage.Forms.Deduped
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: ResolveKinds | _: InferTypes | _: ResolveFlows | _: InferWidths => true

--- a/src/main/scala/firrtl/passes/ExpandWhens.scala
+++ b/src/main/scala/firrtl/passes/ExpandWhens.scala
@@ -8,7 +8,7 @@ import firrtl.Utils._
 import firrtl.Mappers._
 import firrtl.PrimOps._
 import firrtl.WrappedExpression._
-import firrtl.options.{DependencyID, PreservesAll}
+import firrtl.options.{Dependency, PreservesAll}
 
 import annotation.tailrec
 import collection.mutable
@@ -27,11 +27,11 @@ import collection.mutable
 class ExpandWhens extends Pass {
 
   override val prerequisites =
-    Seq( DependencyID[PullMuxes],
-         DependencyID[ReplaceAccesses],
-         DependencyID[ExpandConnects],
-         DependencyID[RemoveAccesses],
-         DependencyID[Uniquify] ) ++ firrtl.stage.Forms.Resolved
+    Seq( Dependency[PullMuxes],
+         Dependency[ReplaceAccesses],
+         Dependency[ExpandConnects],
+         Dependency[RemoveAccesses],
+         Dependency[Uniquify] ) ++ firrtl.stage.Forms.Resolved
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: CheckInitialization | _: ResolveKinds | _: InferTypes => true
@@ -311,11 +311,11 @@ object ExpandWhens extends Pass with DeprecatedPassObject {
 class ExpandWhensAndCheck extends SeqTransform {
 
   override val prerequisites =
-    Seq( DependencyID[PullMuxes],
-         DependencyID[ReplaceAccesses],
-         DependencyID[ExpandConnects],
-         DependencyID[RemoveAccesses],
-         DependencyID[Uniquify] ) ++ firrtl.stage.Forms.Deduped
+    Seq( Dependency[PullMuxes],
+         Dependency[ReplaceAccesses],
+         Dependency[ExpandConnects],
+         Dependency[RemoveAccesses],
+         Dependency[Uniquify] ) ++ firrtl.stage.Forms.Deduped
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: ResolveKinds | _: InferTypes | _: ResolveFlows | _: InferWidths => true

--- a/src/main/scala/firrtl/passes/ExpandWhens.scala
+++ b/src/main/scala/firrtl/passes/ExpandWhens.scala
@@ -34,7 +34,7 @@ class ExpandWhens extends Pass {
          Dependency[Uniquify] ) ++ firrtl.stage.Forms.Resolved
 
   override def invalidates(a: Transform): Boolean = a match {
-    case _: CheckInitialization | _: ResolveKinds | _: InferTypes => true
+    case CheckInitialization | _: ResolveKinds | _: InferTypes => true
     case _ => false
   }
 
@@ -325,6 +325,6 @@ class ExpandWhensAndCheck extends SeqTransform {
   override def inputForm = UnknownForm
   override def outputForm = UnknownForm
 
-  override val transforms = Seq(new ExpandWhens, new CheckInitialization)
+  override val transforms = Seq(new ExpandWhens, CheckInitialization)
 
 }

--- a/src/main/scala/firrtl/passes/InferBinaryPoints.scala
+++ b/src/main/scala/firrtl/passes/InferBinaryPoints.scala
@@ -8,15 +8,15 @@ import firrtl.Mappers._
 import firrtl.annotations.{CircuitTarget, ModuleTarget, ReferenceTarget, Target}
 import firrtl.constraint.ConstraintSolver
 import firrtl.Transform
-import firrtl.options.PreservesAll
+import firrtl.options.{DependencyID, PreservesAll}
 
 class InferBinaryPoints extends Pass with PreservesAll[Transform] {
 
   override val prerequisites =
-    Seq( classOf[ResolveKinds],
-         classOf[InferTypes],
-         classOf[Uniquify],
-         classOf[ResolveFlows] )
+    Seq( DependencyID[ResolveKinds],
+         DependencyID[InferTypes],
+         DependencyID[Uniquify],
+         DependencyID[ResolveFlows] )
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/passes/InferBinaryPoints.scala
+++ b/src/main/scala/firrtl/passes/InferBinaryPoints.scala
@@ -8,15 +8,15 @@ import firrtl.Mappers._
 import firrtl.annotations.{CircuitTarget, ModuleTarget, ReferenceTarget, Target}
 import firrtl.constraint.ConstraintSolver
 import firrtl.Transform
-import firrtl.options.{DependencyID, PreservesAll}
+import firrtl.options.{Dependency, PreservesAll}
 
 class InferBinaryPoints extends Pass with PreservesAll[Transform] {
 
   override val prerequisites =
-    Seq( DependencyID[ResolveKinds],
-         DependencyID[InferTypes],
-         DependencyID[Uniquify],
-         DependencyID[ResolveFlows] )
+    Seq( Dependency[ResolveKinds],
+         Dependency[InferTypes],
+         Dependency[Uniquify],
+         Dependency[ResolveFlows] )
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/passes/InferTypes.scala
+++ b/src/main/scala/firrtl/passes/InferTypes.scala
@@ -6,11 +6,11 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
-import firrtl.options.PreservesAll
+import firrtl.options.{DependencyID, PreservesAll}
 
 class InferTypes extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = classOf[ResolveKinds] +: firrtl.stage.Forms.WorkingIR
+  override val prerequisites = DependencyID[ResolveKinds] +: firrtl.stage.Forms.WorkingIR
 
   type TypeMap = collection.mutable.LinkedHashMap[String, Type]
 

--- a/src/main/scala/firrtl/passes/InferTypes.scala
+++ b/src/main/scala/firrtl/passes/InferTypes.scala
@@ -6,11 +6,11 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
-import firrtl.options.{DependencyID, PreservesAll}
+import firrtl.options.{Dependency, PreservesAll}
 
 class InferTypes extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = DependencyID[ResolveKinds] +: firrtl.stage.Forms.WorkingIR
+  override val prerequisites = Dependency[ResolveKinds] +: firrtl.stage.Forms.WorkingIR
 
   type TypeMap = collection.mutable.LinkedHashMap[String, Type]
 

--- a/src/main/scala/firrtl/passes/InferWidths.scala
+++ b/src/main/scala/firrtl/passes/InferWidths.scala
@@ -11,7 +11,7 @@ import firrtl.Mappers._
 import firrtl.Implicits.width2constraint
 import firrtl.annotations.{CircuitTarget, ModuleTarget, ReferenceTarget, Target}
 import firrtl.constraint.{ConstraintSolver, IsMax}
-import firrtl.options.PreservesAll
+import firrtl.options.{DependencyID, PreservesAll}
 import firrtl.traversals.Foreachers._
 
 object InferWidths {
@@ -65,12 +65,12 @@ case class WidthGeqConstraintAnnotation(loc: ReferenceTarget, exp: ReferenceTarg
 class InferWidths extends Transform with ResolvedAnnotationPaths with PreservesAll[Transform] {
 
   override val prerequisites =
-    Seq( classOf[passes.ResolveKinds],
-         classOf[passes.InferTypes],
-         classOf[passes.Uniquify],
-         classOf[passes.ResolveFlows],
-         classOf[passes.InferBinaryPoints],
-         classOf[passes.TrimIntervals] ) ++ firrtl.stage.Forms.WorkingIR
+    Seq( DependencyID[passes.ResolveKinds],
+         DependencyID[passes.InferTypes],
+         DependencyID[passes.Uniquify],
+         DependencyID[passes.ResolveFlows],
+         DependencyID[passes.InferBinaryPoints],
+         DependencyID[passes.TrimIntervals] ) ++ firrtl.stage.Forms.WorkingIR
 
   def inputForm: CircuitForm = UnknownForm
   def outputForm: CircuitForm = UnknownForm

--- a/src/main/scala/firrtl/passes/InferWidths.scala
+++ b/src/main/scala/firrtl/passes/InferWidths.scala
@@ -11,7 +11,7 @@ import firrtl.Mappers._
 import firrtl.Implicits.width2constraint
 import firrtl.annotations.{CircuitTarget, ModuleTarget, ReferenceTarget, Target}
 import firrtl.constraint.{ConstraintSolver, IsMax}
-import firrtl.options.{DependencyID, PreservesAll}
+import firrtl.options.{Dependency, PreservesAll}
 import firrtl.traversals.Foreachers._
 
 object InferWidths {
@@ -65,12 +65,12 @@ case class WidthGeqConstraintAnnotation(loc: ReferenceTarget, exp: ReferenceTarg
 class InferWidths extends Transform with ResolvedAnnotationPaths with PreservesAll[Transform] {
 
   override val prerequisites =
-    Seq( DependencyID[passes.ResolveKinds],
-         DependencyID[passes.InferTypes],
-         DependencyID[passes.Uniquify],
-         DependencyID[passes.ResolveFlows],
-         DependencyID[passes.InferBinaryPoints],
-         DependencyID[passes.TrimIntervals] ) ++ firrtl.stage.Forms.WorkingIR
+    Seq( Dependency[passes.ResolveKinds],
+         Dependency[passes.InferTypes],
+         Dependency[passes.Uniquify],
+         Dependency[passes.ResolveFlows],
+         Dependency[passes.InferBinaryPoints],
+         Dependency[passes.TrimIntervals] ) ++ firrtl.stage.Forms.WorkingIR
 
   def inputForm: CircuitForm = UnknownForm
   def outputForm: CircuitForm = UnknownForm

--- a/src/main/scala/firrtl/passes/PadWidths.scala
+++ b/src/main/scala/firrtl/passes/PadWidths.scala
@@ -6,6 +6,7 @@ package passes
 import firrtl.ir._
 import firrtl.PrimOps._
 import firrtl.Mappers._
+import firrtl.options.DependencyID
 
 import scala.collection.mutable
 
@@ -15,14 +16,14 @@ class PadWidths extends Pass {
   override val prerequisites =
     ((new mutable.LinkedHashSet())
        ++ firrtl.stage.Forms.LowForm
-       - classOf[firrtl.passes.Legalize]
-       + classOf[firrtl.passes.RemoveValidIf]
-       + classOf[firrtl.transforms.ConstantPropagation]).toSeq
+       - DependencyID[firrtl.passes.Legalize]
+       + DependencyID[firrtl.passes.RemoveValidIf]
+       + DependencyID[firrtl.transforms.ConstantPropagation]).toSeq
 
   override val dependents =
-    Seq( classOf[firrtl.passes.memlib.VerilogMemDelays],
-         classOf[SystemVerilogEmitter],
-         classOf[VerilogEmitter] )
+    Seq( DependencyID[firrtl.passes.memlib.VerilogMemDelays],
+         DependencyID[SystemVerilogEmitter],
+         DependencyID[VerilogEmitter] )
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: firrtl.transforms.ConstantPropagation | _: Legalize => true

--- a/src/main/scala/firrtl/passes/PadWidths.scala
+++ b/src/main/scala/firrtl/passes/PadWidths.scala
@@ -6,7 +6,7 @@ package passes
 import firrtl.ir._
 import firrtl.PrimOps._
 import firrtl.Mappers._
-import firrtl.options.DependencyID
+import firrtl.options.Dependency
 
 import scala.collection.mutable
 
@@ -16,14 +16,14 @@ class PadWidths extends Pass {
   override val prerequisites =
     ((new mutable.LinkedHashSet())
        ++ firrtl.stage.Forms.LowForm
-       - DependencyID[firrtl.passes.Legalize]
-       + DependencyID[firrtl.passes.RemoveValidIf]
-       + DependencyID[firrtl.transforms.ConstantPropagation]).toSeq
+       - Dependency[firrtl.passes.Legalize]
+       + Dependency[firrtl.passes.RemoveValidIf]
+       + Dependency[firrtl.transforms.ConstantPropagation]).toSeq
 
   override val dependents =
-    Seq( DependencyID[firrtl.passes.memlib.VerilogMemDelays],
-         DependencyID[SystemVerilogEmitter],
-         DependencyID[VerilogEmitter] )
+    Seq( Dependency[firrtl.passes.memlib.VerilogMemDelays],
+         Dependency[SystemVerilogEmitter],
+         Dependency[VerilogEmitter] )
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: firrtl.transforms.ConstantPropagation | _: Legalize => true

--- a/src/main/scala/firrtl/passes/Passes.scala
+++ b/src/main/scala/firrtl/passes/Passes.scala
@@ -7,7 +7,7 @@ import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
 import firrtl.PrimOps._
-import firrtl.options.PreservesAll
+import firrtl.options.{DependencyID, PreservesAll}
 import firrtl.transforms.ConstantPropagation
 
 import scala.collection.mutable
@@ -133,8 +133,8 @@ class PullMuxes extends Pass with PreservesAll[Transform] {
 class ExpandConnects extends Pass with PreservesAll[Transform] {
 
   override val prerequisites =
-    Seq( classOf[PullMuxes],
-         classOf[ReplaceAccesses] ) ++ firrtl.stage.Forms.Deduped
+    Seq( DependencyID[PullMuxes],
+         DependencyID[ReplaceAccesses] ) ++ firrtl.stage.Forms.Deduped
 
   def run(c: Circuit): Circuit = {
     def expand_connects(m: Module): Module = {
@@ -220,7 +220,7 @@ object ExpandConnects extends Pass with DeprecatedPassObject {
 // TODO replace UInt with zero-width wire instead
 class Legalize extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.MidForm :+ classOf[LowerTypes]
+  override val prerequisites = firrtl.stage.Forms.MidForm :+ DependencyID[LowerTypes]
 
   override val optionalPrerequisites = Seq.empty
 
@@ -315,11 +315,11 @@ object Legalize extends Pass with DeprecatedPassObject {
 class VerilogPrep extends Pass with PreservesAll[Transform] {
 
   override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
-    Seq( classOf[firrtl.transforms.BlackBoxSourceHelper],
-         classOf[firrtl.transforms.ReplaceTruncatingArithmetic],
-         classOf[firrtl.transforms.FlattenRegUpdate],
-         classOf[VerilogModulusCleanup],
-         classOf[firrtl.transforms.VerilogRename] )
+    Seq( DependencyID[firrtl.transforms.BlackBoxSourceHelper],
+         DependencyID[firrtl.transforms.ReplaceTruncatingArithmetic],
+         DependencyID[firrtl.transforms.FlattenRegUpdate],
+         DependencyID[VerilogModulusCleanup],
+         DependencyID[firrtl.transforms.VerilogRename] )
 
   type AttachSourceMap = Map[WrappedExpression, Expression]
 

--- a/src/main/scala/firrtl/passes/Passes.scala
+++ b/src/main/scala/firrtl/passes/Passes.scala
@@ -7,7 +7,7 @@ import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
 import firrtl.PrimOps._
-import firrtl.options.{DependencyID, PreservesAll}
+import firrtl.options.{Dependency, PreservesAll}
 import firrtl.transforms.ConstantPropagation
 
 import scala.collection.mutable
@@ -133,8 +133,8 @@ class PullMuxes extends Pass with PreservesAll[Transform] {
 class ExpandConnects extends Pass with PreservesAll[Transform] {
 
   override val prerequisites =
-    Seq( DependencyID[PullMuxes],
-         DependencyID[ReplaceAccesses] ) ++ firrtl.stage.Forms.Deduped
+    Seq( Dependency[PullMuxes],
+         Dependency[ReplaceAccesses] ) ++ firrtl.stage.Forms.Deduped
 
   def run(c: Circuit): Circuit = {
     def expand_connects(m: Module): Module = {
@@ -220,7 +220,7 @@ object ExpandConnects extends Pass with DeprecatedPassObject {
 // TODO replace UInt with zero-width wire instead
 class Legalize extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.MidForm :+ DependencyID(LowerTypes)
+  override val prerequisites = firrtl.stage.Forms.MidForm :+ Dependency(LowerTypes)
 
   override val optionalPrerequisites = Seq.empty
 
@@ -315,11 +315,11 @@ object Legalize extends Pass with DeprecatedPassObject {
 class VerilogPrep extends Pass with PreservesAll[Transform] {
 
   override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
-    Seq( DependencyID[firrtl.transforms.BlackBoxSourceHelper],
-         DependencyID[firrtl.transforms.ReplaceTruncatingArithmetic],
-         DependencyID[firrtl.transforms.FlattenRegUpdate],
-         DependencyID[VerilogModulusCleanup],
-         DependencyID[firrtl.transforms.VerilogRename] )
+    Seq( Dependency[firrtl.transforms.BlackBoxSourceHelper],
+         Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
+         Dependency[firrtl.transforms.FlattenRegUpdate],
+         Dependency[VerilogModulusCleanup],
+         Dependency[firrtl.transforms.VerilogRename] )
 
   type AttachSourceMap = Map[WrappedExpression, Expression]
 

--- a/src/main/scala/firrtl/passes/Passes.scala
+++ b/src/main/scala/firrtl/passes/Passes.scala
@@ -220,7 +220,7 @@ object ExpandConnects extends Pass with DeprecatedPassObject {
 // TODO replace UInt with zero-width wire instead
 class Legalize extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.MidForm :+ DependencyID[LowerTypes]
+  override val prerequisites = firrtl.stage.Forms.MidForm :+ DependencyID(LowerTypes)
 
   override val optionalPrerequisites = Seq.empty
 

--- a/src/main/scala/firrtl/passes/RemoveAccesses.scala
+++ b/src/main/scala/firrtl/passes/RemoveAccesses.scala
@@ -8,17 +8,18 @@ import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.Utils._
 import firrtl.WrappedExpression._
-import scala.collection.mutable
+import firrtl.options.DependencyID
 
+import scala.collection.mutable
 
 /** Removes all [[firrtl.WSubAccess]] from circuit
   */
 class RemoveAccesses extends Pass {
 
   override val prerequisites =
-    Seq( classOf[PullMuxes],
-         classOf[ReplaceAccesses],
-         classOf[ExpandConnects] ) ++ firrtl.stage.Forms.Deduped
+    Seq( DependencyID[PullMuxes],
+         DependencyID[ReplaceAccesses],
+         DependencyID[ExpandConnects] ) ++ firrtl.stage.Forms.Deduped
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: Uniquify => true

--- a/src/main/scala/firrtl/passes/RemoveAccesses.scala
+++ b/src/main/scala/firrtl/passes/RemoveAccesses.scala
@@ -8,7 +8,7 @@ import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.Utils._
 import firrtl.WrappedExpression._
-import firrtl.options.DependencyID
+import firrtl.options.Dependency
 
 import scala.collection.mutable
 
@@ -17,9 +17,9 @@ import scala.collection.mutable
 class RemoveAccesses extends Pass {
 
   override val prerequisites =
-    Seq( DependencyID[PullMuxes],
-         DependencyID[ReplaceAccesses],
-         DependencyID[ExpandConnects] ) ++ firrtl.stage.Forms.Deduped
+    Seq( Dependency[PullMuxes],
+         Dependency[ReplaceAccesses],
+         Dependency[ExpandConnects] ) ++ firrtl.stage.Forms.Deduped
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: Uniquify => true

--- a/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
+++ b/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
@@ -8,7 +8,7 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
-import firrtl.options.PreservesAll
+import firrtl.options.{DependencyID, PreservesAll}
 
 case class MPort(name: String, clk: Expression)
 case class MPorts(readers: ArrayBuffer[MPort], writers: ArrayBuffer[MPort], readwriters: ArrayBuffer[MPort])
@@ -17,8 +17,8 @@ case class DataRef(exp: Expression, male: String, female: String, mask: String, 
 class RemoveCHIRRTL extends Transform with PreservesAll[Transform] {
 
   override val prerequisites = firrtl.stage.Forms.ChirrtlForm ++
-    Seq( classOf[passes.CInferTypes],
-         classOf[passes.CInferMDir] )
+    Seq( DependencyID[passes.CInferTypes],
+         DependencyID[passes.CInferMDir] )
 
   def inputForm: CircuitForm = UnknownForm
   def outputForm: CircuitForm = UnknownForm

--- a/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
+++ b/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
@@ -8,7 +8,7 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
-import firrtl.options.{DependencyID, PreservesAll}
+import firrtl.options.{Dependency, PreservesAll}
 
 case class MPort(name: String, clk: Expression)
 case class MPorts(readers: ArrayBuffer[MPort], writers: ArrayBuffer[MPort], readwriters: ArrayBuffer[MPort])
@@ -17,8 +17,8 @@ case class DataRef(exp: Expression, male: String, female: String, mask: String, 
 class RemoveCHIRRTL extends Transform with PreservesAll[Transform] {
 
   override val prerequisites = firrtl.stage.Forms.ChirrtlForm ++
-    Seq( DependencyID[passes.CInferTypes],
-         DependencyID[passes.CInferMDir] )
+    Seq( Dependency[passes.CInferTypes],
+         Dependency[passes.CInferMDir] )
 
   def inputForm: CircuitForm = UnknownForm
   def outputForm: CircuitForm = UnknownForm

--- a/src/main/scala/firrtl/passes/RemoveIntervals.scala
+++ b/src/main/scala/firrtl/passes/RemoveIntervals.scala
@@ -8,7 +8,7 @@ import firrtl._
 import firrtl.Mappers._
 import Implicits.{bigint2WInt}
 import firrtl.constraint.IsKnown
-import firrtl.options.PreservesAll
+import firrtl.options.{DependencyID, PreservesAll}
 
 import scala.math.BigDecimal.RoundingMode._
 
@@ -39,11 +39,11 @@ class WrapWithRemainder(info: Info, mname: String, wrap: DoPrim)
 class RemoveIntervals extends Pass with PreservesAll[Transform] {
 
   override val prerequisites: Seq[Dependency] =
-    Seq( classOf[PullMuxes],
-         classOf[ReplaceAccesses],
-         classOf[ExpandConnects],
-         classOf[RemoveAccesses],
-         classOf[ExpandWhensAndCheck] ) ++ firrtl.stage.Forms.Deduped
+    Seq( DependencyID[PullMuxes],
+         DependencyID[ReplaceAccesses],
+         DependencyID[ExpandConnects],
+         DependencyID[RemoveAccesses],
+         DependencyID[ExpandWhensAndCheck] ) ++ firrtl.stage.Forms.Deduped
 
   def run(c: Circuit): Circuit = {
     val alignedCircuit = c

--- a/src/main/scala/firrtl/passes/RemoveIntervals.scala
+++ b/src/main/scala/firrtl/passes/RemoveIntervals.scala
@@ -8,7 +8,7 @@ import firrtl._
 import firrtl.Mappers._
 import Implicits.{bigint2WInt}
 import firrtl.constraint.IsKnown
-import firrtl.options.{DependencyID, PreservesAll}
+import firrtl.options.{Dependency, PreservesAll}
 
 import scala.math.BigDecimal.RoundingMode._
 
@@ -38,12 +38,12 @@ class WrapWithRemainder(info: Info, mname: String, wrap: DoPrim)
   */
 class RemoveIntervals extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites: Seq[DependencyID[Transform]] =
-    Seq( DependencyID[PullMuxes],
-         DependencyID[ReplaceAccesses],
-         DependencyID[ExpandConnects],
-         DependencyID[RemoveAccesses],
-         DependencyID[ExpandWhensAndCheck] ) ++ firrtl.stage.Forms.Deduped
+  override val prerequisites: Seq[Dependency[Transform]] =
+    Seq( Dependency[PullMuxes],
+         Dependency[ReplaceAccesses],
+         Dependency[ExpandConnects],
+         Dependency[RemoveAccesses],
+         Dependency[ExpandWhensAndCheck] ) ++ firrtl.stage.Forms.Deduped
 
   def run(c: Circuit): Circuit = {
     val alignedCircuit = c

--- a/src/main/scala/firrtl/passes/RemoveIntervals.scala
+++ b/src/main/scala/firrtl/passes/RemoveIntervals.scala
@@ -38,7 +38,7 @@ class WrapWithRemainder(info: Info, mname: String, wrap: DoPrim)
   */
 class RemoveIntervals extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites: Seq[Dependency] =
+  override val prerequisites: Seq[DependencyID[Transform]] =
     Seq( DependencyID[PullMuxes],
          DependencyID[ReplaceAccesses],
          DependencyID[ExpandConnects],

--- a/src/main/scala/firrtl/passes/RemoveValidIf.scala
+++ b/src/main/scala/firrtl/passes/RemoveValidIf.scala
@@ -6,6 +6,7 @@ package passes
 import firrtl.Mappers._
 import firrtl.ir._
 import Utils.throwInternalError
+import firrtl.options.DependencyID
 
 /** Remove [[firrtl.ir.ValidIf ValidIf]] and replace [[firrtl.ir.IsInvalid IsInvalid]] with a connection to zero */
 class RemoveValidIf extends Pass {
@@ -15,8 +16,8 @@ class RemoveValidIf extends Pass {
   override val prerequisites = firrtl.stage.Forms.LowForm
 
   override val dependents =
-    Seq( classOf[SystemVerilogEmitter],
-         classOf[VerilogEmitter] )
+    Seq( DependencyID[SystemVerilogEmitter],
+         DependencyID[VerilogEmitter] )
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: Legalize | _: firrtl.transforms.ConstantPropagation => true

--- a/src/main/scala/firrtl/passes/RemoveValidIf.scala
+++ b/src/main/scala/firrtl/passes/RemoveValidIf.scala
@@ -6,7 +6,7 @@ package passes
 import firrtl.Mappers._
 import firrtl.ir._
 import Utils.throwInternalError
-import firrtl.options.DependencyID
+import firrtl.options.Dependency
 
 /** Remove [[firrtl.ir.ValidIf ValidIf]] and replace [[firrtl.ir.IsInvalid IsInvalid]] with a connection to zero */
 class RemoveValidIf extends Pass {
@@ -16,8 +16,8 @@ class RemoveValidIf extends Pass {
   override val prerequisites = firrtl.stage.Forms.LowForm
 
   override val dependents =
-    Seq( DependencyID[SystemVerilogEmitter],
-         DependencyID[VerilogEmitter] )
+    Seq( Dependency[SystemVerilogEmitter],
+         Dependency[VerilogEmitter] )
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: Legalize | _: firrtl.transforms.ConstantPropagation => true

--- a/src/main/scala/firrtl/passes/ReplaceAccesses.scala
+++ b/src/main/scala/firrtl/passes/ReplaceAccesses.scala
@@ -6,14 +6,14 @@ import firrtl.Transform
 import firrtl.ir._
 import firrtl.{WSubAccess, WSubIndex}
 import firrtl.Mappers._
-import firrtl.options.PreservesAll
+import firrtl.options.{DependencyID, PreservesAll}
 
 /** Replaces constant [[firrtl.WSubAccess]] with [[firrtl.WSubIndex]]
   * TODO Fold in to High Firrtl Const Prop
   */
 class ReplaceAccesses extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.Deduped :+ classOf[PullMuxes]
+  override val prerequisites = firrtl.stage.Forms.Deduped :+ DependencyID[PullMuxes]
 
   def run(c: Circuit): Circuit = {
     def onStmt(s: Statement): Statement = s map onStmt map onExp

--- a/src/main/scala/firrtl/passes/ReplaceAccesses.scala
+++ b/src/main/scala/firrtl/passes/ReplaceAccesses.scala
@@ -6,14 +6,14 @@ import firrtl.Transform
 import firrtl.ir._
 import firrtl.{WSubAccess, WSubIndex}
 import firrtl.Mappers._
-import firrtl.options.{DependencyID, PreservesAll}
+import firrtl.options.{Dependency, PreservesAll}
 
 /** Replaces constant [[firrtl.WSubAccess]] with [[firrtl.WSubIndex]]
   * TODO Fold in to High Firrtl Const Prop
   */
 class ReplaceAccesses extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.Deduped :+ DependencyID[PullMuxes]
+  override val prerequisites = firrtl.stage.Forms.Deduped :+ Dependency[PullMuxes]
 
   def run(c: Circuit): Circuit = {
     def onStmt(s: Statement): Statement = s map onStmt map onExp

--- a/src/main/scala/firrtl/passes/Resolves.scala
+++ b/src/main/scala/firrtl/passes/Resolves.scala
@@ -5,7 +5,7 @@ package firrtl.passes
 import firrtl._
 import firrtl.ir._
 import firrtl.Mappers._
-import firrtl.options.PreservesAll
+import firrtl.options.{DependencyID, PreservesAll}
 import Utils.throwInternalError
 
 
@@ -65,9 +65,9 @@ object ResolveFlows extends Pass with DeprecatedPassObject {
 class ResolveFlows extends Pass with PreservesAll[Transform] {
 
   override val prerequisites =
-    Seq( classOf[passes.ResolveKinds],
-         classOf[passes.InferTypes],
-         classOf[passes.Uniquify] ) ++ firrtl.stage.Forms.WorkingIR
+    Seq( DependencyID[passes.ResolveKinds],
+         DependencyID[passes.InferTypes],
+         DependencyID[passes.Uniquify] ) ++ firrtl.stage.Forms.WorkingIR
 
   def resolve_e(g: Flow)(e: Expression): Expression = e match {
     case ex: WRef => ex copy (flow = g)
@@ -119,7 +119,7 @@ object CInferMDir extends Pass with DeprecatedPassObject {
 
 class CInferMDir extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.ChirrtlForm :+ classOf[CInferTypes]
+  override val prerequisites = firrtl.stage.Forms.ChirrtlForm :+ DependencyID[CInferTypes]
 
   type MPortDirMap = collection.mutable.LinkedHashMap[String, MPortDir]
 

--- a/src/main/scala/firrtl/passes/Resolves.scala
+++ b/src/main/scala/firrtl/passes/Resolves.scala
@@ -5,7 +5,7 @@ package firrtl.passes
 import firrtl._
 import firrtl.ir._
 import firrtl.Mappers._
-import firrtl.options.{DependencyID, PreservesAll}
+import firrtl.options.{Dependency, PreservesAll}
 import Utils.throwInternalError
 
 
@@ -65,9 +65,9 @@ object ResolveFlows extends Pass with DeprecatedPassObject {
 class ResolveFlows extends Pass with PreservesAll[Transform] {
 
   override val prerequisites =
-    Seq( DependencyID[passes.ResolveKinds],
-         DependencyID[passes.InferTypes],
-         DependencyID[passes.Uniquify] ) ++ firrtl.stage.Forms.WorkingIR
+    Seq( Dependency[passes.ResolveKinds],
+         Dependency[passes.InferTypes],
+         Dependency[passes.Uniquify] ) ++ firrtl.stage.Forms.WorkingIR
 
   def resolve_e(g: Flow)(e: Expression): Expression = e match {
     case ex: WRef => ex copy (flow = g)
@@ -119,7 +119,7 @@ object CInferMDir extends Pass with DeprecatedPassObject {
 
 class CInferMDir extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.ChirrtlForm :+ DependencyID[CInferTypes]
+  override val prerequisites = firrtl.stage.Forms.ChirrtlForm :+ Dependency[CInferTypes]
 
   type MPortDirMap = collection.mutable.LinkedHashMap[String, MPortDir]
 

--- a/src/main/scala/firrtl/passes/SplitExpressions.scala
+++ b/src/main/scala/firrtl/passes/SplitExpressions.scala
@@ -5,7 +5,7 @@ package passes
 
 import firrtl.{SystemVerilogEmitter, VerilogEmitter}
 import firrtl.ir._
-import firrtl.options.PreservesAll
+import firrtl.options.{DependencyID, PreservesAll}
 import firrtl.Mappers._
 import firrtl.Utils.{kind, flow, get_info}
 
@@ -17,12 +17,12 @@ import scala.collection.mutable
 class SplitExpressions extends Pass with PreservesAll[Transform] {
 
   override val prerequisites = firrtl.stage.Forms.LowForm ++
-    Seq( classOf[passes.RemoveValidIf],
-         classOf[firrtl.passes.memlib.VerilogMemDelays] )
+    Seq( DependencyID[passes.RemoveValidIf],
+         DependencyID[firrtl.passes.memlib.VerilogMemDelays] )
 
   override val dependents =
-    Seq( classOf[SystemVerilogEmitter],
-         classOf[VerilogEmitter] )
+    Seq( DependencyID[SystemVerilogEmitter],
+         DependencyID[VerilogEmitter] )
 
    private def onModule(m: Module): Module = {
       val namespace = Namespace(m)

--- a/src/main/scala/firrtl/passes/SplitExpressions.scala
+++ b/src/main/scala/firrtl/passes/SplitExpressions.scala
@@ -5,7 +5,7 @@ package passes
 
 import firrtl.{SystemVerilogEmitter, VerilogEmitter}
 import firrtl.ir._
-import firrtl.options.{DependencyID, PreservesAll}
+import firrtl.options.{Dependency, PreservesAll}
 import firrtl.Mappers._
 import firrtl.Utils.{kind, flow, get_info}
 
@@ -17,12 +17,12 @@ import scala.collection.mutable
 class SplitExpressions extends Pass with PreservesAll[Transform] {
 
   override val prerequisites = firrtl.stage.Forms.LowForm ++
-    Seq( DependencyID[passes.RemoveValidIf],
-         DependencyID[firrtl.passes.memlib.VerilogMemDelays] )
+    Seq( Dependency[passes.RemoveValidIf],
+         Dependency[firrtl.passes.memlib.VerilogMemDelays] )
 
   override val dependents =
-    Seq( DependencyID[SystemVerilogEmitter],
-         DependencyID[VerilogEmitter] )
+    Seq( Dependency[SystemVerilogEmitter],
+         Dependency[VerilogEmitter] )
 
    private def onModule(m: Module): Module = {
       val namespace = Namespace(m)

--- a/src/main/scala/firrtl/passes/TrimIntervals.scala
+++ b/src/main/scala/firrtl/passes/TrimIntervals.scala
@@ -10,7 +10,7 @@ import firrtl.Mappers._
 import firrtl.Utils.{error, field_type, getUIntWidth, max, module_type, sub_type}
 import Implicits.{bigint2WInt, int2WInt}
 import firrtl.constraint.{IsFloor, IsKnown, IsMul}
-import firrtl.options.PreservesAll
+import firrtl.options.{DependencyID, PreservesAll}
 
 /** Replaces IntervalType with SIntType, three AST walks:
   * 1) Align binary points
@@ -26,11 +26,11 @@ import firrtl.options.PreservesAll
 class TrimIntervals extends Pass with PreservesAll[Transform] {
 
   override val prerequisites =
-    Seq( classOf[passes.ResolveKinds],
-         classOf[passes.InferTypes],
-         classOf[passes.Uniquify],
-         classOf[passes.ResolveFlows],
-         classOf[passes.InferBinaryPoints] )
+    Seq( DependencyID[passes.ResolveKinds],
+         DependencyID[passes.InferTypes],
+         DependencyID[passes.Uniquify],
+         DependencyID[passes.ResolveFlows],
+         DependencyID[passes.InferBinaryPoints] )
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/passes/TrimIntervals.scala
+++ b/src/main/scala/firrtl/passes/TrimIntervals.scala
@@ -10,7 +10,7 @@ import firrtl.Mappers._
 import firrtl.Utils.{error, field_type, getUIntWidth, max, module_type, sub_type}
 import Implicits.{bigint2WInt, int2WInt}
 import firrtl.constraint.{IsFloor, IsKnown, IsMul}
-import firrtl.options.{DependencyID, PreservesAll}
+import firrtl.options.{Dependency, PreservesAll}
 
 /** Replaces IntervalType with SIntType, three AST walks:
   * 1) Align binary points
@@ -26,11 +26,11 @@ import firrtl.options.{DependencyID, PreservesAll}
 class TrimIntervals extends Pass with PreservesAll[Transform] {
 
   override val prerequisites =
-    Seq( DependencyID[passes.ResolveKinds],
-         DependencyID[passes.InferTypes],
-         DependencyID[passes.Uniquify],
-         DependencyID[passes.ResolveFlows],
-         DependencyID[passes.InferBinaryPoints] )
+    Seq( Dependency[passes.ResolveKinds],
+         Dependency[passes.InferTypes],
+         Dependency[passes.Uniquify],
+         Dependency[passes.ResolveFlows],
+         Dependency[passes.InferBinaryPoints] )
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/passes/Uniquify.scala
+++ b/src/main/scala/firrtl/passes/Uniquify.scala
@@ -8,8 +8,9 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
-import MemPortUtils.memType
+import firrtl.options.DependencyID
 
+import MemPortUtils.memType
 
 object Uniquify extends Transform with DeprecatedTransformObject {
 
@@ -105,8 +106,8 @@ class Uniquify extends Transform {
   import Uniquify._
 
   override val prerequisites =
-    Seq( classOf[ResolveKinds],
-         classOf[InferTypes] ) ++ firrtl.stage.Forms.WorkingIR
+    Seq( DependencyID[ResolveKinds],
+         DependencyID[InferTypes] ) ++ firrtl.stage.Forms.WorkingIR
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: ResolveKinds | _: InferTypes => true

--- a/src/main/scala/firrtl/passes/Uniquify.scala
+++ b/src/main/scala/firrtl/passes/Uniquify.scala
@@ -8,7 +8,7 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
-import firrtl.options.DependencyID
+import firrtl.options.Dependency
 
 import MemPortUtils.memType
 
@@ -106,8 +106,8 @@ class Uniquify extends Transform {
   import Uniquify._
 
   override val prerequisites =
-    Seq( DependencyID[ResolveKinds],
-         DependencyID[InferTypes] ) ++ firrtl.stage.Forms.WorkingIR
+    Seq( Dependency[ResolveKinds],
+         Dependency[InferTypes] ) ++ firrtl.stage.Forms.WorkingIR
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: ResolveKinds | _: InferTypes => true

--- a/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
+++ b/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
@@ -7,7 +7,7 @@ import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.PrimOps.{Bits, Rem}
 import firrtl.Utils._
-import firrtl.options.PreservesAll
+import firrtl.options.{DependencyID, PreservesAll}
 
 import scala.collection.mutable
 
@@ -27,9 +27,9 @@ import scala.collection.mutable
 class VerilogModulusCleanup extends Pass with PreservesAll[Transform] {
 
   override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
-    Seq( classOf[firrtl.transforms.BlackBoxSourceHelper],
-         classOf[firrtl.transforms.ReplaceTruncatingArithmetic],
-         classOf[firrtl.transforms.FlattenRegUpdate] )
+    Seq( DependencyID[firrtl.transforms.BlackBoxSourceHelper],
+         DependencyID[firrtl.transforms.ReplaceTruncatingArithmetic],
+         DependencyID[firrtl.transforms.FlattenRegUpdate] )
 
   private def onModule(m: Module): Module = {
     val namespace = Namespace(m)

--- a/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
+++ b/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
@@ -7,7 +7,7 @@ import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.PrimOps.{Bits, Rem}
 import firrtl.Utils._
-import firrtl.options.{DependencyID, PreservesAll}
+import firrtl.options.{Dependency, PreservesAll}
 
 import scala.collection.mutable
 
@@ -27,9 +27,9 @@ import scala.collection.mutable
 class VerilogModulusCleanup extends Pass with PreservesAll[Transform] {
 
   override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
-    Seq( DependencyID[firrtl.transforms.BlackBoxSourceHelper],
-         DependencyID[firrtl.transforms.ReplaceTruncatingArithmetic],
-         DependencyID[firrtl.transforms.FlattenRegUpdate] )
+    Seq( Dependency[firrtl.transforms.BlackBoxSourceHelper],
+         Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
+         Dependency[firrtl.transforms.FlattenRegUpdate] )
 
   private def onModule(m: Module): Module = {
     val namespace = Namespace(m)

--- a/src/main/scala/firrtl/passes/ZeroWidth.scala
+++ b/src/main/scala/firrtl/passes/ZeroWidth.scala
@@ -6,17 +6,18 @@ import firrtl.PrimOps._
 import firrtl.ir._
 import firrtl._
 import firrtl.Mappers._
+import firrtl.options.DependencyID
 
 class ZeroWidth extends Transform {
 
   override val prerequisites =
-    Seq( classOf[PullMuxes],
-         classOf[ReplaceAccesses],
-         classOf[ExpandConnects],
-         classOf[RemoveAccesses],
-         classOf[Uniquify],
-         classOf[ExpandWhensAndCheck],
-         classOf[ConvertFixedToSInt] ) ++ firrtl.stage.Forms.Deduped
+    Seq( DependencyID[PullMuxes],
+         DependencyID[ReplaceAccesses],
+         DependencyID[ExpandConnects],
+         DependencyID[RemoveAccesses],
+         DependencyID[Uniquify],
+         DependencyID[ExpandWhensAndCheck],
+         DependencyID[ConvertFixedToSInt] ) ++ firrtl.stage.Forms.Deduped
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: InferTypes => true

--- a/src/main/scala/firrtl/passes/ZeroWidth.scala
+++ b/src/main/scala/firrtl/passes/ZeroWidth.scala
@@ -6,18 +6,18 @@ import firrtl.PrimOps._
 import firrtl.ir._
 import firrtl._
 import firrtl.Mappers._
-import firrtl.options.DependencyID
+import firrtl.options.Dependency
 
 class ZeroWidth extends Transform {
 
   override val prerequisites =
-    Seq( DependencyID[PullMuxes],
-         DependencyID[ReplaceAccesses],
-         DependencyID[ExpandConnects],
-         DependencyID[RemoveAccesses],
-         DependencyID[Uniquify],
-         DependencyID[ExpandWhensAndCheck],
-         DependencyID[ConvertFixedToSInt] ) ++ firrtl.stage.Forms.Deduped
+    Seq( Dependency[PullMuxes],
+         Dependency[ReplaceAccesses],
+         Dependency[ExpandConnects],
+         Dependency[RemoveAccesses],
+         Dependency[Uniquify],
+         Dependency[ExpandWhensAndCheck],
+         Dependency[ConvertFixedToSInt] ) ++ firrtl.stage.Forms.Deduped
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: InferTypes => true

--- a/src/main/scala/firrtl/passes/memlib/InferReadWrite.scala
+++ b/src/main/scala/firrtl/passes/memlib/InferReadWrite.scala
@@ -157,7 +157,7 @@ class InferReadWrite extends Transform with SeqTransformBased with HasShellOptio
 
   def transforms = Seq(
     InferReadWritePass,
-    new CheckInitialization,
+    CheckInitialization,
     new InferTypes,
     new ResolveKinds,
     new ResolveFlows

--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
@@ -122,7 +122,7 @@ class ReplSeqMem extends Transform with HasShellOptions {
         new ReplaceMemMacros(outConfigFile),
         new WiringTransform,
         new SimpleMidTransform(RemoveEmpty),
-        new SimpleMidTransform(new CheckInitialization),
+        new SimpleMidTransform(CheckInitialization),
         new SimpleMidTransform(new InferTypes),
         new Uniquify,
         new SimpleMidTransform(new ResolveKinds),

--- a/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
+++ b/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
@@ -9,6 +9,7 @@ import firrtl.Utils._
 import firrtl.Mappers._
 import firrtl.traversals.Foreachers._
 import firrtl.transforms
+import firrtl.options.DependencyID
 
 import MemPortUtils._
 import WrappedExpression._
@@ -167,11 +168,11 @@ class MemDelayAndReadwriteTransformer(m: DefModule) {
 
 class VerilogMemDelays extends Pass {
 
-  override val prerequisites = firrtl.stage.Forms.LowForm :+ classOf[firrtl.passes.RemoveValidIf]
+  override val prerequisites = firrtl.stage.Forms.LowForm :+ DependencyID[firrtl.passes.RemoveValidIf]
 
   override val dependents =
-    Seq( classOf[VerilogEmitter],
-         classOf[SystemVerilogEmitter] )
+    Seq( DependencyID[VerilogEmitter],
+         DependencyID[SystemVerilogEmitter] )
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: transforms.ConstantPropagation => true

--- a/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
+++ b/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
@@ -9,7 +9,7 @@ import firrtl.Utils._
 import firrtl.Mappers._
 import firrtl.traversals.Foreachers._
 import firrtl.transforms
-import firrtl.options.DependencyID
+import firrtl.options.Dependency
 
 import MemPortUtils._
 import WrappedExpression._
@@ -168,11 +168,11 @@ class MemDelayAndReadwriteTransformer(m: DefModule) {
 
 class VerilogMemDelays extends Pass {
 
-  override val prerequisites = firrtl.stage.Forms.LowForm :+ DependencyID[firrtl.passes.RemoveValidIf]
+  override val prerequisites = firrtl.stage.Forms.LowForm :+ Dependency[firrtl.passes.RemoveValidIf]
 
   override val dependents =
-    Seq( DependencyID[VerilogEmitter],
-         DependencyID[SystemVerilogEmitter] )
+    Seq( Dependency[VerilogEmitter],
+         Dependency[SystemVerilogEmitter] )
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: transforms.ConstantPropagation => true

--- a/src/main/scala/firrtl/stage/FirrtlStage.scala
+++ b/src/main/scala/firrtl/stage/FirrtlStage.scala
@@ -3,12 +3,12 @@
 package firrtl.stage
 
 import firrtl.AnnotationSeq
-import firrtl.options.{DependencyID, Phase, PhaseManager, PreservesAll, Shell, Stage, StageMain}
+import firrtl.options.{Dependency, Phase, PhaseManager, PreservesAll, Shell, Stage, StageMain}
 import firrtl.options.phases.DeletedWrapper
 import firrtl.stage.phases.CatchExceptions
 
 class FirrtlPhase
-    extends PhaseManager(targets=Seq(DependencyID[firrtl.stage.phases.Compiler], DependencyID[firrtl.stage.phases.WriteEmitted]))
+    extends PhaseManager(targets=Seq(Dependency[firrtl.stage.phases.Compiler], Dependency[firrtl.stage.phases.WriteEmitted]))
     with PreservesAll[Phase] {
 
   override val wrappers = Seq(CatchExceptions(_: Phase), DeletedWrapper(_: Phase))

--- a/src/main/scala/firrtl/stage/FirrtlStage.scala
+++ b/src/main/scala/firrtl/stage/FirrtlStage.scala
@@ -3,12 +3,12 @@
 package firrtl.stage
 
 import firrtl.AnnotationSeq
-import firrtl.options.{Phase, PhaseManager, PreservesAll, Shell, Stage, StageMain}
+import firrtl.options.{DependencyID, Phase, PhaseManager, PreservesAll, Shell, Stage, StageMain}
 import firrtl.options.phases.DeletedWrapper
 import firrtl.stage.phases.CatchExceptions
 
 class FirrtlPhase
-    extends PhaseManager(targets=Seq(classOf[firrtl.stage.phases.Compiler], classOf[firrtl.stage.phases.WriteEmitted]))
+    extends PhaseManager(targets=Seq(DependencyID[firrtl.stage.phases.Compiler], DependencyID[firrtl.stage.phases.WriteEmitted]))
     with PreservesAll[Phase] {
 
   override val wrappers = Seq(CatchExceptions(_: Phase), DeletedWrapper(_: Phase))

--- a/src/main/scala/firrtl/stage/Forms.scala
+++ b/src/main/scala/firrtl/stage/Forms.scala
@@ -3,6 +3,7 @@
 package firrtl.stage
 
 import firrtl._
+import firrtl.options.DependencyID
 import firrtl.stage.TransformManager.TransformDependency
 
 /*
@@ -16,28 +17,28 @@ object Forms {
   val ChirrtlForm: Seq[TransformDependency] = Seq.empty
 
   val MinimalHighForm: Seq[TransformDependency] = ChirrtlForm ++
-    Seq( classOf[passes.CheckChirrtl],
-         classOf[passes.CInferTypes],
-         classOf[passes.CInferMDir],
-         classOf[passes.RemoveCHIRRTL] )
+    Seq( DependencyID[passes.CheckChirrtl],
+         DependencyID[passes.CInferTypes],
+         DependencyID[passes.CInferMDir],
+         DependencyID[passes.RemoveCHIRRTL] )
 
-  val WorkingIR: Seq[TransformDependency] = MinimalHighForm :+ classOf[passes.ToWorkingIR]
+  val WorkingIR: Seq[TransformDependency] = MinimalHighForm :+ DependencyID[passes.ToWorkingIR]
 
   val Resolved: Seq[TransformDependency] = WorkingIR ++
-    Seq( classOf[passes.CheckHighForm],
-         classOf[passes.ResolveKinds],
-         classOf[passes.InferTypes],
-         classOf[passes.CheckTypes],
-         classOf[passes.Uniquify],
-         classOf[passes.ResolveFlows],
-         classOf[passes.CheckFlows],
-         classOf[passes.InferBinaryPoints],
-         classOf[passes.TrimIntervals],
-         classOf[passes.InferWidths],
-         classOf[passes.CheckWidths],
-         classOf[firrtl.transforms.InferResets] )
+    Seq( DependencyID[passes.CheckHighForm],
+         DependencyID[passes.ResolveKinds],
+         DependencyID[passes.InferTypes],
+         DependencyID[passes.CheckTypes],
+         DependencyID[passes.Uniquify],
+         DependencyID[passes.ResolveFlows],
+         DependencyID[passes.CheckFlows],
+         DependencyID[passes.InferBinaryPoints],
+         DependencyID[passes.TrimIntervals],
+         DependencyID[passes.InferWidths],
+         DependencyID[passes.CheckWidths],
+         DependencyID[firrtl.transforms.InferResets] )
 
-  val Deduped: Seq[TransformDependency] = Resolved :+ classOf[firrtl.transforms.DedupModules]
+  val Deduped: Seq[TransformDependency] = Resolved :+ DependencyID[firrtl.transforms.DedupModules]
 
   val HighForm: Seq[TransformDependency] = ChirrtlForm ++
     MinimalHighForm ++
@@ -46,51 +47,51 @@ object Forms {
     Deduped
 
   val MidForm: Seq[TransformDependency] = HighForm ++
-    Seq( classOf[passes.PullMuxes],
-         classOf[passes.ReplaceAccesses],
-         classOf[passes.ExpandConnects],
-         classOf[passes.RemoveAccesses],
-         classOf[passes.ExpandWhensAndCheck],
-         classOf[passes.RemoveIntervals],
-         classOf[passes.ConvertFixedToSInt],
-         classOf[passes.ZeroWidth] )
+    Seq( DependencyID[passes.PullMuxes],
+         DependencyID[passes.ReplaceAccesses],
+         DependencyID[passes.ExpandConnects],
+         DependencyID[passes.RemoveAccesses],
+         DependencyID[passes.ExpandWhensAndCheck],
+         DependencyID[passes.RemoveIntervals],
+         DependencyID[passes.ConvertFixedToSInt],
+         DependencyID[passes.ZeroWidth] )
 
   val LowForm: Seq[TransformDependency] = MidForm ++
-    Seq( classOf[passes.LowerTypes],
-         classOf[passes.Legalize],
-         classOf[firrtl.transforms.RemoveReset],
-         classOf[firrtl.transforms.CheckCombLoops],
-         classOf[checks.CheckResets],
-         classOf[firrtl.transforms.RemoveWires] )
+    Seq( DependencyID[passes.LowerTypes],
+         DependencyID[passes.Legalize],
+         DependencyID[firrtl.transforms.RemoveReset],
+         DependencyID[firrtl.transforms.CheckCombLoops],
+         DependencyID[checks.CheckResets],
+         DependencyID[firrtl.transforms.RemoveWires] )
 
   val LowFormMinimumOptimized: Seq[TransformDependency] = LowForm ++
-    Seq( classOf[passes.RemoveValidIf],
-         classOf[passes.memlib.VerilogMemDelays],
-         classOf[passes.SplitExpressions] )
+    Seq( DependencyID[passes.RemoveValidIf],
+         DependencyID[passes.memlib.VerilogMemDelays],
+         DependencyID[passes.SplitExpressions] )
 
   val LowFormOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
-    Seq( classOf[firrtl.transforms.ConstantPropagation],
-         classOf[passes.PadWidths],
-         classOf[firrtl.transforms.CombineCats],
-         classOf[passes.CommonSubexpressionElimination],
-         classOf[firrtl.transforms.DeadCodeElimination] )
+    Seq( DependencyID[firrtl.transforms.ConstantPropagation],
+         DependencyID[passes.PadWidths],
+         DependencyID[firrtl.transforms.CombineCats],
+         DependencyID[passes.CommonSubexpressionElimination],
+         DependencyID[firrtl.transforms.DeadCodeElimination] )
 
   val VerilogMinimumOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
-    Seq( classOf[firrtl.transforms.BlackBoxSourceHelper],
-         classOf[firrtl.transforms.ReplaceTruncatingArithmetic],
-         classOf[firrtl.transforms.FlattenRegUpdate],
-         classOf[passes.VerilogModulusCleanup],
-         classOf[firrtl.transforms.VerilogRename],
-         classOf[passes.VerilogPrep],
-         classOf[firrtl.AddDescriptionNodes] )
+    Seq( DependencyID[firrtl.transforms.BlackBoxSourceHelper],
+         DependencyID[firrtl.transforms.ReplaceTruncatingArithmetic],
+         DependencyID[firrtl.transforms.FlattenRegUpdate],
+         DependencyID[passes.VerilogModulusCleanup],
+         DependencyID[firrtl.transforms.VerilogRename],
+         DependencyID[passes.VerilogPrep],
+         DependencyID[firrtl.AddDescriptionNodes] )
 
   val VerilogOptimized: Seq[TransformDependency] = LowFormOptimized ++
-    Seq( classOf[firrtl.transforms.BlackBoxSourceHelper],
-         classOf[firrtl.transforms.ReplaceTruncatingArithmetic],
-         classOf[firrtl.transforms.FlattenRegUpdate],
-         classOf[passes.VerilogModulusCleanup],
-         classOf[firrtl.transforms.VerilogRename],
-         classOf[passes.VerilogPrep],
-         classOf[firrtl.AddDescriptionNodes] )
+    Seq( DependencyID[firrtl.transforms.BlackBoxSourceHelper],
+         DependencyID[firrtl.transforms.ReplaceTruncatingArithmetic],
+         DependencyID[firrtl.transforms.FlattenRegUpdate],
+         DependencyID[passes.VerilogModulusCleanup],
+         DependencyID[firrtl.transforms.VerilogRename],
+         DependencyID[passes.VerilogPrep],
+         DependencyID[firrtl.AddDescriptionNodes] )
 
 }

--- a/src/main/scala/firrtl/stage/Forms.scala
+++ b/src/main/scala/firrtl/stage/Forms.scala
@@ -3,7 +3,7 @@
 package firrtl.stage
 
 import firrtl._
-import firrtl.options.DependencyID
+import firrtl.options.Dependency
 import firrtl.stage.TransformManager.TransformDependency
 
 /*
@@ -17,28 +17,28 @@ object Forms {
   lazy val ChirrtlForm: Seq[TransformDependency] = Seq.empty
 
   lazy val MinimalHighForm: Seq[TransformDependency] = ChirrtlForm ++
-    Seq( DependencyID[passes.CheckChirrtl],
-         DependencyID[passes.CInferTypes],
-         DependencyID[passes.CInferMDir],
-         DependencyID[passes.RemoveCHIRRTL] )
+    Seq( Dependency[passes.CheckChirrtl],
+         Dependency[passes.CInferTypes],
+         Dependency[passes.CInferMDir],
+         Dependency[passes.RemoveCHIRRTL] )
 
-  lazy val WorkingIR: Seq[TransformDependency] = MinimalHighForm :+ DependencyID[passes.ToWorkingIR]
+  lazy val WorkingIR: Seq[TransformDependency] = MinimalHighForm :+ Dependency[passes.ToWorkingIR]
 
   lazy val Resolved: Seq[TransformDependency] = WorkingIR ++
-    Seq( DependencyID[passes.CheckHighForm],
-         DependencyID[passes.ResolveKinds],
-         DependencyID[passes.InferTypes],
-         DependencyID[passes.CheckTypes],
-         DependencyID[passes.Uniquify],
-         DependencyID[passes.ResolveFlows],
-         DependencyID[passes.CheckFlows],
-         DependencyID[passes.InferBinaryPoints],
-         DependencyID[passes.TrimIntervals],
-         DependencyID[passes.InferWidths],
-         DependencyID[passes.CheckWidths],
-         DependencyID[firrtl.transforms.InferResets] )
+    Seq( Dependency[passes.CheckHighForm],
+         Dependency[passes.ResolveKinds],
+         Dependency[passes.InferTypes],
+         Dependency[passes.CheckTypes],
+         Dependency[passes.Uniquify],
+         Dependency[passes.ResolveFlows],
+         Dependency[passes.CheckFlows],
+         Dependency[passes.InferBinaryPoints],
+         Dependency[passes.TrimIntervals],
+         Dependency[passes.InferWidths],
+         Dependency[passes.CheckWidths],
+         Dependency[firrtl.transforms.InferResets] )
 
-  lazy val Deduped: Seq[TransformDependency] = Resolved :+ DependencyID[firrtl.transforms.DedupModules]
+  lazy val Deduped: Seq[TransformDependency] = Resolved :+ Dependency[firrtl.transforms.DedupModules]
 
   lazy val HighForm: Seq[TransformDependency] = ChirrtlForm ++
     MinimalHighForm ++
@@ -47,51 +47,51 @@ object Forms {
     Deduped
 
   lazy val MidForm: Seq[TransformDependency] = HighForm ++
-    Seq( DependencyID[passes.PullMuxes],
-         DependencyID[passes.ReplaceAccesses],
-         DependencyID[passes.ExpandConnects],
-         DependencyID[passes.RemoveAccesses],
-         DependencyID[passes.ExpandWhensAndCheck],
-         DependencyID[passes.RemoveIntervals],
-         DependencyID[passes.ConvertFixedToSInt],
-         DependencyID[passes.ZeroWidth] )
+    Seq( Dependency[passes.PullMuxes],
+         Dependency[passes.ReplaceAccesses],
+         Dependency[passes.ExpandConnects],
+         Dependency[passes.RemoveAccesses],
+         Dependency[passes.ExpandWhensAndCheck],
+         Dependency[passes.RemoveIntervals],
+         Dependency[passes.ConvertFixedToSInt],
+         Dependency[passes.ZeroWidth] )
 
   lazy val LowForm: Seq[TransformDependency] = MidForm ++
-    Seq( DependencyID(passes.LowerTypes),
-         DependencyID[passes.Legalize],
-         DependencyID[firrtl.transforms.RemoveReset],
-         DependencyID[firrtl.transforms.CheckCombLoops],
-         DependencyID[checks.CheckResets],
-         DependencyID[firrtl.transforms.RemoveWires] )
+    Seq( Dependency(passes.LowerTypes),
+         Dependency[passes.Legalize],
+         Dependency[firrtl.transforms.RemoveReset],
+         Dependency[firrtl.transforms.CheckCombLoops],
+         Dependency[checks.CheckResets],
+         Dependency[firrtl.transforms.RemoveWires] )
 
   lazy val LowFormMinimumOptimized: Seq[TransformDependency] = LowForm ++
-    Seq( DependencyID[passes.RemoveValidIf],
-         DependencyID[passes.memlib.VerilogMemDelays],
-         DependencyID[passes.SplitExpressions] )
+    Seq( Dependency[passes.RemoveValidIf],
+         Dependency[passes.memlib.VerilogMemDelays],
+         Dependency[passes.SplitExpressions] )
 
   lazy val LowFormOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
-    Seq( DependencyID[firrtl.transforms.ConstantPropagation],
-         DependencyID[passes.PadWidths],
-         DependencyID[firrtl.transforms.CombineCats],
-         DependencyID[passes.CommonSubexpressionElimination],
-         DependencyID[firrtl.transforms.DeadCodeElimination] )
+    Seq( Dependency[firrtl.transforms.ConstantPropagation],
+         Dependency[passes.PadWidths],
+         Dependency[firrtl.transforms.CombineCats],
+         Dependency[passes.CommonSubexpressionElimination],
+         Dependency[firrtl.transforms.DeadCodeElimination] )
 
   lazy val VerilogMinimumOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
-    Seq( DependencyID[firrtl.transforms.BlackBoxSourceHelper],
-         DependencyID[firrtl.transforms.ReplaceTruncatingArithmetic],
-         DependencyID[firrtl.transforms.FlattenRegUpdate],
-         DependencyID[passes.VerilogModulusCleanup],
-         DependencyID[firrtl.transforms.VerilogRename],
-         DependencyID[passes.VerilogPrep],
-         DependencyID[firrtl.AddDescriptionNodes] )
+    Seq( Dependency[firrtl.transforms.BlackBoxSourceHelper],
+         Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
+         Dependency[firrtl.transforms.FlattenRegUpdate],
+         Dependency[passes.VerilogModulusCleanup],
+         Dependency[firrtl.transforms.VerilogRename],
+         Dependency[passes.VerilogPrep],
+         Dependency[firrtl.AddDescriptionNodes] )
 
   lazy val VerilogOptimized: Seq[TransformDependency] = LowFormOptimized ++
-    Seq( DependencyID[firrtl.transforms.BlackBoxSourceHelper],
-         DependencyID[firrtl.transforms.ReplaceTruncatingArithmetic],
-         DependencyID[firrtl.transforms.FlattenRegUpdate],
-         DependencyID[passes.VerilogModulusCleanup],
-         DependencyID[firrtl.transforms.VerilogRename],
-         DependencyID[passes.VerilogPrep],
-         DependencyID[firrtl.AddDescriptionNodes] )
+    Seq( Dependency[firrtl.transforms.BlackBoxSourceHelper],
+         Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
+         Dependency[firrtl.transforms.FlattenRegUpdate],
+         Dependency[passes.VerilogModulusCleanup],
+         Dependency[firrtl.transforms.VerilogRename],
+         Dependency[passes.VerilogPrep],
+         Dependency[firrtl.AddDescriptionNodes] )
 
 }

--- a/src/main/scala/firrtl/stage/Forms.scala
+++ b/src/main/scala/firrtl/stage/Forms.scala
@@ -14,17 +14,17 @@ import firrtl.stage.TransformManager.TransformDependency
 
 object Forms {
 
-  def ChirrtlForm: Seq[TransformDependency] = Seq.empty
+  lazy val ChirrtlForm: Seq[TransformDependency] = Seq.empty
 
-  def MinimalHighForm: Seq[TransformDependency] = ChirrtlForm ++
+  lazy val MinimalHighForm: Seq[TransformDependency] = ChirrtlForm ++
     Seq( DependencyID[passes.CheckChirrtl],
          DependencyID[passes.CInferTypes],
          DependencyID[passes.CInferMDir],
          DependencyID[passes.RemoveCHIRRTL] )
 
-  def WorkingIR: Seq[TransformDependency] = MinimalHighForm :+ DependencyID[passes.ToWorkingIR]
+  lazy val WorkingIR: Seq[TransformDependency] = MinimalHighForm :+ DependencyID[passes.ToWorkingIR]
 
-  def Resolved: Seq[TransformDependency] = WorkingIR ++
+  lazy val Resolved: Seq[TransformDependency] = WorkingIR ++
     Seq( DependencyID[passes.CheckHighForm],
          DependencyID[passes.ResolveKinds],
          DependencyID[passes.InferTypes],
@@ -38,15 +38,15 @@ object Forms {
          DependencyID[passes.CheckWidths],
          DependencyID[firrtl.transforms.InferResets] )
 
-  def Deduped: Seq[TransformDependency] = Resolved :+ DependencyID[firrtl.transforms.DedupModules]
+  lazy val Deduped: Seq[TransformDependency] = Resolved :+ DependencyID[firrtl.transforms.DedupModules]
 
-  def HighForm: Seq[TransformDependency] = ChirrtlForm ++
+  lazy val HighForm: Seq[TransformDependency] = ChirrtlForm ++
     MinimalHighForm ++
     WorkingIR ++
     Resolved ++
     Deduped
 
-  def MidForm: Seq[TransformDependency] = HighForm ++
+  lazy val MidForm: Seq[TransformDependency] = HighForm ++
     Seq( DependencyID[passes.PullMuxes],
          DependencyID[passes.ReplaceAccesses],
          DependencyID[passes.ExpandConnects],
@@ -56,7 +56,7 @@ object Forms {
          DependencyID[passes.ConvertFixedToSInt],
          DependencyID[passes.ZeroWidth] )
 
-  def LowForm: Seq[TransformDependency] = MidForm ++
+  lazy val LowForm: Seq[TransformDependency] = MidForm ++
     Seq( DependencyID(passes.LowerTypes),
          DependencyID[passes.Legalize],
          DependencyID[firrtl.transforms.RemoveReset],
@@ -64,19 +64,19 @@ object Forms {
          DependencyID[checks.CheckResets],
          DependencyID[firrtl.transforms.RemoveWires] )
 
-  def LowFormMinimumOptimized: Seq[TransformDependency] = LowForm ++
+  lazy val LowFormMinimumOptimized: Seq[TransformDependency] = LowForm ++
     Seq( DependencyID[passes.RemoveValidIf],
          DependencyID[passes.memlib.VerilogMemDelays],
          DependencyID[passes.SplitExpressions] )
 
-  def LowFormOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
+  lazy val LowFormOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
     Seq( DependencyID[firrtl.transforms.ConstantPropagation],
          DependencyID[passes.PadWidths],
          DependencyID[firrtl.transforms.CombineCats],
          DependencyID[passes.CommonSubexpressionElimination],
          DependencyID[firrtl.transforms.DeadCodeElimination] )
 
-  def VerilogMinimumOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
+  lazy val VerilogMinimumOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
     Seq( DependencyID[firrtl.transforms.BlackBoxSourceHelper],
          DependencyID[firrtl.transforms.ReplaceTruncatingArithmetic],
          DependencyID[firrtl.transforms.FlattenRegUpdate],
@@ -85,7 +85,7 @@ object Forms {
          DependencyID[passes.VerilogPrep],
          DependencyID[firrtl.AddDescriptionNodes] )
 
-  def VerilogOptimized: Seq[TransformDependency] = LowFormOptimized ++
+  lazy val VerilogOptimized: Seq[TransformDependency] = LowFormOptimized ++
     Seq( DependencyID[firrtl.transforms.BlackBoxSourceHelper],
          DependencyID[firrtl.transforms.ReplaceTruncatingArithmetic],
          DependencyID[firrtl.transforms.FlattenRegUpdate],

--- a/src/main/scala/firrtl/stage/Forms.scala
+++ b/src/main/scala/firrtl/stage/Forms.scala
@@ -17,7 +17,7 @@ object Forms {
   lazy val ChirrtlForm: Seq[TransformDependency] = Seq.empty
 
   lazy val MinimalHighForm: Seq[TransformDependency] = ChirrtlForm ++
-    Seq( Dependency[passes.CheckChirrtl],
+    Seq( Dependency(passes.CheckChirrtl),
          Dependency[passes.CInferTypes],
          Dependency[passes.CInferMDir],
          Dependency[passes.RemoveCHIRRTL] )
@@ -25,17 +25,17 @@ object Forms {
   lazy val WorkingIR: Seq[TransformDependency] = MinimalHighForm :+ Dependency[passes.ToWorkingIR]
 
   lazy val Resolved: Seq[TransformDependency] = WorkingIR ++
-    Seq( Dependency[passes.CheckHighForm],
+    Seq( Dependency(passes.CheckHighForm),
          Dependency[passes.ResolveKinds],
          Dependency[passes.InferTypes],
-         Dependency[passes.CheckTypes],
+         Dependency(passes.CheckTypes),
          Dependency[passes.Uniquify],
          Dependency[passes.ResolveFlows],
-         Dependency[passes.CheckFlows],
+         Dependency(passes.CheckFlows),
          Dependency[passes.InferBinaryPoints],
          Dependency[passes.TrimIntervals],
          Dependency[passes.InferWidths],
-         Dependency[passes.CheckWidths],
+         Dependency(passes.CheckWidths),
          Dependency[firrtl.transforms.InferResets] )
 
   lazy val Deduped: Seq[TransformDependency] = Resolved :+ Dependency[firrtl.transforms.DedupModules]

--- a/src/main/scala/firrtl/stage/Forms.scala
+++ b/src/main/scala/firrtl/stage/Forms.scala
@@ -14,17 +14,17 @@ import firrtl.stage.TransformManager.TransformDependency
 
 object Forms {
 
-  val ChirrtlForm: Seq[TransformDependency] = Seq.empty
+  def ChirrtlForm: Seq[TransformDependency] = Seq.empty
 
-  val MinimalHighForm: Seq[TransformDependency] = ChirrtlForm ++
+  def MinimalHighForm: Seq[TransformDependency] = ChirrtlForm ++
     Seq( DependencyID[passes.CheckChirrtl],
          DependencyID[passes.CInferTypes],
          DependencyID[passes.CInferMDir],
          DependencyID[passes.RemoveCHIRRTL] )
 
-  val WorkingIR: Seq[TransformDependency] = MinimalHighForm :+ DependencyID[passes.ToWorkingIR]
+  def WorkingIR: Seq[TransformDependency] = MinimalHighForm :+ DependencyID[passes.ToWorkingIR]
 
-  val Resolved: Seq[TransformDependency] = WorkingIR ++
+  def Resolved: Seq[TransformDependency] = WorkingIR ++
     Seq( DependencyID[passes.CheckHighForm],
          DependencyID[passes.ResolveKinds],
          DependencyID[passes.InferTypes],
@@ -38,15 +38,15 @@ object Forms {
          DependencyID[passes.CheckWidths],
          DependencyID[firrtl.transforms.InferResets] )
 
-  val Deduped: Seq[TransformDependency] = Resolved :+ DependencyID[firrtl.transforms.DedupModules]
+  def Deduped: Seq[TransformDependency] = Resolved :+ DependencyID[firrtl.transforms.DedupModules]
 
-  val HighForm: Seq[TransformDependency] = ChirrtlForm ++
+  def HighForm: Seq[TransformDependency] = ChirrtlForm ++
     MinimalHighForm ++
     WorkingIR ++
     Resolved ++
     Deduped
 
-  val MidForm: Seq[TransformDependency] = HighForm ++
+  def MidForm: Seq[TransformDependency] = HighForm ++
     Seq( DependencyID[passes.PullMuxes],
          DependencyID[passes.ReplaceAccesses],
          DependencyID[passes.ExpandConnects],
@@ -56,7 +56,7 @@ object Forms {
          DependencyID[passes.ConvertFixedToSInt],
          DependencyID[passes.ZeroWidth] )
 
-  val LowForm: Seq[TransformDependency] = MidForm ++
+  def LowForm: Seq[TransformDependency] = MidForm ++
     Seq( DependencyID[passes.LowerTypes],
          DependencyID[passes.Legalize],
          DependencyID[firrtl.transforms.RemoveReset],
@@ -64,19 +64,19 @@ object Forms {
          DependencyID[checks.CheckResets],
          DependencyID[firrtl.transforms.RemoveWires] )
 
-  val LowFormMinimumOptimized: Seq[TransformDependency] = LowForm ++
+  def LowFormMinimumOptimized: Seq[TransformDependency] = LowForm ++
     Seq( DependencyID[passes.RemoveValidIf],
          DependencyID[passes.memlib.VerilogMemDelays],
          DependencyID[passes.SplitExpressions] )
 
-  val LowFormOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
+  def LowFormOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
     Seq( DependencyID[firrtl.transforms.ConstantPropagation],
          DependencyID[passes.PadWidths],
          DependencyID[firrtl.transforms.CombineCats],
          DependencyID[passes.CommonSubexpressionElimination],
          DependencyID[firrtl.transforms.DeadCodeElimination] )
 
-  val VerilogMinimumOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
+  def VerilogMinimumOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
     Seq( DependencyID[firrtl.transforms.BlackBoxSourceHelper],
          DependencyID[firrtl.transforms.ReplaceTruncatingArithmetic],
          DependencyID[firrtl.transforms.FlattenRegUpdate],
@@ -85,7 +85,7 @@ object Forms {
          DependencyID[passes.VerilogPrep],
          DependencyID[firrtl.AddDescriptionNodes] )
 
-  val VerilogOptimized: Seq[TransformDependency] = LowFormOptimized ++
+  def VerilogOptimized: Seq[TransformDependency] = LowFormOptimized ++
     Seq( DependencyID[firrtl.transforms.BlackBoxSourceHelper],
          DependencyID[firrtl.transforms.ReplaceTruncatingArithmetic],
          DependencyID[firrtl.transforms.FlattenRegUpdate],

--- a/src/main/scala/firrtl/stage/Forms.scala
+++ b/src/main/scala/firrtl/stage/Forms.scala
@@ -57,7 +57,7 @@ object Forms {
          DependencyID[passes.ZeroWidth] )
 
   def LowForm: Seq[TransformDependency] = MidForm ++
-    Seq( DependencyID[passes.LowerTypes],
+    Seq( DependencyID(passes.LowerTypes),
          DependencyID[passes.Legalize],
          DependencyID[firrtl.transforms.RemoveReset],
          DependencyID[firrtl.transforms.CheckCombLoops],

--- a/src/main/scala/firrtl/stage/TransformManager.scala
+++ b/src/main/scala/firrtl/stage/TransformManager.scala
@@ -3,7 +3,7 @@
 package firrtl.stage
 
 import firrtl.{CircuitForm, CircuitState, Transform, UnknownForm}
-import firrtl.options.DependencyManager
+import firrtl.options.{DependencyID, DependencyManager}
 
 /** A [[Transform]] that ensures some other [[Transform]]s and their prerequisites are executed.
   *
@@ -29,6 +29,6 @@ class TransformManager(
 object TransformManager {
 
   /** The type used to represent dependencies between [[Transform]]s */
-  type TransformDependency = Class[_ <: Transform]
+  type TransformDependency = DependencyID[Transform]
 
 }

--- a/src/main/scala/firrtl/stage/TransformManager.scala
+++ b/src/main/scala/firrtl/stage/TransformManager.scala
@@ -22,7 +22,7 @@ class TransformManager(
 
   override def execute(state: CircuitState): CircuitState = transform(state)
 
-  override protected def copy(a: Seq[Dependency], b: Seq[Dependency], c: Set[Transform]) = new TransformManager(a, b, c)
+  override protected def copy(a: Seq[DependencyID[Transform]], b: Seq[DependencyID[Transform]], c: Set[Transform]) = new TransformManager(a, b, c)
 
 }
 

--- a/src/main/scala/firrtl/stage/TransformManager.scala
+++ b/src/main/scala/firrtl/stage/TransformManager.scala
@@ -3,7 +3,7 @@
 package firrtl.stage
 
 import firrtl.{CircuitForm, CircuitState, Transform, UnknownForm}
-import firrtl.options.{DependencyID, DependencyManager}
+import firrtl.options.{Dependency, DependencyManager}
 
 /** A [[Transform]] that ensures some other [[Transform]]s and their prerequisites are executed.
   *
@@ -22,13 +22,13 @@ class TransformManager(
 
   override def execute(state: CircuitState): CircuitState = transform(state)
 
-  override protected def copy(a: Seq[DependencyID[Transform]], b: Seq[DependencyID[Transform]], c: Set[Transform]) = new TransformManager(a, b, c)
+  override protected def copy(a: Seq[Dependency[Transform]], b: Seq[Dependency[Transform]], c: Set[Transform]) = new TransformManager(a, b, c)
 
 }
 
 object TransformManager {
 
   /** The type used to represent dependencies between [[Transform]]s */
-  type TransformDependency = DependencyID[Transform]
+  type TransformDependency = Dependency[Transform]
 
 }

--- a/src/main/scala/firrtl/stage/phases/AddCircuit.scala
+++ b/src/main/scala/firrtl/stage/phases/AddCircuit.scala
@@ -5,7 +5,7 @@ package firrtl.stage.phases
 import firrtl.stage._
 
 import firrtl.{AnnotationSeq, Parser}
-import firrtl.options.{Phase, PhasePrerequisiteException, PreservesAll}
+import firrtl.options.{DependencyID, Phase, PhasePrerequisiteException, PreservesAll}
 
 /** [[firrtl.options.Phase Phase]] that expands [[FirrtlFileAnnotation]]/[[FirrtlSourceAnnotation]] into
   * [[FirrtlCircuitAnnotation]]s and deletes the originals. This is part of the preprocessing done on an input
@@ -27,7 +27,7 @@ import firrtl.options.{Phase, PhasePrerequisiteException, PreservesAll}
   */
 class AddCircuit extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(classOf[AddDefaults], classOf[Checks])
+  override val prerequisites = Seq(DependencyID[AddDefaults], DependencyID[Checks])
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/stage/phases/AddCircuit.scala
+++ b/src/main/scala/firrtl/stage/phases/AddCircuit.scala
@@ -5,7 +5,7 @@ package firrtl.stage.phases
 import firrtl.stage._
 
 import firrtl.{AnnotationSeq, Parser}
-import firrtl.options.{DependencyID, Phase, PhasePrerequisiteException, PreservesAll}
+import firrtl.options.{Dependency, Phase, PhasePrerequisiteException, PreservesAll}
 
 /** [[firrtl.options.Phase Phase]] that expands [[FirrtlFileAnnotation]]/[[FirrtlSourceAnnotation]] into
   * [[FirrtlCircuitAnnotation]]s and deletes the originals. This is part of the preprocessing done on an input
@@ -27,7 +27,7 @@ import firrtl.options.{DependencyID, Phase, PhasePrerequisiteException, Preserve
   */
 class AddCircuit extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(DependencyID[AddDefaults], DependencyID[Checks])
+  override val prerequisites = Seq(Dependency[AddDefaults], Dependency[Checks])
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/stage/phases/AddImplicitEmitter.scala
+++ b/src/main/scala/firrtl/stage/phases/AddImplicitEmitter.scala
@@ -4,14 +4,14 @@ package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, EmitAnnotation, EmitCircuitAnnotation}
 import firrtl.stage.{CompilerAnnotation, RunFirrtlTransformAnnotation}
-import firrtl.options.{Phase, PreservesAll}
+import firrtl.options.{DependencyID, Phase, PreservesAll}
 
 /** [[firrtl.options.Phase Phase]] that adds a [[firrtl.EmitCircuitAnnotation EmitCircuitAnnotation]] derived from a
   * [[firrtl.stage.CompilerAnnotation CompilerAnnotation]] if one does not already exist.
   */
 class AddImplicitEmitter extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(classOf[AddDefaults])
+  override val prerequisites = Seq(DependencyID[AddDefaults])
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/stage/phases/AddImplicitEmitter.scala
+++ b/src/main/scala/firrtl/stage/phases/AddImplicitEmitter.scala
@@ -4,14 +4,14 @@ package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, EmitAnnotation, EmitCircuitAnnotation}
 import firrtl.stage.{CompilerAnnotation, RunFirrtlTransformAnnotation}
-import firrtl.options.{DependencyID, Phase, PreservesAll}
+import firrtl.options.{Dependency, Phase, PreservesAll}
 
 /** [[firrtl.options.Phase Phase]] that adds a [[firrtl.EmitCircuitAnnotation EmitCircuitAnnotation]] derived from a
   * [[firrtl.stage.CompilerAnnotation CompilerAnnotation]] if one does not already exist.
   */
 class AddImplicitEmitter extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(DependencyID[AddDefaults])
+  override val prerequisites = Seq(Dependency[AddDefaults])
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
+++ b/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
@@ -3,7 +3,7 @@
 package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, EmitAllModulesAnnotation}
-import firrtl.options.{Phase, PreservesAll, Viewer}
+import firrtl.options.{DependencyID, Phase, PreservesAll, Viewer}
 import firrtl.stage.{FirrtlOptions, OutputFileAnnotation}
 
 /** [[firrtl.options.Phase Phase]] that adds an [[OutputFileAnnotation]] if one does not already exist.
@@ -22,7 +22,7 @@ import firrtl.stage.{FirrtlOptions, OutputFileAnnotation}
   */
 class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(classOf[AddCircuit])
+  override val prerequisites = Seq(DependencyID[AddCircuit])
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
+++ b/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
@@ -3,7 +3,7 @@
 package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, EmitAllModulesAnnotation}
-import firrtl.options.{DependencyID, Phase, PreservesAll, Viewer}
+import firrtl.options.{Dependency, Phase, PreservesAll, Viewer}
 import firrtl.stage.{FirrtlOptions, OutputFileAnnotation}
 
 /** [[firrtl.options.Phase Phase]] that adds an [[OutputFileAnnotation]] if one does not already exist.
@@ -22,7 +22,7 @@ import firrtl.stage.{FirrtlOptions, OutputFileAnnotation}
   */
 class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(DependencyID[AddCircuit])
+  override val prerequisites = Seq(Dependency[AddCircuit])
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/stage/phases/Checks.scala
+++ b/src/main/scala/firrtl/stage/phases/Checks.scala
@@ -6,7 +6,7 @@ import firrtl.stage._
 
 import firrtl.{AnnotationSeq, EmitAllModulesAnnotation, EmitCircuitAnnotation}
 import firrtl.annotations.Annotation
-import firrtl.options.{OptionsException, Phase, PreservesAll}
+import firrtl.options.{DependencyID, OptionsException, Phase, PreservesAll}
 
 /** [[firrtl.options.Phase Phase]] that strictly validates an [[AnnotationSeq]]. The checks applied are intended to be
   * extremeley strict. Nothing is inferred or assumed to take a default value (for default value resolution see
@@ -18,7 +18,7 @@ import firrtl.options.{OptionsException, Phase, PreservesAll}
   */
 class Checks extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(classOf[AddDefaults], classOf[AddImplicitEmitter])
+  override val prerequisites = Seq(DependencyID[AddDefaults], DependencyID[AddImplicitEmitter])
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/stage/phases/Checks.scala
+++ b/src/main/scala/firrtl/stage/phases/Checks.scala
@@ -6,7 +6,7 @@ import firrtl.stage._
 
 import firrtl.{AnnotationSeq, EmitAllModulesAnnotation, EmitCircuitAnnotation}
 import firrtl.annotations.Annotation
-import firrtl.options.{DependencyID, OptionsException, Phase, PreservesAll}
+import firrtl.options.{Dependency, OptionsException, Phase, PreservesAll}
 
 /** [[firrtl.options.Phase Phase]] that strictly validates an [[AnnotationSeq]]. The checks applied are intended to be
   * extremeley strict. Nothing is inferred or assumed to take a default value (for default value resolution see
@@ -18,7 +18,7 @@ import firrtl.options.{DependencyID, OptionsException, Phase, PreservesAll}
   */
 class Checks extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(DependencyID[AddDefaults], DependencyID[AddImplicitEmitter])
+  override val prerequisites = Seq(Dependency[AddDefaults], Dependency[AddImplicitEmitter])
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/stage/phases/Compiler.scala
+++ b/src/main/scala/firrtl/stage/phases/Compiler.scala
@@ -3,7 +3,7 @@
 package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, ChirrtlForm, CircuitState, Compiler => FirrtlCompiler, Transform, seqToAnnoSeq}
-import firrtl.options.{DependencyID, Phase, PhasePrerequisiteException, PreservesAll, Translator}
+import firrtl.options.{Dependency, Phase, PhasePrerequisiteException, PreservesAll, Translator}
 import firrtl.stage.{CompilerAnnotation, FirrtlCircuitAnnotation, Forms, RunFirrtlTransformAnnotation}
 import firrtl.stage.TransformManager.TransformDependency
 
@@ -45,13 +45,13 @@ private [stage] case class Defaults(
 class Compiler extends Phase with Translator[AnnotationSeq, Seq[CompilerRun]] with PreservesAll[Phase] {
 
   override val prerequisites =
-    Seq(DependencyID[AddDefaults],
-        DependencyID[AddImplicitEmitter],
-        DependencyID[Checks],
-        DependencyID[AddCircuit],
-        DependencyID[AddImplicitOutputFile])
+    Seq(Dependency[AddDefaults],
+        Dependency[AddImplicitEmitter],
+        Dependency[Checks],
+        Dependency[AddCircuit],
+        Dependency[AddImplicitOutputFile])
 
-  override val dependents = Seq(DependencyID[WriteEmitted])
+  override val dependents = Seq(Dependency[WriteEmitted])
 
   /** Convert an [[AnnotationSeq]] into a sequence of compiler runs. */
   protected def aToB(a: AnnotationSeq): Seq[CompilerRun] = {
@@ -95,7 +95,7 @@ class Compiler extends Phase with Translator[AnnotationSeq, Seq[CompilerRun]] wi
   protected def internalTransform(b: Seq[CompilerRun]): Seq[CompilerRun] = {
     def f(c: CompilerRun): CompilerRun = {
       val targets = c.compiler match {
-        case Some(d) => c.transforms.reverse.map(DependencyID.fromTransform(_)) ++ compilerToTransforms(d)
+        case Some(d) => c.transforms.reverse.map(Dependency.fromTransform(_)) ++ compilerToTransforms(d)
         case None    => throw new PhasePrerequisiteException("No compiler specified!") }
       val tm = new firrtl.stage.transforms.Compiler(targets)
       val (timeMillis, annotationsOut) = firrtl.Utils.time { tm.transform(c.stateIn) }

--- a/src/main/scala/firrtl/stage/phases/Compiler.scala
+++ b/src/main/scala/firrtl/stage/phases/Compiler.scala
@@ -95,7 +95,7 @@ class Compiler extends Phase with Translator[AnnotationSeq, Seq[CompilerRun]] wi
   protected def internalTransform(b: Seq[CompilerRun]): Seq[CompilerRun] = {
     def f(c: CompilerRun): CompilerRun = {
       val targets = c.compiler match {
-        case Some(d) => c.transforms.reverse.map(t => DependencyID(t.getClass)) ++ compilerToTransforms(d)
+        case Some(d) => c.transforms.reverse.map(DependencyID.fromTransform(_)) ++ compilerToTransforms(d)
         case None    => throw new PhasePrerequisiteException("No compiler specified!") }
       val tm = new firrtl.stage.transforms.Compiler(targets)
       val (timeMillis, annotationsOut) = firrtl.Utils.time { tm.transform(c.stateIn) }

--- a/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
+++ b/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
@@ -10,6 +10,7 @@ import firrtl.FileUtils
 import firrtl.proto.FromProto
 import firrtl.options.{InputAnnotationFileAnnotation, OptionsException, Phase, PreservesAll, StageOptions, StageUtils}
 import firrtl.options.Viewer
+import firrtl.options.DependencyID
 
 import scopt.OptionParser
 
@@ -123,9 +124,9 @@ object DriverCompatibility {
     */
   class AddImplicitAnnotationFile extends Phase with PreservesAll[Phase] {
 
-    override val prerequisites = Seq(classOf[AddImplicitFirrtlFile])
+    override val prerequisites = Seq(DependencyID[AddImplicitFirrtlFile])
 
-    override val dependents = Seq(classOf[FirrtlPhase], classOf[FirrtlStage])
+    override val dependents = Seq(DependencyID[FirrtlPhase], DependencyID[FirrtlStage])
 
     /** Try to add an [[firrtl.options.InputAnnotationFileAnnotation InputAnnotationFileAnnotation]] implicitly specified by
       * an [[AnnotationSeq]]. */
@@ -164,7 +165,7 @@ object DriverCompatibility {
 
     override val prerequisites = Seq.empty
 
-    override val dependents = Seq(classOf[FirrtlPhase], classOf[FirrtlStage])
+    override val dependents = Seq(DependencyID[FirrtlPhase], DependencyID[FirrtlStage])
 
     /** Try to add a [[FirrtlFileAnnotation]] implicitly specified by an [[AnnotationSeq]]. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {
@@ -195,7 +196,7 @@ object DriverCompatibility {
 
     override val prerequisites = Seq.empty
 
-    override val dependents = Seq(classOf[FirrtlPhase], classOf[FirrtlStage])
+    override val dependents = Seq(DependencyID[FirrtlPhase], DependencyID[FirrtlStage])
 
     /** Add one [[EmitAnnotation]] foreach [[CompilerAnnotation]]. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {
@@ -219,9 +220,9 @@ object DriverCompatibility {
               "1.2")
   class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
 
-    override val prerequisites = Seq(classOf[AddImplicitFirrtlFile])
+    override val prerequisites = Seq(DependencyID[AddImplicitFirrtlFile])
 
-    override val dependents = Seq(classOf[FirrtlPhase], classOf[FirrtlStage])
+    override val dependents = Seq(DependencyID[FirrtlPhase], DependencyID[FirrtlStage])
 
     /** Add an [[OutputFileAnnotation]] derived from a [[TopNameAnnotation]] if needed. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
+++ b/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
@@ -10,7 +10,7 @@ import firrtl.FileUtils
 import firrtl.proto.FromProto
 import firrtl.options.{InputAnnotationFileAnnotation, OptionsException, Phase, PreservesAll, StageOptions, StageUtils}
 import firrtl.options.Viewer
-import firrtl.options.DependencyID
+import firrtl.options.Dependency
 
 import scopt.OptionParser
 
@@ -124,9 +124,9 @@ object DriverCompatibility {
     */
   class AddImplicitAnnotationFile extends Phase with PreservesAll[Phase] {
 
-    override val prerequisites = Seq(DependencyID[AddImplicitFirrtlFile])
+    override val prerequisites = Seq(Dependency[AddImplicitFirrtlFile])
 
-    override val dependents = Seq(DependencyID[FirrtlPhase], DependencyID[FirrtlStage])
+    override val dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
 
     /** Try to add an [[firrtl.options.InputAnnotationFileAnnotation InputAnnotationFileAnnotation]] implicitly specified by
       * an [[AnnotationSeq]]. */
@@ -165,7 +165,7 @@ object DriverCompatibility {
 
     override val prerequisites = Seq.empty
 
-    override val dependents = Seq(DependencyID[FirrtlPhase], DependencyID[FirrtlStage])
+    override val dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
 
     /** Try to add a [[FirrtlFileAnnotation]] implicitly specified by an [[AnnotationSeq]]. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {
@@ -196,7 +196,7 @@ object DriverCompatibility {
 
     override val prerequisites = Seq.empty
 
-    override val dependents = Seq(DependencyID[FirrtlPhase], DependencyID[FirrtlStage])
+    override val dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
 
     /** Add one [[EmitAnnotation]] foreach [[CompilerAnnotation]]. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {
@@ -220,9 +220,9 @@ object DriverCompatibility {
               "1.2")
   class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
 
-    override val prerequisites = Seq(DependencyID[AddImplicitFirrtlFile])
+    override val prerequisites = Seq(Dependency[AddImplicitFirrtlFile])
 
-    override val dependents = Seq(DependencyID[FirrtlPhase], DependencyID[FirrtlStage])
+    override val dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
 
     /** Add an [[OutputFileAnnotation]] derived from a [[TopNameAnnotation]] if needed. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/stage/transforms/TrackTransforms.scala
+++ b/src/main/scala/firrtl/stage/transforms/TrackTransforms.scala
@@ -4,7 +4,7 @@ package firrtl.stage.transforms
 
 import firrtl.{AnnotationSeq, CircuitState, Transform}
 import firrtl.annotations.NoTargetAnnotation
-import firrtl.options.DependencyManagerException
+import firrtl.options.{DependencyID, DependencyManagerException}
 
 case class TransformHistoryAnnotation(history: Seq[Transform], state: Set[Transform]) extends NoTargetAnnotation {
 
@@ -47,7 +47,7 @@ class TrackTransforms(val underlying: Transform) extends Transform with WrappedT
     val state = c.annotations
       .collectFirst{ case TransformHistoryAnnotation(_, state) => state }
       .getOrElse(Set.empty[Transform])
-      .map(_.getClass)
+      .map(t => DependencyID(t.getClass))
 
     if (!trueUnderlying.prerequisites.toSet.subsetOf(state)) {
       throw new DependencyManagerException(

--- a/src/main/scala/firrtl/stage/transforms/TrackTransforms.scala
+++ b/src/main/scala/firrtl/stage/transforms/TrackTransforms.scala
@@ -4,7 +4,7 @@ package firrtl.stage.transforms
 
 import firrtl.{AnnotationSeq, CircuitState, Transform}
 import firrtl.annotations.NoTargetAnnotation
-import firrtl.options.{DependencyID, DependencyManagerException}
+import firrtl.options.{Dependency, DependencyManagerException}
 
 case class TransformHistoryAnnotation(history: Seq[Transform], state: Set[Transform]) extends NoTargetAnnotation {
 
@@ -47,7 +47,7 @@ class TrackTransforms(val underlying: Transform) extends Transform with WrappedT
     val state = c.annotations
       .collectFirst{ case TransformHistoryAnnotation(_, state) => state }
       .getOrElse(Set.empty[Transform])
-      .map(DependencyID.fromTransform(_))
+      .map(Dependency.fromTransform(_))
 
     if (!trueUnderlying.prerequisites.toSet.subsetOf(state)) {
       throw new DependencyManagerException(

--- a/src/main/scala/firrtl/stage/transforms/TrackTransforms.scala
+++ b/src/main/scala/firrtl/stage/transforms/TrackTransforms.scala
@@ -47,7 +47,7 @@ class TrackTransforms(val underlying: Transform) extends Transform with WrappedT
     val state = c.annotations
       .collectFirst{ case TransformHistoryAnnotation(_, state) => state }
       .getOrElse(Set.empty[Transform])
-      .map(t => DependencyID(t.getClass))
+      .map(DependencyID.fromTransform(_))
 
     if (!trueUnderlying.prerequisites.toSet.subsetOf(state)) {
       throw new DependencyManagerException(

--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -6,6 +6,7 @@ import java.io.{File, FileNotFoundException, FileInputStream, FileOutputStream, 
 
 import firrtl._
 import firrtl.annotations._
+import firrtl.options.DependencyID
 
 import scala.collection.immutable.ListSet
 

--- a/src/main/scala/firrtl/transforms/CheckCombLoops.scala
+++ b/src/main/scala/firrtl/transforms/CheckCombLoops.scala
@@ -4,7 +4,6 @@ package firrtl.transforms
 
 import scala.collection.mutable
 
-
 import firrtl._
 import firrtl.ir._
 import firrtl.passes.{Errors, PassException}
@@ -13,7 +12,7 @@ import firrtl.annotations._
 import firrtl.Utils.throwInternalError
 import firrtl.graph._
 import firrtl.analyses.InstanceGraph
-import firrtl.options.{PreservesAll, RegisteredTransform, ShellOption}
+import firrtl.options.{DependencyID, PreservesAll, RegisteredTransform, ShellOption}
 
 /*
  * A case class that represents a net in the circuit. This is
@@ -100,9 +99,9 @@ class CheckCombLoops extends Transform with RegisteredTransform with PreservesAl
   def outputForm = LowForm
 
   override val prerequisites = firrtl.stage.Forms.MidForm ++
-    Seq( classOf[passes.LowerTypes],
-         classOf[passes.Legalize],
-         classOf[firrtl.transforms.RemoveReset] )
+    Seq( DependencyID[passes.LowerTypes],
+         DependencyID[passes.Legalize],
+         DependencyID[firrtl.transforms.RemoveReset] )
 
   override val optionalPrerequisites = Seq.empty
 

--- a/src/main/scala/firrtl/transforms/CheckCombLoops.scala
+++ b/src/main/scala/firrtl/transforms/CheckCombLoops.scala
@@ -12,7 +12,7 @@ import firrtl.annotations._
 import firrtl.Utils.throwInternalError
 import firrtl.graph._
 import firrtl.analyses.InstanceGraph
-import firrtl.options.{DependencyID, PreservesAll, RegisteredTransform, ShellOption}
+import firrtl.options.{Dependency, PreservesAll, RegisteredTransform, ShellOption}
 
 /*
  * A case class that represents a net in the circuit. This is
@@ -99,9 +99,9 @@ class CheckCombLoops extends Transform with RegisteredTransform with PreservesAl
   def outputForm = LowForm
 
   override val prerequisites = firrtl.stage.Forms.MidForm ++
-    Seq( DependencyID(passes.LowerTypes),
-         DependencyID[passes.Legalize],
-         DependencyID[firrtl.transforms.RemoveReset] )
+    Seq( Dependency(passes.LowerTypes),
+         Dependency[passes.Legalize],
+         Dependency[firrtl.transforms.RemoveReset] )
 
   override val optionalPrerequisites = Seq.empty
 

--- a/src/main/scala/firrtl/transforms/CheckCombLoops.scala
+++ b/src/main/scala/firrtl/transforms/CheckCombLoops.scala
@@ -99,7 +99,7 @@ class CheckCombLoops extends Transform with RegisteredTransform with PreservesAl
   def outputForm = LowForm
 
   override val prerequisites = firrtl.stage.Forms.MidForm ++
-    Seq( DependencyID[passes.LowerTypes],
+    Seq( DependencyID(passes.LowerTypes),
          DependencyID[passes.Legalize],
          DependencyID[firrtl.transforms.RemoveReset] )
 

--- a/src/main/scala/firrtl/transforms/CombineCats.scala
+++ b/src/main/scala/firrtl/transforms/CombineCats.scala
@@ -8,6 +8,7 @@ import firrtl.PrimOps._
 import firrtl.WrappedExpression._
 import firrtl.annotations.NoTargetAnnotation
 import firrtl.options.PreservesAll
+import firrtl.options.DependencyID
 
 import scala.collection.mutable
 
@@ -57,16 +58,16 @@ class CombineCats extends Transform with PreservesAll[Transform] {
   def outputForm: LowForm.type = LowForm
 
   override val prerequisites = firrtl.stage.Forms.LowForm ++
-    Seq( classOf[passes.RemoveValidIf],
-         classOf[firrtl.transforms.ConstantPropagation],
-         classOf[firrtl.passes.memlib.VerilogMemDelays],
-         classOf[firrtl.passes.SplitExpressions] )
+    Seq( DependencyID[passes.RemoveValidIf],
+         DependencyID[firrtl.transforms.ConstantPropagation],
+         DependencyID[firrtl.passes.memlib.VerilogMemDelays],
+         DependencyID[firrtl.passes.SplitExpressions] )
 
   override val optionalPrerequisites = Seq.empty
 
   override val dependents = Seq(
-    classOf[SystemVerilogEmitter],
-    classOf[VerilogEmitter] )
+    DependencyID[SystemVerilogEmitter],
+    DependencyID[VerilogEmitter] )
 
   val defaultMaxCatLen = 10
 

--- a/src/main/scala/firrtl/transforms/CombineCats.scala
+++ b/src/main/scala/firrtl/transforms/CombineCats.scala
@@ -8,7 +8,7 @@ import firrtl.PrimOps._
 import firrtl.WrappedExpression._
 import firrtl.annotations.NoTargetAnnotation
 import firrtl.options.PreservesAll
-import firrtl.options.DependencyID
+import firrtl.options.Dependency
 
 import scala.collection.mutable
 
@@ -58,16 +58,16 @@ class CombineCats extends Transform with PreservesAll[Transform] {
   def outputForm: LowForm.type = LowForm
 
   override val prerequisites = firrtl.stage.Forms.LowForm ++
-    Seq( DependencyID[passes.RemoveValidIf],
-         DependencyID[firrtl.transforms.ConstantPropagation],
-         DependencyID[firrtl.passes.memlib.VerilogMemDelays],
-         DependencyID[firrtl.passes.SplitExpressions] )
+    Seq( Dependency[passes.RemoveValidIf],
+         Dependency[firrtl.transforms.ConstantPropagation],
+         Dependency[firrtl.passes.memlib.VerilogMemDelays],
+         Dependency[firrtl.passes.SplitExpressions] )
 
   override val optionalPrerequisites = Seq.empty
 
   override val dependents = Seq(
-    DependencyID[SystemVerilogEmitter],
-    DependencyID[VerilogEmitter] )
+    Dependency[SystemVerilogEmitter],
+    Dependency[VerilogEmitter] )
 
   val defaultMaxCatLen = 10
 

--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -13,6 +13,7 @@ import firrtl.PrimOps._
 import firrtl.graph.DiGraph
 import firrtl.analyses.InstanceGraph
 import firrtl.annotations.TargetToken.Ref
+import firrtl.options.DependencyID
 
 import annotation.tailrec
 import collection.mutable
@@ -99,16 +100,16 @@ class ConstantPropagation extends Transform with ResolvedAnnotationPaths {
   override val prerequisites =
     ((new mutable.LinkedHashSet())
        ++ firrtl.stage.Forms.LowForm
-       - classOf[firrtl.passes.Legalize]
-       + classOf[firrtl.passes.RemoveValidIf]).toSeq
+       - DependencyID[firrtl.passes.Legalize]
+       + DependencyID[firrtl.passes.RemoveValidIf]).toSeq
 
   override val optionalPrerequisites = Seq.empty
 
   override val dependents =
-    Seq( classOf[firrtl.passes.memlib.VerilogMemDelays],
-         classOf[firrtl.passes.SplitExpressions],
-         classOf[SystemVerilogEmitter],
-         classOf[VerilogEmitter] )
+    Seq( DependencyID[firrtl.passes.memlib.VerilogMemDelays],
+         DependencyID[firrtl.passes.SplitExpressions],
+         DependencyID[SystemVerilogEmitter],
+         DependencyID[VerilogEmitter] )
 
   override def invalidates(a: Transform): Boolean = a match {
     case a: firrtl.passes.Legalize => true

--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -13,7 +13,7 @@ import firrtl.PrimOps._
 import firrtl.graph.DiGraph
 import firrtl.analyses.InstanceGraph
 import firrtl.annotations.TargetToken.Ref
-import firrtl.options.DependencyID
+import firrtl.options.Dependency
 
 import annotation.tailrec
 import collection.mutable
@@ -100,16 +100,16 @@ class ConstantPropagation extends Transform with ResolvedAnnotationPaths {
   override val prerequisites =
     ((new mutable.LinkedHashSet())
        ++ firrtl.stage.Forms.LowForm
-       - DependencyID[firrtl.passes.Legalize]
-       + DependencyID[firrtl.passes.RemoveValidIf]).toSeq
+       - Dependency[firrtl.passes.Legalize]
+       + Dependency[firrtl.passes.RemoveValidIf]).toSeq
 
   override val optionalPrerequisites = Seq.empty
 
   override val dependents =
-    Seq( DependencyID[firrtl.passes.memlib.VerilogMemDelays],
-         DependencyID[firrtl.passes.SplitExpressions],
-         DependencyID[SystemVerilogEmitter],
-         DependencyID[VerilogEmitter] )
+    Seq( Dependency[firrtl.passes.memlib.VerilogMemDelays],
+         Dependency[firrtl.passes.SplitExpressions],
+         Dependency[SystemVerilogEmitter],
+         Dependency[VerilogEmitter] )
 
   override def invalidates(a: Transform): Boolean = a match {
     case a: firrtl.passes.Legalize => true

--- a/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
+++ b/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
@@ -10,7 +10,7 @@ import firrtl.analyses.InstanceGraph
 import firrtl.Mappers._
 import firrtl.Utils.{throwInternalError, kind}
 import firrtl.MemoizedHash._
-import firrtl.options.{PreservesAll, RegisteredTransform, ShellOption}
+import firrtl.options.{DependencyID, PreservesAll, RegisteredTransform, ShellOption}
 
 import collection.mutable
 
@@ -35,23 +35,23 @@ class DeadCodeElimination extends Transform with ResolvedAnnotationPaths with Re
   def outputForm = LowForm
 
   override val prerequisites = firrtl.stage.Forms.LowForm ++
-    Seq( classOf[firrtl.passes.RemoveValidIf],
-         classOf[firrtl.transforms.ConstantPropagation],
-         classOf[firrtl.passes.memlib.VerilogMemDelays],
-         classOf[firrtl.passes.SplitExpressions],
-         classOf[firrtl.transforms.CombineCats],
-         classOf[passes.CommonSubexpressionElimination] )
+    Seq( DependencyID[firrtl.passes.RemoveValidIf],
+         DependencyID[firrtl.transforms.ConstantPropagation],
+         DependencyID[firrtl.passes.memlib.VerilogMemDelays],
+         DependencyID[firrtl.passes.SplitExpressions],
+         DependencyID[firrtl.transforms.CombineCats],
+         DependencyID[passes.CommonSubexpressionElimination] )
 
   override val optionalPrerequisites = Seq.empty
 
   override val dependents =
-    Seq( classOf[firrtl.transforms.BlackBoxSourceHelper],
-         classOf[firrtl.transforms.ReplaceTruncatingArithmetic],
-         classOf[firrtl.transforms.FlattenRegUpdate],
-         classOf[passes.VerilogModulusCleanup],
-         classOf[firrtl.transforms.VerilogRename],
-         classOf[passes.VerilogPrep],
-         classOf[firrtl.AddDescriptionNodes] )
+    Seq( DependencyID[firrtl.transforms.BlackBoxSourceHelper],
+         DependencyID[firrtl.transforms.ReplaceTruncatingArithmetic],
+         DependencyID[firrtl.transforms.FlattenRegUpdate],
+         DependencyID[passes.VerilogModulusCleanup],
+         DependencyID[firrtl.transforms.VerilogRename],
+         DependencyID[passes.VerilogPrep],
+         DependencyID[firrtl.AddDescriptionNodes] )
 
   val options = Seq(
     new ShellOption[Unit](

--- a/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
+++ b/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
@@ -10,7 +10,7 @@ import firrtl.analyses.InstanceGraph
 import firrtl.Mappers._
 import firrtl.Utils.{throwInternalError, kind}
 import firrtl.MemoizedHash._
-import firrtl.options.{DependencyID, PreservesAll, RegisteredTransform, ShellOption}
+import firrtl.options.{Dependency, PreservesAll, RegisteredTransform, ShellOption}
 
 import collection.mutable
 
@@ -35,23 +35,23 @@ class DeadCodeElimination extends Transform with ResolvedAnnotationPaths with Re
   def outputForm = LowForm
 
   override val prerequisites = firrtl.stage.Forms.LowForm ++
-    Seq( DependencyID[firrtl.passes.RemoveValidIf],
-         DependencyID[firrtl.transforms.ConstantPropagation],
-         DependencyID[firrtl.passes.memlib.VerilogMemDelays],
-         DependencyID[firrtl.passes.SplitExpressions],
-         DependencyID[firrtl.transforms.CombineCats],
-         DependencyID[passes.CommonSubexpressionElimination] )
+    Seq( Dependency[firrtl.passes.RemoveValidIf],
+         Dependency[firrtl.transforms.ConstantPropagation],
+         Dependency[firrtl.passes.memlib.VerilogMemDelays],
+         Dependency[firrtl.passes.SplitExpressions],
+         Dependency[firrtl.transforms.CombineCats],
+         Dependency[passes.CommonSubexpressionElimination] )
 
   override val optionalPrerequisites = Seq.empty
 
   override val dependents =
-    Seq( DependencyID[firrtl.transforms.BlackBoxSourceHelper],
-         DependencyID[firrtl.transforms.ReplaceTruncatingArithmetic],
-         DependencyID[firrtl.transforms.FlattenRegUpdate],
-         DependencyID[passes.VerilogModulusCleanup],
-         DependencyID[firrtl.transforms.VerilogRename],
-         DependencyID[passes.VerilogPrep],
-         DependencyID[firrtl.AddDescriptionNodes] )
+    Seq( Dependency[firrtl.transforms.BlackBoxSourceHelper],
+         Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
+         Dependency[firrtl.transforms.FlattenRegUpdate],
+         Dependency[passes.VerilogModulusCleanup],
+         Dependency[firrtl.transforms.VerilogRename],
+         Dependency[passes.VerilogPrep],
+         Dependency[firrtl.AddDescriptionNodes] )
 
   val options = Seq(
     new ShellOption[Unit](

--- a/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
+++ b/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
@@ -6,6 +6,7 @@ package transforms
 import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.Utils._
+import firrtl.options.DependencyID
 
 import scala.collection.mutable
 
@@ -109,8 +110,8 @@ class FlattenRegUpdate extends Transform {
   def outputForm = MidForm
 
   override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
-    Seq( classOf[BlackBoxSourceHelper],
-         classOf[ReplaceTruncatingArithmetic] )
+    Seq( DependencyID[BlackBoxSourceHelper],
+         DependencyID[ReplaceTruncatingArithmetic] )
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
+++ b/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
@@ -6,7 +6,7 @@ package transforms
 import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.Utils._
-import firrtl.options.DependencyID
+import firrtl.options.Dependency
 
 import scala.collection.mutable
 
@@ -110,8 +110,8 @@ class FlattenRegUpdate extends Transform {
   def outputForm = MidForm
 
   override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
-    Seq( DependencyID[BlackBoxSourceHelper],
-         DependencyID[ReplaceTruncatingArithmetic] )
+    Seq( Dependency[BlackBoxSourceHelper],
+         Dependency[ReplaceTruncatingArithmetic] )
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/transforms/InferResets.scala
+++ b/src/main/scala/firrtl/transforms/InferResets.scala
@@ -9,6 +9,7 @@ import firrtl.traversals.Foreachers._
 import firrtl.annotations.{ReferenceTarget, TargetToken}
 import firrtl.Utils.toTarget
 import firrtl.passes.{Pass, PassException, Errors, InferTypes}
+import firrtl.options.DependencyID
 
 import scala.collection.mutable
 import scala.util.Try
@@ -82,11 +83,11 @@ class InferResets extends Transform {
   def outputForm: CircuitForm = UnknownForm
 
   override val prerequisites =
-    Seq( classOf[passes.ResolveKinds],
-         classOf[passes.InferTypes],
-         classOf[passes.Uniquify],
-         classOf[passes.ResolveFlows],
-         classOf[passes.InferWidths] ) ++ stage.Forms.WorkingIR
+    Seq( DependencyID[passes.ResolveKinds],
+         DependencyID[passes.InferTypes],
+         DependencyID[passes.Uniquify],
+         DependencyID[passes.ResolveFlows],
+         DependencyID[passes.InferWidths] ) ++ stage.Forms.WorkingIR
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: checks.CheckResets | _: passes.CheckTypes => true

--- a/src/main/scala/firrtl/transforms/InferResets.scala
+++ b/src/main/scala/firrtl/transforms/InferResets.scala
@@ -90,8 +90,8 @@ class InferResets extends Transform {
          Dependency[passes.InferWidths] ) ++ stage.Forms.WorkingIR
 
   override def invalidates(a: Transform): Boolean = a match {
-    case _: checks.CheckResets | _: passes.CheckTypes => true
-    case _                                            => false
+    case _: checks.CheckResets | passes.CheckTypes => true
+    case _                                         => false
   }
 
   import InferResets._

--- a/src/main/scala/firrtl/transforms/InferResets.scala
+++ b/src/main/scala/firrtl/transforms/InferResets.scala
@@ -9,7 +9,7 @@ import firrtl.traversals.Foreachers._
 import firrtl.annotations.{ReferenceTarget, TargetToken}
 import firrtl.Utils.toTarget
 import firrtl.passes.{Pass, PassException, Errors, InferTypes}
-import firrtl.options.DependencyID
+import firrtl.options.Dependency
 
 import scala.collection.mutable
 import scala.util.Try
@@ -83,11 +83,11 @@ class InferResets extends Transform {
   def outputForm: CircuitForm = UnknownForm
 
   override val prerequisites =
-    Seq( DependencyID[passes.ResolveKinds],
-         DependencyID[passes.InferTypes],
-         DependencyID[passes.Uniquify],
-         DependencyID[passes.ResolveFlows],
-         DependencyID[passes.InferWidths] ) ++ stage.Forms.WorkingIR
+    Seq( Dependency[passes.ResolveKinds],
+         Dependency[passes.InferTypes],
+         Dependency[passes.Uniquify],
+         Dependency[passes.ResolveFlows],
+         Dependency[passes.InferWidths] ) ++ stage.Forms.WorkingIR
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: checks.CheckResets | _: passes.CheckTypes => true

--- a/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
+++ b/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
@@ -10,6 +10,8 @@ import firrtl.ir
 import firrtl.passes.{Uniquify, PassException}
 import firrtl.Utils.v_keywords
 import firrtl.Mappers._
+import firrtl.options.DependencyID
+
 import scala.collection.mutable
 
 /** Transform that removes collisions with reserved keywords
@@ -234,10 +236,10 @@ class RemoveKeywordCollisions(keywords: Set[String]) extends Transform {
 class VerilogRename extends RemoveKeywordCollisions(v_keywords) {
 
   override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
-    Seq( classOf[BlackBoxSourceHelper],
-         classOf[ReplaceTruncatingArithmetic],
-         classOf[FlattenRegUpdate],
-         classOf[passes.VerilogModulusCleanup] )
+    Seq( DependencyID[BlackBoxSourceHelper],
+         DependencyID[ReplaceTruncatingArithmetic],
+         DependencyID[FlattenRegUpdate],
+         DependencyID[passes.VerilogModulusCleanup] )
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
+++ b/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
@@ -10,7 +10,7 @@ import firrtl.ir
 import firrtl.passes.{Uniquify, PassException}
 import firrtl.Utils.v_keywords
 import firrtl.Mappers._
-import firrtl.options.DependencyID
+import firrtl.options.Dependency
 
 import scala.collection.mutable
 
@@ -236,10 +236,10 @@ class RemoveKeywordCollisions(keywords: Set[String]) extends Transform {
 class VerilogRename extends RemoveKeywordCollisions(v_keywords) {
 
   override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
-    Seq( DependencyID[BlackBoxSourceHelper],
-         DependencyID[ReplaceTruncatingArithmetic],
-         DependencyID[FlattenRegUpdate],
-         DependencyID[passes.VerilogModulusCleanup] )
+    Seq( Dependency[BlackBoxSourceHelper],
+         Dependency[ReplaceTruncatingArithmetic],
+         Dependency[FlattenRegUpdate],
+         Dependency[passes.VerilogModulusCleanup] )
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/transforms/RemoveReset.scala
+++ b/src/main/scala/firrtl/transforms/RemoveReset.scala
@@ -8,6 +8,7 @@ import firrtl.Mappers._
 import firrtl.traversals.Foreachers._
 import firrtl.options.PreservesAll
 import firrtl.WrappedExpression.we
+import firrtl.options.DependencyID
 
 import scala.collection.{immutable, mutable}
 
@@ -20,8 +21,8 @@ class RemoveReset extends Transform {
   def outputForm = LowForm
 
   override val prerequisites = firrtl.stage.Forms.MidForm ++
-    Seq( classOf[passes.LowerTypes],
-         classOf[passes.Legalize] )
+    Seq( DependencyID[passes.LowerTypes],
+         DependencyID[passes.Legalize] )
 
   override val optionalPrerequisites = Seq.empty
 

--- a/src/main/scala/firrtl/transforms/RemoveReset.scala
+++ b/src/main/scala/firrtl/transforms/RemoveReset.scala
@@ -8,7 +8,7 @@ import firrtl.Mappers._
 import firrtl.traversals.Foreachers._
 import firrtl.options.PreservesAll
 import firrtl.WrappedExpression.we
-import firrtl.options.DependencyID
+import firrtl.options.Dependency
 
 import scala.collection.{immutable, mutable}
 
@@ -21,8 +21,8 @@ class RemoveReset extends Transform {
   def outputForm = LowForm
 
   override val prerequisites = firrtl.stage.Forms.MidForm ++
-    Seq( DependencyID(passes.LowerTypes),
-         DependencyID[passes.Legalize] )
+    Seq( Dependency(passes.LowerTypes),
+         Dependency[passes.Legalize] )
 
   override val optionalPrerequisites = Seq.empty
 

--- a/src/main/scala/firrtl/transforms/RemoveReset.scala
+++ b/src/main/scala/firrtl/transforms/RemoveReset.scala
@@ -21,7 +21,7 @@ class RemoveReset extends Transform {
   def outputForm = LowForm
 
   override val prerequisites = firrtl.stage.Forms.MidForm ++
-    Seq( DependencyID[passes.LowerTypes],
+    Seq( DependencyID(passes.LowerTypes),
          DependencyID[passes.Legalize] )
 
   override val optionalPrerequisites = Seq.empty

--- a/src/main/scala/firrtl/transforms/RemoveWires.scala
+++ b/src/main/scala/firrtl/transforms/RemoveWires.scala
@@ -9,7 +9,7 @@ import firrtl.Mappers._
 import firrtl.traversals.Foreachers._
 import firrtl.WrappedExpression._
 import firrtl.graph.{MutableDiGraph, CyclicException}
-import firrtl.options.PreservesAll
+import firrtl.options.{DependencyID, PreservesAll}
 
 import scala.collection.mutable
 import scala.util.{Try, Success, Failure}
@@ -25,12 +25,12 @@ class RemoveWires extends Transform with PreservesAll[Transform] {
   def outputForm = LowForm
 
   override val prerequisites = firrtl.stage.Forms.MidForm ++
-    Seq( classOf[passes.LowerTypes],
-         classOf[passes.Legalize],
-         classOf[transforms.RemoveReset],
-         classOf[transforms.CheckCombLoops] )
+    Seq( DependencyID[passes.LowerTypes],
+         DependencyID[passes.Legalize],
+         DependencyID[transforms.RemoveReset],
+         DependencyID[transforms.CheckCombLoops] )
 
-  override val optionalPrerequisites = Seq(classOf[checks.CheckResets])
+  override val optionalPrerequisites = Seq(DependencyID[checks.CheckResets])
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/transforms/RemoveWires.scala
+++ b/src/main/scala/firrtl/transforms/RemoveWires.scala
@@ -9,7 +9,7 @@ import firrtl.Mappers._
 import firrtl.traversals.Foreachers._
 import firrtl.WrappedExpression._
 import firrtl.graph.{MutableDiGraph, CyclicException}
-import firrtl.options.{DependencyID, PreservesAll}
+import firrtl.options.{Dependency, PreservesAll}
 
 import scala.collection.mutable
 import scala.util.{Try, Success, Failure}
@@ -25,12 +25,12 @@ class RemoveWires extends Transform with PreservesAll[Transform] {
   def outputForm = LowForm
 
   override val prerequisites = firrtl.stage.Forms.MidForm ++
-    Seq( DependencyID(passes.LowerTypes),
-         DependencyID[passes.Legalize],
-         DependencyID[transforms.RemoveReset],
-         DependencyID[transforms.CheckCombLoops] )
+    Seq( Dependency(passes.LowerTypes),
+         Dependency[passes.Legalize],
+         Dependency[transforms.RemoveReset],
+         Dependency[transforms.CheckCombLoops] )
 
-  override val optionalPrerequisites = Seq(DependencyID[checks.CheckResets])
+  override val optionalPrerequisites = Seq(Dependency[checks.CheckResets])
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/transforms/RemoveWires.scala
+++ b/src/main/scala/firrtl/transforms/RemoveWires.scala
@@ -25,7 +25,7 @@ class RemoveWires extends Transform with PreservesAll[Transform] {
   def outputForm = LowForm
 
   override val prerequisites = firrtl.stage.Forms.MidForm ++
-    Seq( DependencyID[passes.LowerTypes],
+    Seq( DependencyID(passes.LowerTypes),
          DependencyID[passes.Legalize],
          DependencyID[transforms.RemoveReset],
          DependencyID[transforms.CheckCombLoops] )

--- a/src/main/scala/firrtl/transforms/ReplaceTruncatingArithmetic.scala
+++ b/src/main/scala/firrtl/transforms/ReplaceTruncatingArithmetic.scala
@@ -5,6 +5,7 @@ import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.PrimOps._
 import firrtl.WrappedExpression._
+import firrtl.options.DependencyID
 
 import scala.collection.mutable
 
@@ -66,7 +67,7 @@ class ReplaceTruncatingArithmetic extends Transform {
   def inputForm = LowForm
   def outputForm = LowForm
 
-  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized :+ classOf[BlackBoxSourceHelper]
+  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized :+ DependencyID[BlackBoxSourceHelper]
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/firrtl/transforms/ReplaceTruncatingArithmetic.scala
+++ b/src/main/scala/firrtl/transforms/ReplaceTruncatingArithmetic.scala
@@ -5,7 +5,7 @@ import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.PrimOps._
 import firrtl.WrappedExpression._
-import firrtl.options.DependencyID
+import firrtl.options.Dependency
 
 import scala.collection.mutable
 
@@ -67,7 +67,7 @@ class ReplaceTruncatingArithmetic extends Transform {
   def inputForm = LowForm
   def outputForm = LowForm
 
-  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized :+ DependencyID[BlackBoxSourceHelper]
+  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized :+ Dependency[BlackBoxSourceHelper]
 
   override val dependents = Seq.empty
 

--- a/src/main/scala/logger/phases/Checks.scala
+++ b/src/main/scala/logger/phases/Checks.scala
@@ -4,7 +4,7 @@ package logger.phases
 
 import firrtl.AnnotationSeq
 import firrtl.annotations.Annotation
-import firrtl.options.{Phase, PreservesAll}
+import firrtl.options.{DependencyID, Phase, PreservesAll}
 
 import logger.{LogLevelAnnotation, LogFileAnnotation, LoggerException}
 
@@ -14,7 +14,7 @@ import scala.collection.mutable
   * for a [[Logger]] */
 class Checks extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(classOf[AddDefaults])
+  override val prerequisites = Seq(DependencyID[AddDefaults])
   override val dependents = Seq.empty
 
   /** Ensure that an [[firrtl.AnnotationSeq AnnotationSeq]] has necessary [[Logger]] [[firrtl.annotations.Annotation

--- a/src/main/scala/logger/phases/Checks.scala
+++ b/src/main/scala/logger/phases/Checks.scala
@@ -4,7 +4,7 @@ package logger.phases
 
 import firrtl.AnnotationSeq
 import firrtl.annotations.Annotation
-import firrtl.options.{DependencyID, Phase, PreservesAll}
+import firrtl.options.{Dependency, Phase, PreservesAll}
 
 import logger.{LogLevelAnnotation, LogFileAnnotation, LoggerException}
 
@@ -14,7 +14,7 @@ import scala.collection.mutable
   * for a [[Logger]] */
 class Checks extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(DependencyID[AddDefaults])
+  override val prerequisites = Seq(Dependency[AddDefaults])
   override val dependents = Seq.empty
 
   /** Ensure that an [[firrtl.AnnotationSeq AnnotationSeq]] has necessary [[Logger]] [[firrtl.annotations.Annotation

--- a/src/test/scala/firrtlTests/ChirrtlSpec.scala
+++ b/src/test/scala/firrtlTests/ChirrtlSpec.scala
@@ -7,7 +7,7 @@ import firrtl.passes._
 
 class ChirrtlSpec extends FirrtlFlatSpec {
   def transforms = Seq(
-    new CheckChirrtl,
+    CheckChirrtl,
     new CInferTypes,
     new CInferMDir,
     new RemoveCHIRRTL,

--- a/src/test/scala/firrtlTests/CustomTransformSpec.scala
+++ b/src/test/scala/firrtlTests/CustomTransformSpec.scala
@@ -7,7 +7,7 @@ import firrtl._
 import firrtl.passes.Pass
 import firrtl.ir._
 import firrtl.annotations.{Annotation, NoTargetAnnotation}
-import firrtl.options.DependencyID
+import firrtl.options.Dependency
 import firrtl.stage.{FirrtlSourceAnnotation, FirrtlStage, Forms, RunFirrtlTransformAnnotation}
 import firrtl.transforms.IdentityTransform
 
@@ -149,9 +149,9 @@ class CustomTransformSpec extends FirrtlFlatSpec {
 
   they should "run right before the emitter when inputForm=LowForm" in {
 
-    val custom = DependencyID[IdentityLowForm]
+    val custom = Dependency[IdentityLowForm]
 
-    def testOrder(emitter: DependencyID[Emitter], preceders: Seq[DependencyID[Transform]]): Unit = {
+    def testOrder(emitter: Dependency[Emitter], preceders: Seq[Dependency[Transform]]): Unit = {
       info(s"""${preceders.map(_.getSimpleName).mkString(" -> ")} -> ${custom.getSimpleName} -> ${emitter.getSimpleName} ok!""")
 
       val compiler = new firrtl.stage.transforms.Compiler(Seq(custom, emitter))
@@ -161,14 +161,14 @@ class CustomTransformSpec extends FirrtlFlatSpec {
 
       compiler
         .flattenedTransformOrder
-        .map(DependencyID.fromTransform(_))
+        .map(Dependency.fromTransform(_))
         .containsSlice(expectedSlice) should be (true)
     }
 
-    Seq( (DependencyID[LowFirrtlEmitter],      Seq(Forms.LowForm.last)                 ),
-         (DependencyID[MinimumVerilogEmitter], Seq(Forms.LowFormMinimumOptimized.last) ),
-         (DependencyID[VerilogEmitter],        Seq(Forms.LowFormOptimized.last)        ),
-         (DependencyID[SystemVerilogEmitter],  Seq(Forms.LowFormOptimized.last)        )
+    Seq( (Dependency[LowFirrtlEmitter],      Seq(Forms.LowForm.last)                 ),
+         (Dependency[MinimumVerilogEmitter], Seq(Forms.LowFormMinimumOptimized.last) ),
+         (Dependency[VerilogEmitter],        Seq(Forms.LowFormOptimized.last)        ),
+         (Dependency[SystemVerilogEmitter],  Seq(Forms.LowFormOptimized.last)        )
     ).foreach((testOrder _).tupled)
   }
 

--- a/src/test/scala/firrtlTests/CustomTransformSpec.scala
+++ b/src/test/scala/firrtlTests/CustomTransformSpec.scala
@@ -15,15 +15,6 @@ import scala.reflect.runtime
 
 object CustomTransformSpec {
 
-  private def asDependency(t: Transform): DependencyID[Transform] = {
-    val isSingleton = runtime.currentMirror.reflect(t).symbol.isModuleClass
-    if (isSingleton) {
-      DependencyID(Right(t.asInstanceOf[Transform with Singleton]))
-    } else {
-      DependencyID(Left(t.getClass))
-    }
-  }
-
   class ReplaceExtModuleTransform extends SeqTransform with FirrtlMatchers {
     // Simple module
     val delayModuleString = """
@@ -170,7 +161,7 @@ class CustomTransformSpec extends FirrtlFlatSpec {
 
       compiler
         .flattenedTransformOrder
-        .map(asDependency(_))
+        .map(DependencyID.fromTransform(_))
         .containsSlice(expectedSlice) should be (true)
     }
 

--- a/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
+++ b/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
@@ -6,6 +6,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 import firrtl._
 import firrtl.passes
+import firrtl.options.DependencyID
 import firrtl.stage.{Forms, TransformManager}
 import firrtl.transforms.IdentityTransform
 
@@ -229,7 +230,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
 
   it should "work for Chirrtl -> Chirrtl" in {
     val expected = new Transforms.ChirrtlToChirrtl :: new firrtl.ChirrtlEmitter :: Nil
-    val tm = new TransformManager(classOf[firrtl.ChirrtlEmitter] :: classOf[Transforms.ChirrtlToChirrtl] :: Nil)
+    val tm = new TransformManager(DependencyID[firrtl.ChirrtlEmitter] :: DependencyID[Transforms.ChirrtlToChirrtl] :: Nil)
     compare(expected, tm)
   }
 
@@ -238,7 +239,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       new TransformManager(Forms.HighForm).flattenedTransformOrder ++
         Some(new Transforms.HighToHigh) ++
         (new TransformManager(Forms.MidForm, Forms.HighForm).flattenedTransformOrder)
-    val tm = new TransformManager(Forms.MidForm :+ classOf[Transforms.HighToHigh])
+    val tm = new TransformManager(Forms.MidForm :+ DependencyID[Transforms.HighToHigh])
     compare(expected, tm)
   }
 
@@ -247,7 +248,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       new TransformManager(Forms.HighForm).flattenedTransformOrder ++
         Some(new Transforms.HighToChirrtl) ++
         (new TransformManager(Forms.HighForm, Forms.ChirrtlForm).flattenedTransformOrder)
-    val tm = new TransformManager(Forms.HighForm :+ classOf[Transforms.HighToChirrtl])
+    val tm = new TransformManager(Forms.HighForm :+ DependencyID[Transforms.HighToChirrtl])
     compare(expected, tm)
   }
 
@@ -256,7 +257,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       new TransformManager(Forms.MidForm).flattenedTransformOrder ++
         Some(new Transforms.MidToMid) ++
         (new TransformManager(Forms.LowForm, Forms.MidForm).flattenedTransformOrder)
-    val tm = new TransformManager(Forms.LowForm :+ classOf[Transforms.MidToMid])
+    val tm = new TransformManager(Forms.LowForm :+ DependencyID[Transforms.MidToMid])
     compare(expected, tm)
   }
 
@@ -265,7 +266,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       new TransformManager(Forms.MidForm).flattenedTransformOrder ++
         Some(new Transforms.MidToHigh) ++
         (new TransformManager(Forms.LowForm, Forms.MinimalHighForm).flattenedTransformOrder)
-    val tm = new TransformManager(Forms.LowForm :+ classOf[Transforms.MidToHigh])
+    val tm = new TransformManager(Forms.LowForm :+ DependencyID[Transforms.MidToHigh])
     compare(expected, tm)
   }
 
@@ -274,7 +275,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       new TransformManager(Forms.MidForm).flattenedTransformOrder ++
         Some(new Transforms.MidToChirrtl) ++
         (new TransformManager(Forms.LowForm, Forms.ChirrtlForm).flattenedTransformOrder)
-    val tm = new TransformManager(Forms.LowForm :+ classOf[Transforms.MidToChirrtl])
+    val tm = new TransformManager(Forms.LowForm :+ DependencyID[Transforms.MidToChirrtl])
     compare(expected, tm)
   }
 
@@ -282,7 +283,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
     val expected =
       new TransformManager(Forms.LowFormOptimized).flattenedTransformOrder ++
         Seq(new Transforms.LowToLow)
-    val tm = new TransformManager(Forms.LowFormOptimized :+ classOf[Transforms.LowToLow])
+    val tm = new TransformManager(Forms.LowFormOptimized :+ DependencyID[Transforms.LowToLow])
     compare(expected, tm)
   }
 
@@ -291,7 +292,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       new TransformManager(Forms.LowFormOptimized).flattenedTransformOrder ++
         Seq(new Transforms.LowToMid) ++
         (new TransformManager(Forms.LowFormOptimized, Forms.MidForm).flattenedTransformOrder)
-    val tm = new TransformManager(Forms.LowFormOptimized :+ classOf[Transforms.LowToMid])
+    val tm = new TransformManager(Forms.LowFormOptimized :+ DependencyID[Transforms.LowToMid])
     compare(expected, tm)
   }
 
@@ -300,7 +301,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       new TransformManager(Forms.LowFormOptimized).flattenedTransformOrder ++
         Seq(new Transforms.LowToHigh) ++
         (new TransformManager(Forms.LowFormOptimized, Forms.MinimalHighForm).flattenedTransformOrder)
-    val tm = new TransformManager(Forms.LowFormOptimized :+ classOf[Transforms.LowToHigh])
+    val tm = new TransformManager(Forms.LowFormOptimized :+ DependencyID[Transforms.LowToHigh])
     compare(expected, tm)
   }
 
@@ -309,7 +310,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       new TransformManager(Forms.LowFormOptimized).flattenedTransformOrder ++
         Seq(new Transforms.LowToChirrtl) ++
         (new TransformManager(Forms.LowFormOptimized, Forms.ChirrtlForm).flattenedTransformOrder)
-    val tm = new TransformManager(Forms.LowFormOptimized :+ classOf[Transforms.LowToChirrtl])
+    val tm = new TransformManager(Forms.LowFormOptimized :+ DependencyID[Transforms.LowToChirrtl])
     compare(expected, tm)
   }
 
@@ -317,7 +318,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
     val expected =
       new TransformManager(Forms.LowForm).flattenedTransformOrder ++
         Seq(new Transforms.LowToLow, new firrtl.LowFirrtlEmitter)
-    val tm = (new TransformManager(Seq(classOf[firrtl.LowFirrtlEmitter], classOf[Transforms.LowToLow])))
+    val tm = (new TransformManager(Seq(DependencyID[firrtl.LowFirrtlEmitter], DependencyID[Transforms.LowToLow])))
     compare(expected, tm)
   }
 
@@ -325,7 +326,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
     val expected =
       new TransformManager(Forms.LowFormMinimumOptimized).flattenedTransformOrder ++
         Seq(new Transforms.LowToLow, new firrtl.MinimumVerilogEmitter)
-    val tm = (new TransformManager(Seq(classOf[firrtl.MinimumVerilogEmitter], classOf[Transforms.LowToLow])))
+    val tm = (new TransformManager(Seq(DependencyID[firrtl.MinimumVerilogEmitter], DependencyID[Transforms.LowToLow])))
     compare(expected, tm)
   }
 
@@ -333,7 +334,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
     val expected =
       new TransformManager(Forms.LowFormOptimized).flattenedTransformOrder ++
         Seq(new Transforms.LowToLow, new firrtl.VerilogEmitter)
-    val tm = (new TransformManager(Seq(classOf[firrtl.VerilogEmitter], classOf[Transforms.LowToLow])))
+    val tm = (new TransformManager(Seq(DependencyID[firrtl.VerilogEmitter], DependencyID[Transforms.LowToLow])))
     compare(expected, tm)
   }
 

--- a/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
+++ b/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 import firrtl._
 import firrtl.passes
-import firrtl.options.DependencyID
+import firrtl.options.Dependency
 import firrtl.stage.{Forms, TransformManager}
 import firrtl.transforms.IdentityTransform
 
@@ -230,7 +230,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
 
   it should "work for Chirrtl -> Chirrtl" in {
     val expected = new Transforms.ChirrtlToChirrtl :: new firrtl.ChirrtlEmitter :: Nil
-    val tm = new TransformManager(DependencyID[firrtl.ChirrtlEmitter] :: DependencyID[Transforms.ChirrtlToChirrtl] :: Nil)
+    val tm = new TransformManager(Dependency[firrtl.ChirrtlEmitter] :: Dependency[Transforms.ChirrtlToChirrtl] :: Nil)
     compare(expected, tm)
   }
 
@@ -239,7 +239,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       new TransformManager(Forms.HighForm).flattenedTransformOrder ++
         Some(new Transforms.HighToHigh) ++
         (new TransformManager(Forms.MidForm, Forms.HighForm).flattenedTransformOrder)
-    val tm = new TransformManager(Forms.MidForm :+ DependencyID[Transforms.HighToHigh])
+    val tm = new TransformManager(Forms.MidForm :+ Dependency[Transforms.HighToHigh])
     compare(expected, tm)
   }
 
@@ -248,7 +248,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       new TransformManager(Forms.HighForm).flattenedTransformOrder ++
         Some(new Transforms.HighToChirrtl) ++
         (new TransformManager(Forms.HighForm, Forms.ChirrtlForm).flattenedTransformOrder)
-    val tm = new TransformManager(Forms.HighForm :+ DependencyID[Transforms.HighToChirrtl])
+    val tm = new TransformManager(Forms.HighForm :+ Dependency[Transforms.HighToChirrtl])
     compare(expected, tm)
   }
 
@@ -257,7 +257,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       new TransformManager(Forms.MidForm).flattenedTransformOrder ++
         Some(new Transforms.MidToMid) ++
         (new TransformManager(Forms.LowForm, Forms.MidForm).flattenedTransformOrder)
-    val tm = new TransformManager(Forms.LowForm :+ DependencyID[Transforms.MidToMid])
+    val tm = new TransformManager(Forms.LowForm :+ Dependency[Transforms.MidToMid])
     compare(expected, tm)
   }
 
@@ -266,7 +266,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       new TransformManager(Forms.MidForm).flattenedTransformOrder ++
         Some(new Transforms.MidToHigh) ++
         (new TransformManager(Forms.LowForm, Forms.MinimalHighForm).flattenedTransformOrder)
-    val tm = new TransformManager(Forms.LowForm :+ DependencyID[Transforms.MidToHigh])
+    val tm = new TransformManager(Forms.LowForm :+ Dependency[Transforms.MidToHigh])
     compare(expected, tm)
   }
 
@@ -275,7 +275,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       new TransformManager(Forms.MidForm).flattenedTransformOrder ++
         Some(new Transforms.MidToChirrtl) ++
         (new TransformManager(Forms.LowForm, Forms.ChirrtlForm).flattenedTransformOrder)
-    val tm = new TransformManager(Forms.LowForm :+ DependencyID[Transforms.MidToChirrtl])
+    val tm = new TransformManager(Forms.LowForm :+ Dependency[Transforms.MidToChirrtl])
     compare(expected, tm)
   }
 
@@ -283,7 +283,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
     val expected =
       new TransformManager(Forms.LowFormOptimized).flattenedTransformOrder ++
         Seq(new Transforms.LowToLow)
-    val tm = new TransformManager(Forms.LowFormOptimized :+ DependencyID[Transforms.LowToLow])
+    val tm = new TransformManager(Forms.LowFormOptimized :+ Dependency[Transforms.LowToLow])
     compare(expected, tm)
   }
 
@@ -292,7 +292,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       new TransformManager(Forms.LowFormOptimized).flattenedTransformOrder ++
         Seq(new Transforms.LowToMid) ++
         (new TransformManager(Forms.LowFormOptimized, Forms.MidForm).flattenedTransformOrder)
-    val tm = new TransformManager(Forms.LowFormOptimized :+ DependencyID[Transforms.LowToMid])
+    val tm = new TransformManager(Forms.LowFormOptimized :+ Dependency[Transforms.LowToMid])
     compare(expected, tm)
   }
 
@@ -301,7 +301,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       new TransformManager(Forms.LowFormOptimized).flattenedTransformOrder ++
         Seq(new Transforms.LowToHigh) ++
         (new TransformManager(Forms.LowFormOptimized, Forms.MinimalHighForm).flattenedTransformOrder)
-    val tm = new TransformManager(Forms.LowFormOptimized :+ DependencyID[Transforms.LowToHigh])
+    val tm = new TransformManager(Forms.LowFormOptimized :+ Dependency[Transforms.LowToHigh])
     compare(expected, tm)
   }
 
@@ -310,7 +310,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       new TransformManager(Forms.LowFormOptimized).flattenedTransformOrder ++
         Seq(new Transforms.LowToChirrtl) ++
         (new TransformManager(Forms.LowFormOptimized, Forms.ChirrtlForm).flattenedTransformOrder)
-    val tm = new TransformManager(Forms.LowFormOptimized :+ DependencyID[Transforms.LowToChirrtl])
+    val tm = new TransformManager(Forms.LowFormOptimized :+ Dependency[Transforms.LowToChirrtl])
     compare(expected, tm)
   }
 
@@ -318,7 +318,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
     val expected =
       new TransformManager(Forms.LowForm).flattenedTransformOrder ++
         Seq(new Transforms.LowToLow, new firrtl.LowFirrtlEmitter)
-    val tm = (new TransformManager(Seq(DependencyID[firrtl.LowFirrtlEmitter], DependencyID[Transforms.LowToLow])))
+    val tm = (new TransformManager(Seq(Dependency[firrtl.LowFirrtlEmitter], Dependency[Transforms.LowToLow])))
     compare(expected, tm)
   }
 
@@ -326,7 +326,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
     val expected =
       new TransformManager(Forms.LowFormMinimumOptimized).flattenedTransformOrder ++
         Seq(new Transforms.LowToLow, new firrtl.MinimumVerilogEmitter)
-    val tm = (new TransformManager(Seq(DependencyID[firrtl.MinimumVerilogEmitter], DependencyID[Transforms.LowToLow])))
+    val tm = (new TransformManager(Seq(Dependency[firrtl.MinimumVerilogEmitter], Dependency[Transforms.LowToLow])))
     compare(expected, tm)
   }
 
@@ -334,7 +334,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
     val expected =
       new TransformManager(Forms.LowFormOptimized).flattenedTransformOrder ++
         Seq(new Transforms.LowToLow, new firrtl.VerilogEmitter)
-    val tm = (new TransformManager(Seq(DependencyID[firrtl.VerilogEmitter], DependencyID[Transforms.LowToLow])))
+    val tm = (new TransformManager(Seq(Dependency[firrtl.VerilogEmitter], Dependency[Transforms.LowToLow])))
     compare(expected, tm)
   }
 

--- a/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
+++ b/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
@@ -37,25 +37,25 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
 
   def legacyTransforms(a: CoreTransform): Seq[Transform] = a match {
     case _: ChirrtlToHighFirrtl => Seq(
-      new passes.CheckChirrtl,
+      passes.CheckChirrtl,
       new passes.CInferTypes,
       new passes.CInferMDir,
       new passes.RemoveCHIRRTL)
     case _: IRToWorkingIR => Seq(new passes.ToWorkingIR)
     case _: ResolveAndCheck => Seq(
-      new passes.CheckHighForm,
+      passes.CheckHighForm,
       new passes.ResolveKinds,
       new passes.InferTypes,
-      new passes.CheckTypes,
+      passes.CheckTypes,
       new passes.Uniquify,
       new passes.ResolveKinds,
       new passes.InferTypes,
       new passes.ResolveFlows,
-      new passes.CheckFlows,
+      passes.CheckFlows,
       new passes.InferBinaryPoints,
       new passes.TrimIntervals,
       new passes.InferWidths,
-      new passes.CheckWidths,
+      passes.CheckWidths,
       new firrtl.transforms.InferResets)
     case _: HighFirrtlToMiddleFirrtl => Seq(
       new passes.PullMuxes,
@@ -64,13 +64,13 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       new passes.RemoveAccesses,
       new passes.Uniquify,
       new passes.ExpandWhens,
-      new passes.CheckInitialization,
+      passes.CheckInitialization,
       new passes.ResolveKinds,
       new passes.InferTypes,
-      new passes.CheckTypes,
+      passes.CheckTypes,
       new passes.ResolveFlows,
       new passes.InferWidths,
-      new passes.CheckWidths,
+      passes.CheckWidths,
       new passes.RemoveIntervals,
       new passes.ConvertFixedToSInt,
       new passes.ZeroWidth,

--- a/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
+++ b/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
@@ -76,7 +76,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       new passes.ZeroWidth,
       new passes.InferTypes)
     case _: MiddleFirrtlToLowFirrtl => Seq(
-      new passes.LowerTypes,
+      passes.LowerTypes,
       new passes.ResolveKinds,
       new passes.InferTypes,
       new passes.ResolveFlows,

--- a/src/test/scala/firrtlTests/options/PhaseManagerSpec.scala
+++ b/src/test/scala/firrtlTests/options/PhaseManagerSpec.scala
@@ -5,7 +5,7 @@ package firrtlTests.options
 import org.scalatest.{FlatSpec, Matchers}
 
 import firrtl.AnnotationSeq
-import firrtl.options.{DependencyManagerException, Phase, PhaseManager, PreservesAll, DependencyID}
+import firrtl.options.{DependencyManagerException, Phase, PhaseManager, PreservesAll, Dependency}
 
 import java.io.{File, PrintWriter}
 
@@ -23,19 +23,19 @@ class A extends IdentityPhase {
 
 /** [[Phase]] that requires [[A]] and invalidates nothing */
 class B extends IdentityPhase {
-  override def prerequisites = Seq(DependencyID[A])
+  override def prerequisites = Seq(Dependency[A])
   override def invalidates(phase: Phase): Boolean = false
 }
 
 /** [[Phase]] that requires [[B]] and invalidates nothing */
 class C extends IdentityPhase {
-  override def prerequisites = Seq(DependencyID[A])
+  override def prerequisites = Seq(Dependency[A])
   override def invalidates(phase: Phase): Boolean = false
 }
 
 /** [[Phase]] that requires [[A]] and invalidates [[A]] */
 class D extends IdentityPhase {
-  override def prerequisites = Seq(DependencyID[A])
+  override def prerequisites = Seq(Dependency[A])
   override def invalidates(phase: Phase): Boolean = phase match {
     case _: A => true
     case _ => false
@@ -44,13 +44,13 @@ class D extends IdentityPhase {
 
 /** [[Phase]] that requires [[B]] and invalidates nothing */
 class E extends IdentityPhase {
-  override def prerequisites = Seq(DependencyID[B])
+  override def prerequisites = Seq(Dependency[B])
   override def invalidates(phase: Phase): Boolean = false
 }
 
 /** [[Phase]] that requires [[B]] and [[C]] and invalidates [[E]] */
 class F extends IdentityPhase {
-  override def prerequisites = Seq(DependencyID[B], DependencyID[C])
+  override def prerequisites = Seq(Dependency[B], Dependency[C])
   override def invalidates(phase: Phase): Boolean = phase match {
     case _: E => true
     case _ => false
@@ -60,7 +60,7 @@ class F extends IdentityPhase {
 
 /** [[Phase]] that requires [[C]] and invalidates [[F]] */
 class G extends IdentityPhase {
-  override def prerequisites = Seq(DependencyID[C])
+  override def prerequisites = Seq(Dependency[C])
   override def invalidates(phase: Phase): Boolean = phase match {
     case _: F => true
     case _ => false
@@ -68,11 +68,11 @@ class G extends IdentityPhase {
 }
 
 class CyclicA extends IdentityPhase with PreservesAll[Phase] {
-  override def prerequisites = Seq(DependencyID[CyclicB])
+  override def prerequisites = Seq(Dependency[CyclicB])
 }
 
 class CyclicB extends IdentityPhase with PreservesAll[Phase] {
-  override def prerequisites = Seq(DependencyID[CyclicA])
+  override def prerequisites = Seq(Dependency[CyclicA])
 }
 
 class CyclicC extends IdentityPhase {
@@ -95,25 +95,25 @@ object ComplicatedFixture {
     override def invalidates(phase: Phase): Boolean = false
   }
   class B extends IdentityPhase {
-    override def prerequisites = Seq(DependencyID[A])
+    override def prerequisites = Seq(Dependency[A])
     override def invalidates(phase: Phase): Boolean = false
   }
   class C extends IdentityPhase {
-    override def prerequisites = Seq(DependencyID[A])
+    override def prerequisites = Seq(Dependency[A])
     override def invalidates(phase: Phase): Boolean = phase match {
       case _: B => true
       case _ => false
     }
   }
   class D extends IdentityPhase {
-    override def prerequisites = Seq(DependencyID[B])
+    override def prerequisites = Seq(Dependency[B])
     override def invalidates(phase: Phase): Boolean = phase match {
       case _: C | _: E => true
       case _ => false
     }
   }
   class E extends IdentityPhase {
-    override def prerequisites = Seq(DependencyID[B])
+    override def prerequisites = Seq(Dependency[B])
     override def invalidates(phase: Phase): Boolean = false
   }
 
@@ -132,13 +132,13 @@ object RepeatedAnalysisFixture {
     override def invalidates(phase: Phase): Boolean = false
   }
   class A extends InvalidatesAnalysis {
-    override def prerequisites = Seq(DependencyID[Analysis])
+    override def prerequisites = Seq(Dependency[Analysis])
   }
   class B extends InvalidatesAnalysis {
-    override def prerequisites = Seq(DependencyID[A], DependencyID[Analysis])
+    override def prerequisites = Seq(Dependency[A], Dependency[Analysis])
   }
   class C extends InvalidatesAnalysis {
-    override def prerequisites = Seq(DependencyID[B], DependencyID[Analysis])
+    override def prerequisites = Seq(Dependency[B], Dependency[Analysis])
   }
 
 }
@@ -149,21 +149,21 @@ object InvertedAnalysisFixture {
     override def invalidates(phase: Phase): Boolean = false
   }
   class A extends IdentityPhase {
-    override def prerequisites = Seq(DependencyID[Analysis])
+    override def prerequisites = Seq(Dependency[Analysis])
     override def invalidates(phase: Phase): Boolean = phase match {
       case _: Analysis => true
       case _ => false
     }
   }
   class B extends IdentityPhase {
-    override def prerequisites = Seq(DependencyID[Analysis])
+    override def prerequisites = Seq(Dependency[Analysis])
     override def invalidates(phase: Phase): Boolean = phase match {
       case _: Analysis | _: A => true
       case _ => false
     }
   }
   class C extends IdentityPhase {
-    override def prerequisites = Seq(DependencyID[Analysis])
+    override def prerequisites = Seq(Dependency[Analysis])
     override def invalidates(phase: Phase): Boolean = phase match {
       case _: Analysis | _: B => true
       case _ => false
@@ -179,7 +179,7 @@ object DependentsFixture {
   }
 
   class Second extends IdentityPhase {
-    override val prerequisites = Seq(DependencyID[First])
+    override val prerequisites = Seq(Dependency[First])
     override def invalidates(phase: Phase): Boolean = false
   }
 
@@ -188,8 +188,8 @@ object DependentsFixture {
    * loop detection.
    */
   class Custom extends IdentityPhase {
-    override val prerequisites = Seq(DependencyID[First])
-    override val dependents = Seq(DependencyID[Second])
+    override val prerequisites = Seq(Dependency[First])
+    override val dependents = Seq(Dependency[Second])
     override def invalidates(phase: Phase): Boolean = false
   }
 
@@ -219,7 +219,7 @@ object ChainedInvalidationFixture {
     override def invalidates(phase: Phase): Boolean = false
   }
   class E extends IdentityPhase {
-    override val prerequisites = Seq(DependencyID[A], DependencyID[B], DependencyID[C], DependencyID[D])
+    override val prerequisites = Seq(Dependency[A], Dependency[B], Dependency[C], Dependency[D])
     override def invalidates(phase: Phase): Boolean = false
   }
 
@@ -253,8 +253,8 @@ object UnrelatedFixture {
   class B15 extends IdentityPhase with PreservesAll[Phase]
 
   class B6Sub extends B6 {
-    override val prerequisites = Seq(DependencyID[B6])
-    override val dependents = Seq(DependencyID[B7])
+    override val prerequisites = Seq(Dependency[B6])
+    override val dependents = Seq(Dependency[B7])
   }
 
   class B6_0 extends B6Sub
@@ -275,7 +275,7 @@ object UnrelatedFixture {
   class B6_15 extends B6Sub
 
   class B8Dep extends B8 {
-    override val dependents = Seq(DependencyID[B8])
+    override val dependents = Seq(Dependency[B8])
   }
 
   class B8_0 extends B8Dep
@@ -302,28 +302,28 @@ object CustomAfterOptimizationFixture {
   class Root extends IdentityPhase with PreservesAll[Phase]
 
   class OptMinimum extends IdentityPhase with PreservesAll[Phase] {
-    override val prerequisites = Seq(DependencyID[Root])
-    override val dependents = Seq(DependencyID[AfterOpt])
+    override val prerequisites = Seq(Dependency[Root])
+    override val dependents = Seq(Dependency[AfterOpt])
   }
 
   class OptFull extends IdentityPhase with PreservesAll[Phase] {
-    override val prerequisites = Seq(DependencyID[Root], DependencyID[OptMinimum])
-    override val dependents = Seq(DependencyID[AfterOpt])
+    override val prerequisites = Seq(Dependency[Root], Dependency[OptMinimum])
+    override val dependents = Seq(Dependency[AfterOpt])
   }
 
   class AfterOpt extends IdentityPhase with PreservesAll[Phase]
 
   class DoneMinimum extends IdentityPhase with PreservesAll[Phase] {
-    override val prerequisites = Seq(DependencyID[OptMinimum])
+    override val prerequisites = Seq(Dependency[OptMinimum])
   }
 
   class DoneFull extends IdentityPhase with PreservesAll[Phase] {
-    override val prerequisites = Seq(DependencyID[OptFull])
+    override val prerequisites = Seq(Dependency[OptFull])
   }
 
   class Custom extends IdentityPhase with PreservesAll[Phase] {
-    override val prerequisites = Seq(DependencyID[Root], DependencyID[AfterOpt])
-    override val dependents = Seq(DependencyID[DoneMinimum], DependencyID[DoneFull])
+    override val prerequisites = Seq(Dependency[Root], Dependency[AfterOpt])
+    override val dependents = Seq(Dependency[DoneMinimum], Dependency[DoneFull])
   }
 
 }
@@ -333,25 +333,25 @@ object OptionalPrerequisitesFixture {
   class Root extends IdentityPhase
 
   class OptMinimum extends IdentityPhase with PreservesAll[Phase] {
-    override val prerequisites = Seq(DependencyID[Root])
+    override val prerequisites = Seq(Dependency[Root])
   }
 
   class OptFull extends IdentityPhase with PreservesAll[Phase] {
-    override val prerequisites = Seq(DependencyID[Root], DependencyID[OptMinimum])
+    override val prerequisites = Seq(Dependency[Root], Dependency[OptMinimum])
   }
 
   class DoneMinimum extends IdentityPhase with PreservesAll[Phase] {
-    override val prerequisites = Seq(DependencyID[OptMinimum])
+    override val prerequisites = Seq(Dependency[OptMinimum])
   }
 
   class DoneFull extends IdentityPhase with PreservesAll[Phase] {
-    override val prerequisites = Seq(DependencyID[OptFull])
+    override val prerequisites = Seq(Dependency[OptFull])
   }
 
   class Custom extends IdentityPhase with PreservesAll[Phase] {
-    override val prerequisites = Seq(DependencyID[Root])
-    override val optionalPrerequisites = Seq(DependencyID[OptMinimum], DependencyID[OptFull])
-    override val dependents = Seq(DependencyID[DoneMinimum], DependencyID[DoneFull])
+    override val prerequisites = Seq(Dependency[Root])
+    override val optionalPrerequisites = Seq(Dependency[OptMinimum], Dependency[OptFull])
+    override val dependents = Seq(Dependency[DoneMinimum], Dependency[DoneFull])
   }
 
 }
@@ -368,7 +368,7 @@ object OrderingFixture {
   }
 
   class C extends IdentityPhase {
-    override val prerequisites = Seq(DependencyID[A], DependencyID[B])
+    override val prerequisites = Seq(Dependency[A], Dependency[B])
     override def invalidates(phase: Phase): Boolean = phase match {
       case _: B => true
       case _    => false
@@ -376,7 +376,7 @@ object OrderingFixture {
   }
 
   class Cx extends C {
-    override val prerequisites = Seq(DependencyID[B], DependencyID[A])
+    override val prerequisites = Seq(Dependency[B], Dependency[A])
   }
 
 }
@@ -421,7 +421,7 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
   behavior of this.getClass.getName
 
   it should "do nothing if all targets are reached" in {
-    val targets = Seq(DependencyID[A], DependencyID[B], DependencyID[C], DependencyID[D])
+    val targets = Seq(Dependency[A], Dependency[B], Dependency[C], Dependency[D])
     val pm = new PhaseManager(targets, targets)
 
     writeGraphviz(pm, "test_run_dir/PhaseManagerSpec/DoNothing")
@@ -430,7 +430,7 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
   }
 
   it should "handle a simple dependency" in {
-    val targets = Seq(DependencyID[B])
+    val targets = Seq(Dependency[B])
     val order = Seq(classOf[A], classOf[B])
     val pm = new PhaseManager(targets)
 
@@ -440,7 +440,7 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
   }
 
   it should "handle a simple dependency with an invalidation" in {
-    val targets = Seq(DependencyID[A], DependencyID[B], DependencyID[C], DependencyID[D])
+    val targets = Seq(Dependency[A], Dependency[B], Dependency[C], Dependency[D])
     val order = Seq(classOf[A], classOf[D], classOf[A], classOf[B], classOf[C])
     val pm = new PhaseManager(targets)
 
@@ -450,7 +450,7 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
   }
 
   it should "handle a dependency with two invalidates optimally" in {
-    val targets = Seq(DependencyID[A], DependencyID[B], DependencyID[C], DependencyID[E], DependencyID[F], DependencyID[G])
+    val targets = Seq(Dependency[A], Dependency[B], Dependency[C], Dependency[E], Dependency[F], Dependency[G])
     val pm = new PhaseManager(targets)
 
     writeGraphviz(pm, "test_run_dir/PhaseManagerSpec/TwoInvalidates")
@@ -459,7 +459,7 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
   }
 
   it should "throw an exception for cyclic prerequisites" in {
-    val targets = Seq(DependencyID[CyclicA], DependencyID[CyclicB])
+    val targets = Seq(Dependency[CyclicA], Dependency[CyclicB])
     val pm = new PhaseManager(targets)
 
     writeGraphviz(pm, "test_run_dir/PhaseManagerSpec/CyclicPrerequisites")
@@ -469,7 +469,7 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
   }
 
   it should "throw an exception for cyclic invalidates" in {
-    val targets = Seq(DependencyID[CyclicC], DependencyID[CyclicD])
+    val targets = Seq(Dependency[CyclicC], Dependency[CyclicD])
     val pm = new PhaseManager(targets)
 
     writeGraphviz(pm, "test_run_dir/PhaseManagerSpec/CyclicInvalidates")
@@ -480,7 +480,7 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
 
   it should "handle a complicated graph" in {
     val f = ComplicatedFixture
-    val targets = Seq(DependencyID[f.A], DependencyID[f.B], DependencyID[f.C], DependencyID[f.D], DependencyID[f.E])
+    val targets = Seq(Dependency[f.A], Dependency[f.B], Dependency[f.C], Dependency[f.D], Dependency[f.E])
     val pm = new PhaseManager(targets)
 
     writeGraphviz(pm, "test_run_dir/PhaseManagerSpec/Complicated")
@@ -491,7 +491,7 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
 
   it should "handle repeated recomputed analyses" in {
     val f = RepeatedAnalysisFixture
-    val targets = Seq(DependencyID[f.A], DependencyID[f.B], DependencyID[f.C])
+    val targets = Seq(Dependency[f.A], Dependency[f.B], Dependency[f.C])
     val order =
       Seq( classOf[f.Analysis],
            classOf[f.A],
@@ -508,7 +508,7 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
 
   it should "handle inverted repeated recomputed analyses" in {
     val f = InvertedAnalysisFixture
-    val targets = Seq(DependencyID[f.A], DependencyID[f.B], DependencyID[f.C])
+    val targets = Seq(Dependency[f.A], Dependency[f.B], Dependency[f.C])
     val order =
       Seq( classOf[f.Analysis],
            classOf[f.C],
@@ -528,12 +528,12 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
     val f = DependentsFixture
 
     info("without the custom transform it runs: First -> Second")
-    val pm = new PhaseManager(Seq(DependencyID[f.Second]))
+    val pm = new PhaseManager(Seq(Dependency[f.Second]))
     val orderNoCustom = Seq(classOf[f.First], classOf[f.Second])
     pm.flattenedTransformOrder.map(_.getClass) should be (orderNoCustom)
 
     info("with the custom transform it runs:    First -> Custom -> Second")
-    val pmCustom = new PhaseManager(Seq(DependencyID[f.Custom], DependencyID[f.Second]))
+    val pmCustom = new PhaseManager(Seq(Dependency[f.Custom], Dependency[f.Second]))
     val orderCustom = Seq(classOf[f.First], classOf[f.Custom], classOf[f.Second])
 
     writeGraphviz(pmCustom, "test_run_dir/PhaseManagerSpec/SingleDependent")
@@ -544,8 +544,8 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
   it should "handle chained invalidation" in {
     val f = ChainedInvalidationFixture
 
-    val targets = Seq(DependencyID[f.A], DependencyID[f.E])
-    val current = Seq(DependencyID[f.B], DependencyID[f.C], DependencyID[f.D])
+    val targets = Seq(Dependency[f.A], Dependency[f.E])
+    val current = Seq(Dependency[f.B], Dependency[f.C], Dependency[f.D])
 
     val pm = new PhaseManager(targets, current)
     val order = Seq( classOf[f.A], classOf[f.B], classOf[f.C], classOf[f.D], classOf[f.E] )
@@ -560,66 +560,66 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
 
     /** A bunch of unrelated Phases. This ensures that these run in the order in which they are specified. */
     val targets =
-      Seq( DependencyID[f.B0],
-           DependencyID[f.B1],
-           DependencyID[f.B2],
-           DependencyID[f.B3],
-           DependencyID[f.B4],
-           DependencyID[f.B5],
-           DependencyID[f.B6],
-           DependencyID[f.B7],
-           DependencyID[f.B8],
-           DependencyID[f.B9],
-           DependencyID[f.B10],
-           DependencyID[f.B11],
-           DependencyID[f.B12],
-           DependencyID[f.B13],
-           DependencyID[f.B14],
-           DependencyID[f.B15] )
+      Seq( Dependency[f.B0],
+           Dependency[f.B1],
+           Dependency[f.B2],
+           Dependency[f.B3],
+           Dependency[f.B4],
+           Dependency[f.B5],
+           Dependency[f.B6],
+           Dependency[f.B7],
+           Dependency[f.B8],
+           Dependency[f.B9],
+           Dependency[f.B10],
+           Dependency[f.B11],
+           Dependency[f.B12],
+           Dependency[f.B13],
+           Dependency[f.B14],
+           Dependency[f.B15] )
     /** A sequence of custom transforms that should all run after B6 and before B7. This exercises correct ordering of the
       * prerequisiteGraph and dependentsGraph.
       */
     val prerequisiteTargets =
-      Seq( DependencyID[f.B6_0],
-           DependencyID[f.B6_1],
-           DependencyID[f.B6_2],
-           DependencyID[f.B6_3],
-           DependencyID[f.B6_4],
-           DependencyID[f.B6_5],
-           DependencyID[f.B6_6],
-           DependencyID[f.B6_7],
-           DependencyID[f.B6_8],
-           DependencyID[f.B6_9],
-           DependencyID[f.B6_10],
-           DependencyID[f.B6_11],
-           DependencyID[f.B6_12],
-           DependencyID[f.B6_13],
-           DependencyID[f.B6_14],
-           DependencyID[f.B6_15] )
+      Seq( Dependency[f.B6_0],
+           Dependency[f.B6_1],
+           Dependency[f.B6_2],
+           Dependency[f.B6_3],
+           Dependency[f.B6_4],
+           Dependency[f.B6_5],
+           Dependency[f.B6_6],
+           Dependency[f.B6_7],
+           Dependency[f.B6_8],
+           Dependency[f.B6_9],
+           Dependency[f.B6_10],
+           Dependency[f.B6_11],
+           Dependency[f.B6_12],
+           Dependency[f.B6_13],
+           Dependency[f.B6_14],
+           Dependency[f.B6_15] )
     /** A sequence of transforms that are invalidated by B0 and only define dependents on B8. This exercises the ordering
       * defined by "otherDependents".
       */
     val current =
-      Seq( DependencyID[f.B8_0],
-           DependencyID[f.B8_1],
-           DependencyID[f.B8_2],
-           DependencyID[f.B8_3],
-           DependencyID[f.B8_4],
-           DependencyID[f.B8_5],
-           DependencyID[f.B8_6],
-           DependencyID[f.B8_7],
-           DependencyID[f.B8_8],
-           DependencyID[f.B8_9],
-           DependencyID[f.B8_10],
-           DependencyID[f.B8_11],
-           DependencyID[f.B8_12],
-           DependencyID[f.B8_13],
-           DependencyID[f.B8_14],
-           DependencyID[f.B8_15] )
+      Seq( Dependency[f.B8_0],
+           Dependency[f.B8_1],
+           Dependency[f.B8_2],
+           Dependency[f.B8_3],
+           Dependency[f.B8_4],
+           Dependency[f.B8_5],
+           Dependency[f.B8_6],
+           Dependency[f.B8_7],
+           Dependency[f.B8_8],
+           Dependency[f.B8_9],
+           Dependency[f.B8_10],
+           Dependency[f.B8_11],
+           Dependency[f.B8_12],
+           Dependency[f.B8_13],
+           Dependency[f.B8_14],
+           Dependency[f.B8_15] )
 
     /** The resulting order: B0--B6, B6_0--B6_B15, B7, B8_0--B8_15, B8--B15 */
     val expectedDeps = targets.slice(0, 7) ++ prerequisiteTargets ++ Some(targets(7)) ++ current ++ targets.drop(8)
-    val expectedClasses = expectedDeps.map { case DependencyID(Left(c)) => c }
+    val expectedClasses = expectedDeps.map { case Dependency(Left(c)) => c }
 
     val pm = new PhaseManager(targets ++ prerequisiteTargets ++ current, current.reverse)
 
@@ -631,10 +631,10 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
   it should "allow conditional placement of custom transforms" in {
     val f = CustomAfterOptimizationFixture
 
-    val targetsMinimum = Seq(DependencyID[f.Custom], DependencyID[f.DoneMinimum])
+    val targetsMinimum = Seq(Dependency[f.Custom], Dependency[f.DoneMinimum])
     val pmMinimum = new PhaseManager(targetsMinimum)
 
-    val targetsFull = Seq(DependencyID[f.Custom], DependencyID[f.DoneFull])
+    val targetsFull = Seq(Dependency[f.Custom], Dependency[f.DoneFull])
     val pmFull = new PhaseManager(targetsFull)
 
     val expectedMinimum = Seq(classOf[f.Root], classOf[f.OptMinimum], classOf[f.AfterOpt], classOf[f.Custom], classOf[f.DoneMinimum])
@@ -649,10 +649,10 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
   it should "support optional prerequisites" in {
     val f = OptionalPrerequisitesFixture
 
-    val targetsMinimum = Seq(DependencyID[f.Custom], DependencyID[f.DoneMinimum])
+    val targetsMinimum = Seq(Dependency[f.Custom], Dependency[f.DoneMinimum])
     val pmMinimum = new PhaseManager(targetsMinimum)
 
-    val targetsFull = Seq(DependencyID[f.Custom], DependencyID[f.DoneFull])
+    val targetsFull = Seq(Dependency[f.Custom], Dependency[f.DoneFull])
     val pmFull = new PhaseManager(targetsFull)
 
     val expectedMinimum = Seq(classOf[f.Root], classOf[f.OptMinimum], classOf[f.Custom], classOf[f.DoneMinimum])
@@ -671,13 +671,13 @@ class PhaseManagerSpec extends FlatSpec with Matchers {
     val f = OrderingFixture
 
     {
-      val targets = Seq(DependencyID[f.A], DependencyID[f.B], DependencyID[f.C])
+      val targets = Seq(Dependency[f.A], Dependency[f.B], Dependency[f.C])
       val order = Seq(classOf[f.B], classOf[f.A], classOf[f.C], classOf[f.B], classOf[f.A])
       (new PhaseManager(targets)).flattenedTransformOrder.map(_.getClass) should be (order)
     }
 
     {
-      val targets = Seq(DependencyID[f.A], DependencyID[f.B], DependencyID[f.Cx])
+      val targets = Seq(Dependency[f.A], Dependency[f.B], Dependency[f.Cx])
       val order = Seq(classOf[f.B], classOf[f.A], classOf[f.Cx], classOf[f.B], classOf[f.A])
       (new PhaseManager(targets)).flattenedTransformOrder.map(_.getClass) should be (order)
     }


### PR DESCRIPTION
Here's a newer prototype based on `dependency-api-2`. I reverted `LowerTypes` as an example.

Sorry the delta is so big -- it's mostly changing `classOf` to `DependencyID` in lots of places. The wrapper could probably just be called `Dependency`, and there is the question of whether `Either` is worth using over a sealed trait and two case classes, as @jackkoenig suggested.