### PR TITLE
[wip] Move InferResets later

### DIFF
--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -58,9 +58,11 @@ case class CircuitState(
     * @param targets
     * @return
     */
-  def resolvePaths(targets: Seq[CompleteTarget]): CircuitState = {
-    val newCS = new EliminateTargetPaths().runTransform(this.copy(annotations = ResolvePaths(targets) +: annotations ))
-    newCS.copy(form = form)
+  def resolvePaths(targets: Seq[CompleteTarget]): CircuitState = targets match {
+    case Nil => this
+    case _ =>
+      val newCS = new EliminateTargetPaths().runTransform(this.copy(annotations = ResolvePaths(targets) +: annotations ))
+      newCS.copy(form = form)
   }
 
   /** Returns a new CircuitState with the targets of every annotation of a type in annoClasses

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -48,8 +48,8 @@ class ResolveAndCheck extends CoreTransform {
     new passes.InferBinaryPoints(),
     new passes.TrimIntervals(),
     new passes.InferWidths,
-    passes.CheckWidths,
-    new firrtl.transforms.InferResets)
+    passes.CheckWidths
+  )
 }
 
 /** Expands aggregate connects, removes dynamic accesses, and when
@@ -69,11 +69,13 @@ class HighFirrtlToMiddleFirrtl extends CoreTransform {
     passes.ExpandWhens,
     passes.CheckInitialization,
     passes.ResolveKinds,
+    passes.ResolveFlows,
+    new firrtl.transforms.InferResets,
     passes.InferTypes,
     passes.CheckTypes,
-    passes.ResolveFlows,
     new passes.InferWidths,
     passes.CheckWidths,
+    new firrtl.transforms.DedupModules,
     new passes.RemoveIntervals(),
     passes.ConvertFixedToSInt,
     passes.ZeroWidth,

--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -399,6 +399,7 @@ object Utils extends LazyLogging {
   def mux_type(t1: Type, t2: Type): Type = (t1, t2) match {
     case (ClockType, ClockType) => ClockType
     case (AsyncResetType, AsyncResetType) => AsyncResetType
+    case (ResetType, ResetType) => ResetType
     case (t1: UIntType, t2: UIntType) => UIntType(UnknownWidth)
     case (t1: SIntType, t2: SIntType) => SIntType(UnknownWidth)
     case (t1: FixedType, t2: FixedType) => FixedType(UnknownWidth, UnknownWidth)
@@ -419,6 +420,7 @@ object Utils extends LazyLogging {
     (t1, t2) match {
       case (ClockType, ClockType) => ClockType
       case (AsyncResetType, AsyncResetType) => AsyncResetType
+      case (ResetType, ResetType) => ResetType
       case (t1x: UIntType, t2x: UIntType) => UIntType(IsMax(t1x.width, t2x.width))
       case (t1x: SIntType, t2x: SIntType) => SIntType(IsMax(t1x.width, t2x.width))
       case (FixedType(w1, p1), FixedType(w2, p2)) =>
@@ -493,12 +495,10 @@ object Utils extends LazyLogging {
       case (ClockType, ClockType) => if (flip1 == flip2) Seq((0, 0)) else Nil
       case (AsyncResetType, AsyncResetType) => if (flip1 == flip2) Seq((0, 0)) else Nil
       // The following two cases handle driving ResetType from other legal reset types
-      // Flippedness is important here because ResetType can be driven by other reset types, but it
-      //   cannot *drive* other reset types
       case (ResetType, other) =>
         if (legalResetType(other) && flip1 == Default && flip1 == flip2) Seq((0, 0)) else Nil
       case (other, ResetType) =>
-        if (legalResetType(other) && flip1 == Flip && flip1 == flip2) Seq((0, 0)) else Nil
+        if (legalResetType(other) && flip1 == flip2) Seq((0, 0)) else Nil
       case _ => throwInternalError(s"get_valid_points: shouldn't be here - ($t1, $t2)")
     }
   }

--- a/src/main/scala/firrtl/annotations/transforms/EliminateTargetPaths.scala
+++ b/src/main/scala/firrtl/annotations/transforms/EliminateTargetPaths.scala
@@ -5,7 +5,7 @@ package firrtl.annotations.transforms
 import firrtl.Mappers._
 import firrtl.analyses.InstanceGraph
 import firrtl.annotations.ModuleTarget
-import firrtl.annotations.TargetToken.{Instance, OfModule}
+import firrtl.annotations.TargetToken.{Instance, OfModule, fromDefModuleToTargetToken}
 import firrtl.annotations.analysis.DuplicationHelper
 import firrtl.annotations._
 import firrtl.ir._
@@ -54,22 +54,16 @@ class EliminateTargetPaths extends Transform {
     * @param s
     * @return
     */
-  private def onStmt(dupMap: DuplicationHelper,
-                     oldUsedOfModules: mutable.HashSet[String],
-                     newUsedOfModules: mutable.HashSet[String])
+  private def onStmt(dupMap: DuplicationHelper)
                     (originalModule: String, newModule: String)
                     (s: Statement): Statement = s match {
     case d@DefInstance(_, name, module) =>
       val ofModule = dupMap.getNewOfModule(originalModule, newModule, Instance(name), OfModule(module)).value
-      newUsedOfModules += ofModule
-      oldUsedOfModules += module
       d.copy(module = ofModule)
     case d@WDefInstance(_, name, module, _) =>
       val ofModule = dupMap.getNewOfModule(originalModule, newModule, Instance(name), OfModule(module)).value
-      newUsedOfModules += ofModule
-      oldUsedOfModules += module
       d.copy(module = ofModule)
-    case other => other map onStmt(dupMap, oldUsedOfModules, newUsedOfModules)(originalModule, newModule)
+    case other => other map onStmt(dupMap)(originalModule, newModule)
   }
 
   /** Returns a modified circuit and [[RenameMap]] containing the associated target remapping
@@ -84,14 +78,6 @@ class EliminateTargetPaths extends Transform {
     // For each target, record its path and calculate the necessary modifications to circuit
     targets.foreach { t => dupMap.expandHierarchy(t) }
 
-    // Records original list of used ofModules
-    val oldUsedOfModules = mutable.HashSet[String]()
-    oldUsedOfModules += cir.main
-
-    // Records new list of used ofModules
-    val newUsedOfModules = mutable.HashSet[String]()
-    newUsedOfModules += cir.main
-
     // Contains new list of module declarations
     val duplicatedModuleList = mutable.ArrayBuffer[DefModule]()
 
@@ -102,19 +88,13 @@ class EliminateTargetPaths extends Transform {
         val newM = m match {
           case e: ExtModule => e.copy(name = newName)
           case o: Module =>
-            o.copy(name = newName, body = onStmt(dupMap, oldUsedOfModules, newUsedOfModules)(m.name, newName)(o.body))
+            o.copy(name = newName, body = onStmt(dupMap)(m.name, newName)(o.body))
         }
         duplicatedModuleList += newM
       }
     }
 
-    // Calculate the final module list
-    // A module is in the final list if:
-    // 1) it is a module that is instantiated (new or old)
-    // 2) it is an old module that was not instantiated and is still not instantiated
-    val finalModuleList = duplicatedModuleList.filter(m =>
-      newUsedOfModules.contains(m.name) || (!newUsedOfModules.contains(m.name) && !oldUsedOfModules.contains(m.name))
-    )
+    val finalModuleList = duplicatedModuleList
     lazy val finalModuleSet = finalModuleList.map{ case a: DefModule => a.name }.toSet
 
     // Records how targets have been renamed
@@ -125,7 +105,7 @@ class EliminateTargetPaths extends Transform {
      */
     targets.foreach { t =>
       val newTsx = dupMap.makePathless(t)
-      val newTs = newTsx.filter(c => newUsedOfModules.contains(c.moduleOpt.get))
+      val newTs = newTsx
       if(newTs.nonEmpty) {
         renameMap.record(t, newTs)
         val m = Target.referringModule(t)
@@ -134,7 +114,7 @@ class EliminateTargetPaths extends Transform {
           case a: ModuleTarget if finalModuleSet(a.module) => Some(a)
           case _                                           => None
         }
-        renameMap.record(m, (duplicatedModules ++ oldModule).distinct)
+        renameMap.record(m, (duplicatedModules).distinct)
       }
     }
 
@@ -153,7 +133,8 @@ class EliminateTargetPaths extends Transform {
     val targets = annotations.map(_.asInstanceOf[ResolvePaths]).flatMap(_.targets.collect { case x: IsMember => x })
 
     // Check validity of paths in targets
-    val instanceOfModules = new InstanceGraph(state.circuit).getChildrenInstanceOfModule
+    val iGraph = new InstanceGraph(state.circuit)
+    val instanceOfModules = iGraph.getChildrenInstanceOfModule
     val targetsWithInvalidPaths = mutable.ArrayBuffer[IsMember]()
     targets.foreach { t =>
       val path = t match {
@@ -176,6 +157,23 @@ class EliminateTargetPaths extends Transform {
 
     val (newCircuit, renameMap) = run(state.circuit, targets)
 
-    state.copy(circuit = newCircuit, renames = Some(renameMap), annotations = annotationsx)
+    val iGraphx = new InstanceGraph(newCircuit)
+    val newlyUnreachableModules = iGraphx.unreachableModules diff iGraph.unreachableModules
+
+    val newCircuitGC = {
+      val modulesx = newCircuit.modules.flatMap{
+        case dead if newlyUnreachableModules(dead.OfModule) => None
+        case live =>
+          val m = CircuitTarget(newCircuit.main).module(live.name)
+          renameMap.get(m).foreach(_ => renameMap.record(m, m))
+          Some(live)
+      }
+      newCircuit.copy(modules = modulesx)
+    }
+
+    logger.info("Renames:")
+    logger.info(renameMap.serialize)
+
+    state.copy(circuit = newCircuitGC, renames = Some(renameMap), annotations = annotationsx)
   }
 }

--- a/src/test/scala/firrtlTests/InferResetsSpec.scala
+++ b/src/test/scala/firrtlTests/InferResetsSpec.scala
@@ -5,7 +5,6 @@ package firrtlTests
 import firrtl._
 import firrtl.ir._
 import firrtl.passes.{CheckHighForm, CheckTypes, CheckInitialization}
-import firrtl.transforms.InferResets
 import FirrtlCheckers._
 
 // TODO
@@ -189,8 +188,8 @@ class InferResetsSpec extends FirrtlFlatSpec {
   }
 
   it should "not allow different Reset Types to drive a single Reset" in {
-    an [InferResets.DifferingDriverTypesException] shouldBe thrownBy {
-      val result = compile(s"""
+    val passExceptions = the [passes.PassExceptions] thrownBy {
+      compile(s"""
         |circuit top :
         |  module top :
         |    input reset0 : AsyncReset
@@ -207,6 +206,8 @@ class InferResetsSpec extends FirrtlFlatSpec {
         |""".stripMargin
       )
     }
+    passExceptions.exceptions should contain (_: CheckTypes.MuxSameType)
+    passExceptions.exceptions should contain (_: CheckTypes.InvalidRegInit)
   }
 
   it should "allow concrete reset types to overrule invalidation" in {


### PR DESCRIPTION
### Dependencies

- fixes #1300 
- prerequisites: [#1302, #1370, #1388, #1391, #1392, #1394]

### Checklist

- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix                            
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

No API impact.

### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

Module names may change due to to deduplication/duplication to resolve `InferResets`.

### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.
