### PR TITLE
File Serialization of Annotations

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -107,12 +107,12 @@ sealed trait EmittedAnnotation[T <: EmittedComponent] extends NoTargetAnnotation
 }
 sealed trait EmittedCircuitAnnotation[T <: EmittedCircuit] extends EmittedAnnotation[T] {
 
-  override def toBytes = Some(new StringBuilder(value.value).map(_.toByte))
+  override def toBytes = Some(value.value.getBytes)
 
 }
 sealed trait EmittedModuleAnnotation[T <: EmittedModule] extends EmittedAnnotation[T] {
 
-  override def toBytes = Some(new StringBuilder(value.value).map(_.toByte))
+  override def toBytes = Some(value.value.getBytes)
 
 }
 

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -14,7 +14,7 @@ import firrtl.PrimOps._
 import firrtl.WrappedExpression._
 import Utils._
 import MemPortUtils.{memPortField, memType}
-import firrtl.options.{HasShellOptions, CustomFileEmission, ShellOption, StageOptions, PhaseException}
+import firrtl.options.{HasShellOptions, CustomFileEmission, ShellOption, PhaseException}
 import firrtl.options.Viewer.view
 import firrtl.stage.{FirrtlFileAnnotation, FirrtlOptions, RunFirrtlTransformAnnotation, TransformManager}
 // Datastructures

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -105,7 +105,7 @@ sealed trait EmittedAnnotation[T <: EmittedComponent] extends NoTargetAnnotation
 }
 sealed trait EmittedCircuitAnnotation[T <: EmittedCircuit] extends EmittedAnnotation[T] {
 
-  override def howToSerialize: Option[String] = Some(value.value)
+  override def howToSerialize: Option[Stream[Char]] = Some(new StringBuilder(value.value).toStream)
 
   override def filename(annotations: AnnotationSeq): File = {
     val sopts = view[StageOptions](annotations)
@@ -116,7 +116,7 @@ sealed trait EmittedCircuitAnnotation[T <: EmittedCircuit] extends EmittedAnnota
 }
 sealed trait EmittedModuleAnnotation[T <: EmittedModule] extends EmittedAnnotation[T] {
 
-  override def howToSerialize: Option[String] = Some(value.value)
+  override def howToSerialize: Option[Stream[Char]] = Some(new StringBuilder(value.value).toStream)
 
   override def howToResume(file: File): Option[AnnotationSeq] = None
 

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -118,22 +118,16 @@ sealed trait EmittedModuleAnnotation[T <: EmittedModule] extends EmittedAnnotati
 
   override def toBytes = Some(new StringBuilder(value.value).map(_.toByte))
 
-  override def replacements(file: File): Option[AnnotationSeq] = None
-
 }
 
 case class EmittedFirrtlCircuitAnnotation(value: EmittedFirrtlCircuit)
     extends EmittedCircuitAnnotation[EmittedFirrtlCircuit] {
 
-  override def replacements(file: File): Option[AnnotationSeq] = Some(Seq(FirrtlFileAnnotation(file.toString)))
+  override def replacements(file: File): AnnotationSeq = Seq(FirrtlFileAnnotation(file.toString))
 
 }
 case class EmittedVerilogCircuitAnnotation(value: EmittedVerilogCircuit)
-    extends EmittedCircuitAnnotation[EmittedVerilogCircuit] {
-
-  override def replacements(file: File): Option[AnnotationSeq] = None
-
-}
+    extends EmittedCircuitAnnotation[EmittedVerilogCircuit]
 case class EmittedFirrtlModuleAnnotation(value: EmittedFirrtlModule)
     extends EmittedModuleAnnotation[EmittedFirrtlModule]
 case class EmittedVerilogModuleAnnotation(value: EmittedVerilogModule)

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -105,7 +105,7 @@ sealed trait EmittedAnnotation[T <: EmittedComponent] extends NoTargetAnnotation
 }
 sealed trait EmittedCircuitAnnotation[T <: EmittedCircuit] extends EmittedAnnotation[T] {
 
-  override def howToSerialize: Option[Stream[Byte]] = Some(new StringBuilder(value.value).toStream.map(_.toByte))
+  override def howToSerialize = Some(new StringBuilder(value.value).map(_.toByte))
 
   override def filename(annotations: AnnotationSeq): File = {
     val sopts = view[StageOptions](annotations)
@@ -116,7 +116,7 @@ sealed trait EmittedCircuitAnnotation[T <: EmittedCircuit] extends EmittedAnnota
 }
 sealed trait EmittedModuleAnnotation[T <: EmittedModule] extends EmittedAnnotation[T] {
 
-  override def howToSerialize: Option[Stream[Byte]] = Some(new StringBuilder(value.value).toStream.map(_.toByte))
+  override def howToSerialize = Some(new StringBuilder(value.value).map(_.toByte))
 
   override def howToResume(file: File): Option[AnnotationSeq] = None
 

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -105,7 +105,7 @@ sealed trait EmittedAnnotation[T <: EmittedComponent] extends NoTargetAnnotation
 }
 sealed trait EmittedCircuitAnnotation[T <: EmittedCircuit] extends EmittedAnnotation[T] {
 
-  override def howToSerialize: Option[Stream[Char]] = Some(new StringBuilder(value.value).toStream)
+  override def howToSerialize: Option[Stream[Byte]] = Some(new StringBuilder(value.value).toStream.map(_.toByte))
 
   override def filename(annotations: AnnotationSeq): File = {
     val sopts = view[StageOptions](annotations)
@@ -116,7 +116,7 @@ sealed trait EmittedCircuitAnnotation[T <: EmittedCircuit] extends EmittedAnnota
 }
 sealed trait EmittedModuleAnnotation[T <: EmittedModule] extends EmittedAnnotation[T] {
 
-  override def howToSerialize: Option[Stream[Char]] = Some(new StringBuilder(value.value).toStream)
+  override def howToSerialize: Option[Stream[Byte]] = Some(new StringBuilder(value.value).toStream.map(_.toByte))
 
   override def howToResume(file: File): Option[AnnotationSeq] = None
 

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -107,12 +107,12 @@ sealed trait EmittedAnnotation[T <: EmittedComponent] extends NoTargetAnnotation
 }
 sealed trait EmittedCircuitAnnotation[T <: EmittedCircuit] extends EmittedAnnotation[T] {
 
-  override def toBytes = Some(value.value.getBytes)
+  override def getBytes = value.value.getBytes
 
 }
 sealed trait EmittedModuleAnnotation[T <: EmittedModule] extends EmittedAnnotation[T] {
 
-  override def toBytes = Some(value.value.getBytes)
+  override def getBytes = value.value.getBytes
 
 }
 

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -14,10 +14,13 @@ import firrtl.PrimOps._
 import firrtl.WrappedExpression._
 import Utils._
 import MemPortUtils.{memPortField, memType}
-import firrtl.options.{HasShellOptions, PhaseException, ShellOption, Unserializable}
-import firrtl.stage.{RunFirrtlTransformAnnotation, TransformManager}
+import firrtl.options.{HasShellOptions, HowToSerialize, ShellOption, StageOptions, PhaseException}
+import firrtl.options.Viewer.view
+import firrtl.stage.{FirrtlFileAnnotation, FirrtlOptions, RunFirrtlTransformAnnotation, TransformManager}
 // Datastructures
 import scala.collection.mutable.ArrayBuffer
+
+import java.io.File
 
 case class EmitterException(message: String) extends PassException(message)
 
@@ -92,17 +95,45 @@ final case class EmittedFirrtlModule(name: String, value: String, outputSuffix: 
 final case class EmittedVerilogModule(name: String, value: String, outputSuffix: String) extends EmittedModule
 
 /** Traits for Annotations containing emitted components */
-sealed trait EmittedAnnotation[T <: EmittedComponent] extends NoTargetAnnotation with Unserializable {
+sealed trait EmittedAnnotation[T <: EmittedComponent] extends NoTargetAnnotation with HowToSerialize {
   val value: T
+
+  override protected val baseFileName: String = value.name
+
+  override protected val suffix: Option[String] = Some(value.outputSuffix)
+
 }
-sealed trait EmittedCircuitAnnotation[T <: EmittedCircuit] extends EmittedAnnotation[T]
-sealed trait EmittedModuleAnnotation[T <: EmittedModule] extends EmittedAnnotation[T]
+sealed trait EmittedCircuitAnnotation[T <: EmittedCircuit] extends EmittedAnnotation[T] {
+
+  override def howToSerialize: Option[String] = Some(value.value)
+
+  override def filename(annotations: AnnotationSeq): File = {
+    val sopts = view[StageOptions](annotations)
+    val fopts = view[FirrtlOptions](annotations)
+    new File(sopts.getBuildFileName(fopts.outputFileName.getOrElse(baseFileName), suffix))
+  }
+
+}
+sealed trait EmittedModuleAnnotation[T <: EmittedModule] extends EmittedAnnotation[T] {
+
+  override def howToSerialize: Option[String] = Some(value.value)
+
+  override def howToResume(file: File): Option[AnnotationSeq] = None
+
+}
 
 case class EmittedFirrtlCircuitAnnotation(value: EmittedFirrtlCircuit)
-    extends EmittedCircuitAnnotation[EmittedFirrtlCircuit]
-case class EmittedVerilogCircuitAnnotation(value: EmittedVerilogCircuit)
-    extends EmittedCircuitAnnotation[EmittedVerilogCircuit]
+    extends EmittedCircuitAnnotation[EmittedFirrtlCircuit] {
 
+  override def howToResume(file: File): Option[AnnotationSeq] = Some(Seq(FirrtlFileAnnotation(file.toString)))
+
+}
+case class EmittedVerilogCircuitAnnotation(value: EmittedVerilogCircuit)
+    extends EmittedCircuitAnnotation[EmittedVerilogCircuit] {
+
+  override def howToResume(file: File): Option[AnnotationSeq] = None
+
+}
 case class EmittedFirrtlModuleAnnotation(value: EmittedFirrtlModule)
     extends EmittedModuleAnnotation[EmittedFirrtlModule]
 case class EmittedVerilogModuleAnnotation(value: EmittedVerilogModule)
@@ -465,10 +496,10 @@ class VerilogEmitter extends SeqTransform with Emitter {
     throw EmitterException("Cannot emit verification statements in Verilog" +
       "(2001). Use the SystemVerilog emitter instead.")
   }
-  
-  /** 
+
+  /**
     * Store Emission option per Target
-    * Guarantee only one emission option per Target 
+    * Guarantee only one emission option per Target
     */
   private[firrtl] class EmissionOptionMap[V <: EmissionOption](val df : V) {
     private val m = collection.mutable.HashMap[ReferenceTarget, V]().withDefaultValue(df)
@@ -480,9 +511,9 @@ class VerilogEmitter extends SeqTransform with Emitter {
     }
     def apply(key: ReferenceTarget): V = m.apply(key)
   }
-  
+
   /** Provide API to retrieve EmissionOptions based on the provided [[AnnotationSeq]]
-    * 
+    *
     * @param annotations : AnnotationSeq to be searched for EmissionOptions
     *
     */
@@ -500,16 +531,16 @@ class VerilogEmitter extends SeqTransform with Emitter {
 
     def getRegisterEmissionOption(target: ReferenceTarget): RegisterEmissionOption =
       registerEmissionOption(target)
-      
+
     def getWireEmissionOption(target: ReferenceTarget): WireEmissionOption =
       wireEmissionOption(target)
-      
+
     def getPortEmissionOption(target: ReferenceTarget): PortEmissionOption =
       portEmissionOption(target)
-      
+
     def getNodeEmissionOption(target: ReferenceTarget): NodeEmissionOption =
       nodeEmissionOption(target)
-      
+
     def getConnectEmissionOption(target: ReferenceTarget): ConnectEmissionOption =
       connectEmissionOption(target)
 

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -98,7 +98,9 @@ final case class EmittedVerilogModule(name: String, value: String, outputSuffix:
 sealed trait EmittedAnnotation[T <: EmittedComponent] extends NoTargetAnnotation with CustomFileEmission {
   val value: T
 
-  override protected val baseFileName: String = value.name
+  override protected def baseFileName(annotations: AnnotationSeq): String = {
+    view[FirrtlOptions](annotations).outputFileName.getOrElse(value.name)
+  }
 
   override protected val suffix: Option[String] = Some(value.outputSuffix)
 
@@ -106,12 +108,6 @@ sealed trait EmittedAnnotation[T <: EmittedComponent] extends NoTargetAnnotation
 sealed trait EmittedCircuitAnnotation[T <: EmittedCircuit] extends EmittedAnnotation[T] {
 
   override def toBytes = Some(new StringBuilder(value.value).map(_.toByte))
-
-  override def filename(annotations: AnnotationSeq): File = {
-    val sopts = view[StageOptions](annotations)
-    val fopts = view[FirrtlOptions](annotations)
-    new File(sopts.getBuildFileName(fopts.outputFileName.getOrElse(baseFileName), suffix))
-  }
 
 }
 sealed trait EmittedModuleAnnotation[T <: EmittedModule] extends EmittedAnnotation[T] {

--- a/src/main/scala/firrtl/options/StageAnnotations.scala
+++ b/src/main/scala/firrtl/options/StageAnnotations.scala
@@ -23,7 +23,7 @@ trait HowToSerialize { this: Annotation =>
 
   protected def suffix: Option[String]
 
-  def howToSerialize: Option[Stream[Byte]]
+  def howToSerialize: Option[Iterable[Byte]]
 
   def howToResume(file: File): Option[AnnotationSeq]
 

--- a/src/main/scala/firrtl/options/StageAnnotations.scala
+++ b/src/main/scala/firrtl/options/StageAnnotations.scala
@@ -30,7 +30,7 @@ trait Unserializable { this: Annotation => }
   * expected to be available to downstream transforms. Communication of information between transforms must occur
   * through the annotations that will eventually be serialized to files.
   */
-trait HowToSerialize { this: Annotation =>
+trait CustomFileEmission { this: Annotation =>
 
   /** Output filename where serialized content will be written */
   protected def baseFileName: String
@@ -45,7 +45,7 @@ trait HowToSerialize { this: Annotation =>
     *  def toBytes: Option[Iterable[Byte]] = Some(myString.getBytes)
     * }}}
     */
-  def howToSerialize: Option[Iterable[Byte]]
+  def toBytes: Option[Iterable[Byte]]
 
   /** Optionally, a sequence of annotations that will replace this annotation in the output annotation file.
     *
@@ -54,7 +54,7 @@ trait HowToSerialize { this: Annotation =>
     * serialized to a separate file, this method could include an input file annotation that a later stage can use to
     * read the serialized FIRRTL circuit back in.
     */
-  def howToResume(file: File): Option[AnnotationSeq]
+  def replacements(file: File): Option[AnnotationSeq]
 
   /** Method that returns the filename where this annotation will be serialized.
     *

--- a/src/main/scala/firrtl/options/StageAnnotations.scala
+++ b/src/main/scala/firrtl/options/StageAnnotations.scala
@@ -54,7 +54,7 @@ trait CustomFileEmission { this: Annotation =>
     * serialized to a separate file, this method could include an input file annotation that a later stage can use to
     * read the serialized FIRRTL circuit back in.
     */
-  def replacements(file: File): Option[AnnotationSeq]
+  def replacements(file: File): Option[AnnotationSeq] = None
 
   /** Method that returns the filename where this annotation will be serialized.
     *

--- a/src/main/scala/firrtl/options/StageAnnotations.scala
+++ b/src/main/scala/firrtl/options/StageAnnotations.scala
@@ -23,7 +23,7 @@ trait HowToSerialize { this: Annotation =>
 
   protected def suffix: Option[String]
 
-  def howToSerialize: Option[String]
+  def howToSerialize: Option[Stream[Char]]
 
   def howToResume(file: File): Option[AnnotationSeq]
 

--- a/src/main/scala/firrtl/options/StageAnnotations.scala
+++ b/src/main/scala/firrtl/options/StageAnnotations.scala
@@ -32,8 +32,15 @@ trait Unserializable { this: Annotation => }
   */
 trait CustomFileEmission { this: Annotation =>
 
-  /** Output filename where serialized content will be written */
-  protected def baseFileName: String
+  /** Output filename where serialized content will be written
+    *
+    * The full annotation sequence is a parameter to allow for the location where this annotation will be serialized to
+    * be a function of other annotations, e.g., if the location where information is written is controlled by a separate
+    * file location annotation.
+    *
+    * @param annotations the annotation sequence at the time of emission
+    */
+  protected def baseFileName(annotations: AnnotationSeq): String
 
   /** Optional suffix of the output file */
   protected def suffix: Option[String]
@@ -58,15 +65,10 @@ trait CustomFileEmission { this: Annotation =>
 
   /** Method that returns the filename where this annotation will be serialized.
     *
-    * Users are not normally expected to override this method. Instead, changes to the default behavior can be handled
-    * by overriding the baseFileName and suffix methods. However, if the filename cannot be statically known and is a
-    * function of the content being serialized, then users may need to override this, e.g., if the filename should
-    * include the top module of a FIRRTL circuit.
-    *
     * @param annotations the annotations at the time of serialization
     */
-  def filename(annotations: AnnotationSeq): File = {
-    val name = view[StageOptions](annotations).getBuildFileName(baseFileName, suffix)
+  final def filename(annotations: AnnotationSeq): File = {
+    val name = view[StageOptions](annotations).getBuildFileName(baseFileName(annotations), suffix)
     new File(name)
   }
 

--- a/src/main/scala/firrtl/options/StageAnnotations.scala
+++ b/src/main/scala/firrtl/options/StageAnnotations.scala
@@ -49,12 +49,12 @@ trait CustomFileEmission { this: Annotation =>
 
   /** Optionally, a sequence of annotations that will replace this annotation in the output annotation file.
     *
-    * A non-None implementation of this method is a mechanism for telling a downstream [[firrtl.options.Stage Stage]]
+    * A non-empty implementation of this method is a mechanism for telling a downstream [[firrtl.options.Stage Stage]]
     * how to deserialize the information that was serialized to a separate file. For example, if a FIRRTL circuit is
     * serialized to a separate file, this method could include an input file annotation that a later stage can use to
     * read the serialized FIRRTL circuit back in.
     */
-  def replacements(file: File): Option[AnnotationSeq] = None
+  def replacements(file: File): AnnotationSeq = Seq.empty
 
   /** Method that returns the filename where this annotation will be serialized.
     *

--- a/src/main/scala/firrtl/options/StageAnnotations.scala
+++ b/src/main/scala/firrtl/options/StageAnnotations.scala
@@ -4,6 +4,9 @@ package firrtl.options
 
 import firrtl.AnnotationSeq
 import firrtl.annotations.{Annotation, NoTargetAnnotation}
+import firrtl.options.Viewer.view
+
+import java.io.File
 
 import scopt.OptionParser
 
@@ -13,6 +16,23 @@ sealed trait StageOption { this: Annotation => }
   * This usually means that this is an annotation that is used only internally to a [[Stage]].
   */
 trait Unserializable { this: Annotation => }
+
+trait HowToSerialize { this: Annotation =>
+
+  protected def baseFileName: String
+
+  protected def suffix: Option[String]
+
+  def howToSerialize: Option[String]
+
+  def howToResume(file: File): Option[AnnotationSeq]
+
+  def filename(annotations: AnnotationSeq): File = {
+    val name = view[StageOptions](annotations).getBuildFileName(baseFileName, suffix)
+    new File(name)
+  }
+
+}
 
 /** Holds the name of the target directory
   *  - set with `-td/--target-dir`

--- a/src/main/scala/firrtl/options/StageAnnotations.scala
+++ b/src/main/scala/firrtl/options/StageAnnotations.scala
@@ -23,7 +23,7 @@ trait HowToSerialize { this: Annotation =>
 
   protected def suffix: Option[String]
 
-  def howToSerialize: Option[Stream[Char]]
+  def howToSerialize: Option[Stream[Byte]]
 
   def howToResume(file: File): Option[AnnotationSeq]
 

--- a/src/main/scala/firrtl/options/StageAnnotations.scala
+++ b/src/main/scala/firrtl/options/StageAnnotations.scala
@@ -49,10 +49,10 @@ trait CustomFileEmission { this: Annotation =>
     *
     * If you only need to serialize a string, you can use the `getBytes` method:
     * {{{
-    *  def toBytes: Option[Iterable[Byte]] = Some(myString.getBytes)
+    *  def getBytes: Iterable[Byte] = myString.getBytes
     * }}}
     */
-  def toBytes: Option[Iterable[Byte]]
+  def getBytes: Iterable[Byte]
 
   /** Optionally, a sequence of annotations that will replace this annotation in the output annotation file.
     *

--- a/src/main/scala/firrtl/options/StageOptions.scala
+++ b/src/main/scala/firrtl/options/StageOptions.scala
@@ -59,7 +59,7 @@ class StageOptions private [firrtl] (
       } else {
         new File(targetDir + "/" + f)
       }
-    }.getCanonicalFile
+    }
 
     val parent = file.getParentFile
 

--- a/src/main/scala/firrtl/options/StageOptions.scala
+++ b/src/main/scala/firrtl/options/StageOptions.scala
@@ -59,11 +59,13 @@ class StageOptions private [firrtl] (
       } else {
         new File(targetDir + "/" + f)
       }
+    }.toPath.normalize.toFile
+
+    file.getParentFile match {
+      case null =>
+      case parent if (!parent.exists) => parent.mkdirs()
+      case _ =>
     }
-
-    val parent = file.getParentFile
-
-    if (!parent.exists) { parent.mkdirs() }
 
     file.toString
   }

--- a/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
+++ b/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
@@ -6,7 +6,7 @@ import firrtl.AnnotationSeq
 import firrtl.annotations.{DeletedAnnotation, JsonProtocol}
 import firrtl.options.{Dependency, HowToSerialize, Phase, StageOptions, Unserializable, Viewer}
 
-import java.io.PrintWriter
+import java.io.{BufferedWriter, FileWriter, PrintWriter}
 
 /** [[firrtl.options.Phase Phase]] that writes an [[AnnotationSeq]] to a file. A file is written if and only if a
   * [[StageOptions]] view has a non-empty [[StageOptions.annotationFileOut annotationFileOut]].
@@ -32,9 +32,9 @@ class WriteOutputAnnotations extends Phase {
       case a: HowToSerialize    =>
         val filename = a.filename(annotations)
         a.howToSerialize.map { str =>
-          val pw = new PrintWriter(filename)
-          pw.write(str)
-          pw.close()
+          val w = new BufferedWriter(new FileWriter(filename))
+          str.foreach( w.write(_) )
+          w.close()
         }
         a.howToResume(filename) match {
           case Some(a) => a

--- a/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
+++ b/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
@@ -26,7 +26,7 @@ class WriteOutputAnnotations extends Phase {
   /** Write the input [[AnnotationSeq]] to a fie. */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {
     val sopts = Viewer[StageOptions].view(annotations)
-    val serializable: AnnotationSeq = annotations.flatMap{
+    val serializable: AnnotationSeq = annotations.toSeq.flatMap {
       case _: Unserializable     => None
       case a: DeletedAnnotation  => if (sopts.writeDeleted) { Some(a) } else { None }
       case a: CustomFileEmission =>
@@ -36,10 +36,7 @@ class WriteOutputAnnotations extends Phase {
           str.foreach( w.write(_) )
           w.close()
         }
-        a.replacements(filename) match {
-          case Some(a) => a
-          case None => None
-        }
+        a.replacements(filename)
       case a => Some(a)
     }
 

--- a/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
+++ b/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
@@ -36,13 +36,13 @@ class WriteOutputAnnotations extends Phase {
         val filename = a.filename(annotations)
         val canonical = filename.getCanonicalPath()
 
-        (a.toBytes, filesWritten.get(canonical)) match {
-          case (Some(x), None) =>
+        filesWritten.get(canonical) match {
+          case None =>
             val w = new BufferedWriter(new FileWriter(filename))
-            x.foreach( w.write(_) )
+            a.getBytes.foreach( w.write(_) )
             w.close()
             filesWritten(canonical) = a
-          case (Some(_), Some(first)) =>
+          case Some(first) =>
             val msg =
               s"""|Multiple CustomFileEmission annotations would be serialized to the same file, '$canonical'
                   |  - first writer:
@@ -53,7 +53,6 @@ class WriteOutputAnnotations extends Phase {
                   |      trimmed serialization: ${a.serialize.take(80)}
                   |""".stripMargin
             throw new PhaseException(msg)
-          case (None, _) =>
         }
         a.replacements(filename)
       case a => Some(a)

--- a/src/main/scala/firrtl/stage/FirrtlStage.scala
+++ b/src/main/scala/firrtl/stage/FirrtlStage.scala
@@ -8,8 +8,7 @@ import firrtl.options.phases.DeletedWrapper
 import firrtl.stage.phases.CatchExceptions
 
 class FirrtlPhase
-    extends PhaseManager(targets=Seq(Dependency[firrtl.stage.phases.Compiler],
-                                     Dependency[firrtl.stage.phases.WriteEmitted])) {
+    extends PhaseManager(targets=Seq(Dependency[firrtl.stage.phases.Compiler])) {
 
   override def invalidates(a: Phase) = false
 

--- a/src/main/scala/firrtl/stage/package.scala
+++ b/src/main/scala/firrtl/stage/package.scala
@@ -39,11 +39,9 @@ package object stage {
 
   private [firrtl] implicit object FirrtlExecutionResultView extends OptionsView[FirrtlExecutionResult] with LazyLogging {
 
-    private lazy val dummyWriteEmitted = new WriteEmitted
-
     def view(options: AnnotationSeq): FirrtlExecutionResult = {
       val emittedRes = options
-        .collect{ case DeletedAnnotation(dummyWriteEmitted.name, a: EmittedAnnotation[_]) => a.value.value }
+        .collect{ case a: EmittedAnnotation[_] => a.value.value }
         .mkString("\n")
 
       val emitters = options.collect{ case RunFirrtlTransformAnnotation(e: Emitter) => e }

--- a/src/main/scala/firrtl/stage/phases/Compiler.scala
+++ b/src/main/scala/firrtl/stage/phases/Compiler.scala
@@ -51,7 +51,7 @@ class Compiler extends Phase with Translator[AnnotationSeq, Seq[CompilerRun]] {
         Dependency[AddCircuit],
         Dependency[AddImplicitOutputFile])
 
-  override def optionalPrerequisiteOf = Seq(Dependency[WriteEmitted])
+  override def optionalPrerequisiteOf = Seq.empty
 
   override def invalidates(a: Phase) = false
 

--- a/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
+++ b/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
@@ -24,6 +24,8 @@ import java.io.PrintWriter
   *
   * Any annotations written to files will be deleted.
   */
+@deprecated("Annotations that mixin the HowToSerialize trait are automatically serialized by stages." +
+              "This will be removed in FIRRTL 1.5", "FIRRTL 1.4.0")
 class WriteEmitted extends Phase {
 
   override def prerequisites = Seq.empty

--- a/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
+++ b/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
@@ -24,7 +24,7 @@ import java.io.PrintWriter
   *
   * Any annotations written to files will be deleted.
   */
-@deprecated("Annotations that mixin the HowToSerialize trait are automatically serialized by stages." +
+@deprecated("Annotations that mixin the CustomFileEmission trait are automatically serialized by stages." +
               "This will be removed in FIRRTL 1.5", "FIRRTL 1.4.0")
 class WriteEmitted extends Phase {
 

--- a/src/test/scala/firrtl/stage/phases/tests/DriverCompatibilitySpec.scala
+++ b/src/test/scala/firrtl/stage/phases/tests/DriverCompatibilitySpec.scala
@@ -125,7 +125,7 @@ class DriverCompatibilitySpec extends AnyFlatSpec with Matchers with PrivateMeth
   new PhaseFixture(new AddImplicitFirrtlFile) {
     val annotations = Seq( TopNameAnnotation("foo") )
     val expected = annotations.toSet +
-      FirrtlFileAnnotation(new File("./foo.fir").getPath())
+      FirrtlFileAnnotation(new File("foo.fir").getPath())
 
     phase.transform(annotations).toSet should be (expected)
   }

--- a/src/test/scala/firrtl/stage/phases/tests/DriverCompatibilitySpec.scala
+++ b/src/test/scala/firrtl/stage/phases/tests/DriverCompatibilitySpec.scala
@@ -125,7 +125,7 @@ class DriverCompatibilitySpec extends AnyFlatSpec with Matchers with PrivateMeth
   new PhaseFixture(new AddImplicitFirrtlFile) {
     val annotations = Seq( TopNameAnnotation("foo") )
     val expected = annotations.toSet +
-      FirrtlFileAnnotation(new File("foo.fir").getCanonicalPath)
+      FirrtlFileAnnotation(new File("./foo.fir").getPath())
 
     phase.transform(annotations).toSet should be (expected)
   }

--- a/src/test/scala/firrtl/testutils/FirrtlSpec.scala
+++ b/src/test/scala/firrtl/testutils/FirrtlSpec.scala
@@ -104,13 +104,13 @@ trait FirrtlRunners extends BackendCompilationUtilities {
     val customName = s"${prefix}_custom"
     val customAnnos = getBaseAnnos(customName) ++: toAnnos((new GetNamespace) +: customTransforms) ++: customAnnotations
 
-    val customResult = (new firrtl.stage.FirrtlStage).run(customAnnos)
+    val customResult = (new firrtl.stage.FirrtlStage).execute(Array.empty, customAnnos)
     val nsAnno = customResult.collectFirst { case m: ModuleNamespaceAnnotation => m }.get
 
     val refSuggestedName = s"${prefix}_ref"
     val refAnnos = getBaseAnnos(refSuggestedName) ++: Seq(RunFirrtlTransformAnnotation(new RenameModules), nsAnno)
 
-    val refResult = (new firrtl.stage.FirrtlStage).run(refAnnos)
+    val refResult = (new firrtl.stage.FirrtlStage).execute(Array.empty, refAnnos)
     val refName = refResult.collectFirst({ case stage.FirrtlCircuitAnnotation(c) => c.main }).getOrElse(refSuggestedName)
 
     assert(BackendCompilationUtilities.yosysExpectSuccess(customName, refName, testDir, timesteps))
@@ -145,7 +145,7 @@ trait FirrtlRunners extends BackendCompilationUtilities {
       annotations ++:
       (customTransforms ++ extraCheckTransforms).map(RunFirrtlTransformAnnotation(_))
 
-    (new firrtl.stage.FirrtlStage).run(annos)
+    (new firrtl.stage.FirrtlStage).execute(Array.empty, annos)
 
     testDir
   }

--- a/src/test/scala/firrtlTests/execution/VerilogExecution.scala
+++ b/src/test/scala/firrtlTests/execution/VerilogExecution.scala
@@ -21,7 +21,8 @@ trait VerilogExecution extends TestExecution {
     // Run FIRRTL, emit Verilog file
     val cAnno = FirrtlCircuitAnnotation(c)
     val tdAnno = TargetDirAnnotation(testDir.getAbsolutePath)
-    (new FirrtlStage).run(AnnotationSeq(Seq(cAnno, tdAnno) ++ customAnnotations))
+
+    (new FirrtlStage).execute(Array.empty, AnnotationSeq(Seq(cAnno, tdAnno)) ++ customAnnotations)
 
     // Copy harness resource to test directory
     val harness = new File(testDir, s"top.cpp")

--- a/src/test/scala/firrtlTests/options/phases/WriteOutputAnnotationsSpec.scala
+++ b/src/test/scala/firrtlTests/options/phases/WriteOutputAnnotationsSpec.scala
@@ -146,7 +146,7 @@ private object WriteOutputAnnotationsSpec {
 
     override def toBytes: Option[Stream[Byte]] = Some(new StringBuilder(value).toStream.map(_.toByte))
 
-    override def replacements(file: File): Option[AnnotationSeq] = Some(Seq(Replacement(file.toString)))
+    override def replacements(file: File): AnnotationSeq = Seq(Replacement(file.toString))
 
   }
 

--- a/src/test/scala/firrtlTests/options/phases/WriteOutputAnnotationsSpec.scala
+++ b/src/test/scala/firrtlTests/options/phases/WriteOutputAnnotationsSpec.scala
@@ -156,7 +156,7 @@ private object WriteOutputAnnotationsSpec {
 
     override protected def suffix: Option[String] = Some(".Emission")
 
-    override def toBytes: Option[Iterable[Byte]] = Some(value.getBytes)
+    override def getBytes: Iterable[Byte] = value.getBytes
 
     override def replacements(file: File): AnnotationSeq = Seq(Replacement(file.toString))
 

--- a/src/test/scala/firrtlTests/options/phases/WriteOutputAnnotationsSpec.scala
+++ b/src/test/scala/firrtlTests/options/phases/WriteOutputAnnotationsSpec.scala
@@ -140,7 +140,7 @@ private object WriteOutputAnnotationsSpec {
 
   case class Custom(value: String) extends NoTargetAnnotation with CustomFileEmission {
 
-    override protected def baseFileName: String = "Custom"
+    override protected def baseFileName(a: AnnotationSeq): String = "Custom"
 
     override protected def suffix: Option[String] = Some(".Emission")
 

--- a/src/test/scala/firrtlTests/options/phases/WriteOutputAnnotationsSpec.scala
+++ b/src/test/scala/firrtlTests/options/phases/WriteOutputAnnotationsSpec.scala
@@ -144,7 +144,7 @@ private object WriteOutputAnnotationsSpec {
 
     override protected def suffix: Option[String] = Some(".Serialize")
 
-    override def howToSerialize: Option[String] = Some(value)
+    override def howToSerialize: Option[Stream[Char]] = Some(new StringBuilder(value).toStream)
 
     override def howToResume(file: File): Option[AnnotationSeq] = Some(Seq(HowToFindMe(file.toString)))
 

--- a/src/test/scala/firrtlTests/options/phases/WriteOutputAnnotationsSpec.scala
+++ b/src/test/scala/firrtlTests/options/phases/WriteOutputAnnotationsSpec.scala
@@ -12,6 +12,7 @@ import firrtl.options.{
   InputAnnotationFileAnnotation,
   OutputAnnotationFileAnnotation,
   Phase,
+  PhaseException,
   StageOptions,
   TargetDirAnnotation,
   WriteDeletedAnnotation}
@@ -128,6 +129,17 @@ class WriteOutputAnnotationsSpec extends AnyFlatSpec with Matchers with firrtl.t
 
     info(s"file '$serializedFileName' exists")
     new File(serializedFileName) should (exist)
+  }
+
+  it should "error if multiple annotations try to write to the same file" in new Fixture {
+    val file = new File("write-CustomFileEmission-annotations-error.anno.json")
+    val annotations = Seq( TargetDirAnnotation(dir),
+                           OutputAnnotationFileAnnotation(file.toString),
+                           WriteOutputAnnotationsSpec.Custom("foo"),
+                           WriteOutputAnnotationsSpec.Custom("bar") )
+    intercept[PhaseException] {
+      phase.transform(annotations)
+    }.getMessage should startWith ("Multiple CustomFileEmission annotations")
   }
 
 }

--- a/src/test/scala/firrtlTests/options/phases/WriteOutputAnnotationsSpec.scala
+++ b/src/test/scala/firrtlTests/options/phases/WriteOutputAnnotationsSpec.scala
@@ -144,7 +144,7 @@ private object WriteOutputAnnotationsSpec {
 
     override protected def suffix: Option[String] = Some(".Serialize")
 
-    override def howToSerialize: Option[Stream[Char]] = Some(new StringBuilder(value).toStream)
+    override def howToSerialize: Option[Stream[Byte]] = Some(new StringBuilder(value).toStream.map(_.toByte))
 
     override def howToResume(file: File): Option[AnnotationSeq] = Some(Seq(HowToFindMe(file.toString)))
 

--- a/src/test/scala/firrtlTests/options/phases/WriteOutputAnnotationsSpec.scala
+++ b/src/test/scala/firrtlTests/options/phases/WriteOutputAnnotationsSpec.scala
@@ -156,7 +156,7 @@ private object WriteOutputAnnotationsSpec {
 
     override protected def suffix: Option[String] = Some(".Emission")
 
-    override def toBytes: Option[Stream[Byte]] = Some(new StringBuilder(value).toStream.map(_.toByte))
+    override def toBytes: Option[Iterable[Byte]] = Some(value.getBytes)
 
     override def replacements(file: File): AnnotationSeq = Seq(Replacement(file.toString))
 

--- a/src/test/scala/firrtlTests/transforms/LegalizeReductions.scala
+++ b/src/test/scala/firrtlTests/transforms/LegalizeReductions.scala
@@ -65,7 +65,7 @@ circuit $name :
       TargetDirAnnotation(testDir.toString) ::
       CompilerAnnotation(new MinimumVerilogCompiler) ::
       Nil
-    val resultAnnos = (new FirrtlStage).run(annos)
+    val resultAnnos = (new FirrtlStage).transform(annos)
     val outputFilename = resultAnnos.collectFirst { case OutputFileAnnotation(f) => f }
     outputFilename.toRight(s"Output file not found!")
     // Copy Verilator harness


### PR DESCRIPTION
This adds an annotation mix-in, `CustomFileEmission`, that lets an annotation be serialized to a file as opposed to included in the output annotation JSON. An annotation then controls:

1. How it should be serialized to a string (method `toBytes`)
1. Which file to put this string in (methods `baseFileName`, `suffix`, `filename`)
1. How to replace the file-serialized annotation with some *other* annotations that let downstream stages know about the serialized file (method `replacements`)

The stage-global phase `WriteOutputAnnotations` is modified to handle `CustomFileEmission` annotations such that it writes their contents to the requested file and replaces them with their `replacements`. This means that the FIRRTL Stage-specific Phase `WriteEmitted` for writing emitted annotations is no longer necessary. This is thereby deprecated. A consequence of this is that emitted annotations are no longer deleted. This simplifies the reconstruction of the deprecated `FirrtlExecutionResult` because the deleted emitted annotation no longer has to be examined.

This migrates `EmittedAnnotation` and its children, e.g., `EmittedFirrtlCircuitAnnotation` to use this new file serialization approach. Other candidates for changing include blackbox helpers, memlib, and memory initialization.

This includes the following minor updates:

- `WriteOutputAnnotationsSpec` is updated to check the above logic of `CustomFileEmission`
- `VerilogExecution` is modified to use the `execute` method (which includes Stage-global Phases) as opposed to the `run` method (which does not). This is necessary so that `WriteOutputAnnotations` runs.

I would propose that this fixes #791, but would like @hcook feedback on this approach. As a fix for #791, any transform that wants to write a file needs to emit an annotation that mixes in `CustomFileEmission`. The default Phases common to every Stage take care of the rest.

- Fixes #1272. 
- (Supersedes) Closes #1269.
- (Supersedes) Closes #1267 

### Checklist

- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

#### TODO

- [x] Companion Chisel PRs: 
  - https://github.com/freechipsproject/chisel3/pull/1273
  - https://github.com/freechipsproject/chisel3/pull/1405
- [x] Switch to generate a `Stream[_]` instead of a `String`
- [x] Add behavior for ensuring file creation/uniqueness, appending, or auto-generating a new filename (see `ElaborationArtefacts`)

### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
- code refactoring
<!--   - code cleanup                       -->
<!-- - backend code generation -->
- new feature/API

### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

Adds the `CustomFileEmission` trait and changes the way file serialization works for `EmittedAnnotation`s. Removes `WriteEmitted`.

### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

No Verilog/FIRRTL generation changes.

### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!-- - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->