### PR TITLE
Change LoggerState.globalLevel to Warn

### DIFF
--- a/src/main/scala/logger/Logger.scala
+++ b/src/main/scala/logger/Logger.scala
@@ -54,7 +54,7 @@ trait LazyLogging {
   * when used in multi-threaded environments
   */
 private class LoggerState {
-  var globalLevel = LogLevel.None
+  var globalLevel = LogLevel.Warn
   val classLevels = new scala.collection.mutable.HashMap[String, LogLevel.Value]
   val classToLevelCache = new scala.collection.mutable.HashMap[String, LogLevel.Value]
   var logClassNames = false

--- a/src/test/scala/loggertests/LoggerSpec.scala
+++ b/src/test/scala/loggertests/LoggerSpec.scala
@@ -12,6 +12,7 @@ object LoggerSpec {
   val InfoMsg = "message info"
   val DebugMsg = "message debug"
   val TraceMsg = "message trace"
+  val globalLevel = LogLevel.Warn
 }
 
 class Logger1 extends LazyLogging {
@@ -37,7 +38,7 @@ class LogsInfo3 extends LazyLogging {
 class LoggerSpec extends FreeSpec with Matchers with OneInstancePerTest with LazyLogging {
   "Logger is a simple but powerful logging system" - {
     "Following tests show how global level can control logging" - {
-      "only error shows up by default" in {
+      "only warn and error shows up by default" in {
         Logger.makeScope() {
           val captor = new OutputCaptor
           Logger.setOutput(captor.printStream)
@@ -47,10 +48,10 @@ class LoggerSpec extends FreeSpec with Matchers with OneInstancePerTest with Laz
           val messagesLogged = captor.getOutputAsString
 
           messagesLogged.contains(LoggerSpec.ErrorMsg) should be(true)
-          messagesLogged.contains(LoggerSpec.WarnMsg) should be(false)
-          messagesLogged.contains(LoggerSpec.InfoMsg) should be(false)
-          messagesLogged.contains(LoggerSpec.DebugMsg) should be(false)
-          messagesLogged.contains(LoggerSpec.TraceMsg) should be(false)
+          messagesLogged.contains(LoggerSpec.WarnMsg) should be(LogLevel.Warn <= LoggerSpec.globalLevel)
+          messagesLogged.contains(LoggerSpec.InfoMsg) should be(LogLevel.Info <= LoggerSpec.globalLevel)
+          messagesLogged.contains(LoggerSpec.DebugMsg) should be(LogLevel.Debug <= LoggerSpec.globalLevel)
+          messagesLogged.contains(LoggerSpec.TraceMsg) should be(LogLevel.Trace <= LoggerSpec.globalLevel)
         }
       }
 
@@ -285,7 +286,7 @@ class LoggerSpec extends FreeSpec with Matchers with OneInstancePerTest with Laz
         }
       }
       "Show that nested makeScopes share same state" in {
-        Logger.getGlobalLevel should be (LogLevel.None)
+        Logger.getGlobalLevel should be (LoggerSpec.globalLevel)
 
         Logger.makeScope() {
           Logger.setLevel(LogLevel.Info)
@@ -304,17 +305,17 @@ class LoggerSpec extends FreeSpec with Matchers with OneInstancePerTest with Laz
           Logger.getGlobalLevel should be (LogLevel.Debug)
         }
 
-        Logger.getGlobalLevel should be (LogLevel.None)
+        Logger.getGlobalLevel should be (LoggerSpec.globalLevel)
       }
 
       "Show that first makeScope starts with fresh state" in {
-        Logger.getGlobalLevel should be (LogLevel.None)
+        Logger.getGlobalLevel should be (LoggerSpec.globalLevel)
 
         Logger.setLevel(LogLevel.Warn)
         Logger.getGlobalLevel should be (LogLevel.Warn)
 
         Logger.makeScope() {
-          Logger.getGlobalLevel should be (LogLevel.None)
+          Logger.getGlobalLevel should be (LoggerSpec.globalLevel)
 
           Logger.setLevel(LogLevel.Trace)
           Logger.getGlobalLevel should be (LogLevel.Trace)

--- a/src/test/scala/loggertests/LoggerSpec.scala
+++ b/src/test/scala/loggertests/LoggerSpec.scala
@@ -38,6 +38,25 @@ class LogsInfo3 extends LazyLogging {
 class LoggerSpec extends FreeSpec with Matchers with OneInstancePerTest with LazyLogging {
   "Logger is a simple but powerful logging system" - {
     "Following tests show how global level can control logging" - {
+
+      "setting level to None will result in only error messages" in {
+        Logger.makeScope() {
+          val captor = new OutputCaptor
+          Logger.setOutput(captor.printStream)
+          Logger.setLevel(LogLevel.None)
+
+          val r1 = new Logger1
+          r1.run()
+          val messagesLogged = captor.getOutputAsString
+
+          messagesLogged.contains(LoggerSpec.ErrorMsg) should be(true)
+          messagesLogged.contains(LoggerSpec.WarnMsg) should be(false)
+          messagesLogged.contains(LoggerSpec.InfoMsg) should be(false)
+          messagesLogged.contains(LoggerSpec.DebugMsg) should be(false)
+          messagesLogged.contains(LoggerSpec.TraceMsg) should be(false)
+        }
+      }
+
       "only warn and error shows up by default" in {
         Logger.makeScope() {
           val captor = new OutputCaptor


### PR DESCRIPTION
PR #1305 changes the `globalLogLevel` in `LogLevelAnnotation` to from `None` to `Warn`. Update the default `LoggerState.globalLevel` to `Warn` as well.

### Checklist

- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

- bug fix - 3c8e22d inadvertently disabled `printf()` in tests.

<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

### API Impact

This restores default behavior prior to 3c8e22d which had a side-effect of suppressing `printf()` in tests.

### Backend Code Generation Impact

This restores generation of Verilog `$fwrite()` which would have been removed by 3c8e22d

### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
 - Squash: The PR will be squashed and merged (choose this if you have no preference. 
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
