### PR TITLE
{Firrtl, Circuit}Option should be Unserializable

### DIFF
--- a/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
+++ b/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
@@ -5,7 +5,7 @@ package firrtl.stage
 import firrtl._
 import firrtl.ir.Circuit
 import firrtl.annotations.{Annotation, NoTargetAnnotation}
-import firrtl.options.{HasShellOptions, OptionsException, ShellOption}
+import firrtl.options.{HasShellOptions, OptionsException, ShellOption, Unserializable}
 
 
 import java.io.FileNotFoundException
@@ -14,12 +14,12 @@ import java.nio.file.NoSuchFileException
 /** Indicates that this is an [[firrtl.annotations.Annotation Annotation]] directly used in the construction of a
   * [[FirrtlOptions]] view.
   */
-sealed trait FirrtlOption { this: Annotation => }
+sealed trait FirrtlOption extends Unserializable { this: Annotation => }
 
 /** Indicates that this [[firrtl.annotations.Annotation Annotation]] contains information that is directly convertable
   * to a FIRRTL [[firrtl.ir.Circuit Circuit]].
   */
-sealed trait CircuitOption { this: Annotation =>
+sealed trait CircuitOption extends Unserializable { this: Annotation =>
 
   /** Convert this [[firrtl.annotations.Annotation Annotation]] to a [[FirrtlCircuitAnnotation]]
     */


### PR DESCRIPTION
This mixes in the `Unserializable` trait into `FirrtlOption` and `CircuitOption`. This has the effect of causing FIRRTL-specific options and FIRRTL-specific annotations (like `FirrtlCircuitAnnotation`) from not showing up in the output annotation JSON file.

This fixes #1272 by not writing the FIRRTL circuit to the output JSON file. The FIRRTL circuit should be serialized through an emitter transform (and not through an alternative means like #1277).

### Checklist

- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix (fixes #1272)
- performance improvement
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
- backend code generation (of the output annotation JSON only)
<!--   - new feature/API                    -->

### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

This would affect downstream stages that are expecting FIRRTL options (and a FIRRTL circuit) to exist in the input annotation JSON file. I'm not aware of any tools that are doing this, however.

### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

This modifies the generated annotation JSON file, but does not change output FIRRTL or Verilog.

### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.
