### PR TITLE
Dedup PassTests, add NoCircuitDedupAnnotations

### DIFF
--- a/src/test/scala/firrtlTests/FlattenTests.scala
+++ b/src/test/scala/firrtlTests/FlattenTests.scala
@@ -9,7 +9,7 @@ import firrtl.ir.Circuit
 import firrtl.Parser
 import firrtl.passes.PassExceptions
 import firrtl.annotations.{Annotation, CircuitName, ComponentName, ModuleName, Named}
-import firrtl.transforms.{FlattenAnnotation, Flatten}
+import firrtl.transforms.{FlattenAnnotation, Flatten, NoCircuitDedupAnnotation}
 import logger.{LogLevel, Logger}
 import logger.LogLevel.Debug
 
@@ -159,7 +159,7 @@ class FlattenTests extends LowTransformSpec {
           |    input a : UInt<32>
           |    output b : UInt<32>
           |    b <= a""".stripMargin
-     execute(input, check, Seq(flatten("Top.i")))
+     execute(input, check, Seq(flatten("Top.i"), NoCircuitDedupAnnotation))
   }
   "The module Inline1" should "be inlined" in {
     val input =
@@ -222,7 +222,7 @@ class FlattenTests extends LowTransformSpec {
           |    input a : UInt<32>
           |    output b : UInt<32>
           |    b <= a""".stripMargin
-     execute(input, check, Seq(flatten("Inline1")))
+     execute(input, check, Seq(flatten("Inline1"), NoCircuitDedupAnnotation))
   }
   "The Flatten transform" should "do nothing if no flatten annotations are present" in{
     val input =

--- a/src/test/scala/firrtlTests/InlineInstancesTests.scala
+++ b/src/test/scala/firrtlTests/InlineInstancesTests.scala
@@ -10,6 +10,7 @@ import firrtl.Parser
 import firrtl.passes.PassExceptions
 import firrtl.annotations._
 import firrtl.passes.{InlineAnnotation, InlineInstances}
+import firrtl.transforms.NoCircuitDedupAnnotation
 import logger.{LogLevel, Logger}
 import logger.LogLevel.Debug
 
@@ -442,6 +443,7 @@ class InlineInstancesTests extends LowTransformSpec {
        Seq(
          inline("Inline"),
          inline("NestedInline"),
+         NoCircuitDedupAnnotation,
          DummyAnno(inlined.ref("a")),
          DummyAnno(inlined.ref("b")),
          DummyAnno(nestedInlined.ref("a")),

--- a/src/test/scala/firrtlTests/PassTests.scala
+++ b/src/test/scala/firrtlTests/PassTests.scala
@@ -8,6 +8,7 @@ import org.scalatest.junit.JUnitRunner
 import firrtl.ir.Circuit
 import firrtl.Parser.UseInfo
 import firrtl.passes.{Pass, PassExceptions, RemoveEmpty}
+import firrtl.transforms.DedupModules
 import firrtl._
 import firrtl.annotations._
 import logger._
@@ -73,6 +74,7 @@ trait LowTransformSpec extends SimpleTransformSpec {
       new ChirrtlToHighFirrtl(),
       new IRToWorkingIR(),
       new ResolveAndCheck(),
+      new DedupModules(),
       new HighFirrtlToMiddleFirrtl(),
       new MiddleFirrtlToLowFirrtl(),
       new CustomResolveAndCheck(LowForm),
@@ -87,6 +89,7 @@ trait MiddleTransformSpec extends SimpleTransformSpec {
       new ChirrtlToHighFirrtl(),
       new IRToWorkingIR(),
       new ResolveAndCheck(),
+      new DedupModules(),
       new HighFirrtlToMiddleFirrtl(),
       new CustomResolveAndCheck(MidForm),
       transform
@@ -100,6 +103,7 @@ trait HighTransformSpec extends SimpleTransformSpec {
       new ChirrtlToHighFirrtl(),
       new IRToWorkingIR(),
       new CustomResolveAndCheck(HighForm),
+      new DedupModules(),
       transform
    )
 }

--- a/src/test/scala/firrtlTests/transforms/GroupComponentsSpec.scala
+++ b/src/test/scala/firrtlTests/transforms/GroupComponentsSpec.scala
@@ -2,7 +2,7 @@ package firrtlTests
 package transforms
 
 import firrtl.annotations.{CircuitName, ComponentName, ModuleName}
-import firrtl.transforms.{GroupAnnotation, GroupComponents}
+import firrtl.transforms.{GroupAnnotation, GroupComponents, NoCircuitDedupAnnotation}
 import firrtl._
 import firrtl.ir._
 
@@ -112,9 +112,10 @@ class GroupComponentsSpec extends MiddleTransformSpec {
          |    output out: UInt<8>
          |    out <= UInt(2)
       """.stripMargin
-    val groups = Seq(
+    val annotations = Seq(
       GroupAnnotation(Seq(topComp("c1a"), topComp("c2a")/*, topComp("asum")*/), "A", "cA", Some("_OUT"), Some("_IN")),
-      GroupAnnotation(Seq(topComp("c1b"), topComp("c2b")/*, topComp("bsum")*/), "B", "cB", Some("_OUT"), Some("_IN"))
+      GroupAnnotation(Seq(topComp("c1b"), topComp("c2b")/*, topComp("bsum")*/), "B", "cB", Some("_OUT"), Some("_IN")),
+      NoCircuitDedupAnnotation
     )
     val check =
       s"""circuit Top :
@@ -152,7 +153,7 @@ class GroupComponentsSpec extends MiddleTransformSpec {
          |    output out: UInt<8>
          |    out <= UInt(2)
       """.stripMargin
-    execute(input, check, groups)
+    execute(input, check, annotations)
   }
   "The two sets of instances" should "be grouped with their nodes" in {
     val input =
@@ -179,9 +180,10 @@ class GroupComponentsSpec extends MiddleTransformSpec {
          |    output out: UInt<8>
          |    out <= UInt(2)
       """.stripMargin
-    val groups = Seq(
+    val annotations = Seq(
       GroupAnnotation(Seq(topComp("c1a"), topComp("c2a"), topComp("asum")), "A", "cA", Some("_OUT"), Some("_IN")),
-      GroupAnnotation(Seq(topComp("c1b"), topComp("c2b"), topComp("bsum")), "B", "cB", Some("_OUT"), Some("_IN"))
+      GroupAnnotation(Seq(topComp("c1b"), topComp("c2b"), topComp("bsum")), "B", "cB", Some("_OUT"), Some("_IN")),
+      NoCircuitDedupAnnotation
     )
     val check =
       s"""circuit Top :
@@ -215,7 +217,7 @@ class GroupComponentsSpec extends MiddleTransformSpec {
          |    output out: UInt<8>
          |    out <= UInt(2)
       """.stripMargin
-    execute(input, check, groups)
+    execute(input, check, annotations)
   }
 
   "The two sets of instances" should "be grouped with one not grouped" in {
@@ -249,9 +251,10 @@ class GroupComponentsSpec extends MiddleTransformSpec {
          |    output out: UInt
          |    out <= in
       """.stripMargin
-    val groups = Seq(
+    val annotations = Seq(
       GroupAnnotation(Seq(topComp("c1a"), topComp("c2a"), topComp("asum")), "A", "cA", Some("_OUT"), Some("_IN")),
-      GroupAnnotation(Seq(topComp("c1b"), topComp("c2b"), topComp("bsum")), "B", "cB", Some("_OUT"), Some("_IN"))
+      GroupAnnotation(Seq(topComp("c1b"), topComp("c2b"), topComp("bsum")), "B", "cB", Some("_OUT"), Some("_IN")),
+      NoCircuitDedupAnnotation
     )
     val check =
       s"""circuit Top :
@@ -291,7 +294,7 @@ class GroupComponentsSpec extends MiddleTransformSpec {
          |    output out: UInt<10>
          |    out <= in
       """.stripMargin
-    execute(input, check, groups)
+    execute(input, check, annotations)
   }
 
   "The two sets of instances" should "be grouped with a connection between them" in {


### PR DESCRIPTION
This adds deduplication to `PassTests` , e.g., `LowTransformSpec`, to better align these tests with what actually happens in the FIRRTL compiler or if another core transform internally uses deduplication.

Three tests (inlining, flattening, and grouping) all had baked in assumptions that would not work once deduplication was turned on. This fixes these tests by adding `NoCircuitDedupAnnotation` to disable deduplication for these tests.

### Checklist

- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix                           
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
- new feature/API (**for testing only!**)

### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

This modifies the current testing API. This is only internally used and is not published. Therefore, there is no *public* API impact.

### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
