### PR TITLE
Improve infer resets

### DIFF
--- a/src/main/scala/firrtl/transforms/InferResets.scala
+++ b/src/main/scala/firrtl/transforms/InferResets.scala
@@ -103,19 +103,18 @@ class InferResets extends Transform {
       def onStmt(map: DriverMap)(stmt: Statement): Unit = {
         // Mark driver of a ResetType leaf
         def markResetDriver(lhs: Expression, rhs: Expression): Unit = {
-          val lflip = Utils.to_flip(Utils.gender(lhs))
-          if ((lflip == Default && lhs.tpe == ResetType) ||
-              (lflip == Flip    && rhs.tpe == ResetType)) {
-            val (loc, exp) = lflip match {
-              case Default => (lhs, rhs)
-              case Flip    => (rhs, lhs)
-            }
-            val target = makeTarget(loc)
+          val con = Utils.flow(lhs) match {
+            case SinkFlow   if lhs.tpe == ResetType => Some((lhs, rhs))
+            case SourceFlow if rhs.tpe == ResetType => Some((rhs, lhs))
+            // If sink is not ResetType, do nothing
+            case _                                  => None
+          }
+          con.foreach { case (loc, exp) =>
             val driver = exp.tpe match {
               case ResetType => TargetDriver(makeTarget(exp))
               case tpe       => TypeDriver(tpe, () => makeTarget(exp))
             }
-            map.getOrElseUpdate(target, mutable.ListBuffer()) += driver
+            map.getOrElseUpdate(makeTarget(loc), mutable.ListBuffer()) += driver
           }
         }
         stmt match {
@@ -166,8 +165,8 @@ class InferResets extends Transform {
     val res = mutable.Map[ReferenceTarget, Type]()
     val errors = new Errors
     def rec(target: ReferenceTarget): Type = {
-      val drivers = map.getOrElse(target, Nil)
       res.getOrElseUpdate(target, {
+        val drivers = map.getOrElse(target, Nil)
         val tpes = drivers.flatMap {
           case TargetDriver(t) => rec(t) match {
             // Squash drivers that themselves are undriven


### PR DESCRIPTION
**Note:** While writing this up, my opinion changed to being that the right thing to do is allow overriding the type via last connect semantics. I came to this conclusion after doing all of this work and thinking hard about the section **Remaining question** (see below). My new plan is to take that approach but I'm going ahead with opening the PR to show what I've done and create a place for discussion.

This PR does three things:
1. InferResets will no longer crash if a component of type Reset has no
   drivers; it will leave the type uninferred
2. Components of type Reset that are only invalidated or have no driver
   are no longer considered for inferring the type of downstream Resets
3. Minor cleanups (see cleanup commit)

### Checklist

- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

- bug fix
- code cleanup
- new feature/API

### API Impact

I would argue this is primarily a bug fix, but it is certainly arguably an API expansion. We disallow driving a component of type `Reset` with more than one concrete reset type. Since there are only two, I can put this another way, it is illegal to drive a component of type `Reset` with both `AsyncReset` and `UInt<1>`. This is the obvious behavior with regards to `when` statements since it does not make sense to change the type dynamically in the hardware. To be consistent with that behavior, multiple types are also disallowed with standard last connect whether or not there is a `when` involved.

For example, the following is illegal:
```
wire x : UInt<1>
wire y : AsyncReset
wire w : Reset
w <= x
w <= y
```

This PR does **not** change that behavior; however, it does fix a bug in a way that relates to the above behavior.

Currently, the following will crash in InferResets
```
wire w : Reset
w is invalid   ; crashes with or without this line
wire x : Reset
x <= w
x <= someOtherReset
```
The issue is that `w` has no driver (except invalidation). This leads to the following question: "What effect should `w` have on the type of `x`?" My argument and the behavior implemented in this PR, is that `w` should have no effect on the type of `x`. Since `w` itself has no concrete type, it should be ignored.

### Remaining question

There is one remaining question that I have not yet answered though. What should the concrete type of `w` then be? Because it is invalidated, should it default to `UInt<1>` since we default invalidated things to being driven by 0? In the above example, there's no real issue with `w` being undriven, but what should happen in cases like the following?

```
wire w : Reset
w is invalid
wire x : Reset
x <= someOtherReset
x <= w
```
Now, `w` is the connect that wins on `x`, what type should `w` and `x` get? This PR is giving `x` the type of `someOtherReset` which, currently just silently works. However, I think this behavior is not good. I think there are ~~3~~ 2 options:
1. Default type of `w` is `UInt<1>` and now the type of `x` should be `UInt<1>`, this would be hard to reconcile with the behavior proposed in this PR
2. ~~Make it illegal for a `Reset` to be uninferred.~~ This doesn't make sense, the above would be an error
3. Just switch to allowing last connect semantics to override the type



### Backend Code Generation Impact

No effect

### Desired Merge Strategy

- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

Although it doesn't matter that much
