### PR TITLE
Filter ResolvePaths in EliminateTargetPaths

### DIFF
--- a/src/main/scala/firrtl/annotations/transforms/EliminateTargetPaths.scala
+++ b/src/main/scala/firrtl/annotations/transforms/EliminateTargetPaths.scala
@@ -133,10 +133,13 @@ class EliminateTargetPaths extends Transform {
 
   override protected def execute(state: CircuitState): CircuitState = {
 
-    val annotations = state.annotations.collect { case a: ResolvePaths => a }
+    val (annotations, annotationsx) = state.annotations.partition{
+      case a: ResolvePaths => true
+      case _               => false
+    }
 
     // Collect targets that are not local
-    val targets = annotations.flatMap(_.targets.collect { case x: IsMember => x })
+    val targets = annotations.map(_.asInstanceOf[ResolvePaths]).flatMap(_.targets.collect { case x: IsMember => x })
 
     // Check validity of paths in targets
     val instanceOfModules = new InstanceGraph(state.circuit).getChildrenInstanceOfModule
@@ -162,6 +165,6 @@ class EliminateTargetPaths extends Transform {
 
     val (newCircuit, renameMap) = run(state.circuit, targets)
 
-    state.copy(circuit = newCircuit, renames = Some(renameMap))
+    state.copy(circuit = newCircuit, renames = Some(renameMap), annotations = annotationsx)
   }
 }

--- a/src/test/scala/firrtlTests/annotationTests/EliminateTargetPathsSpec.scala
+++ b/src/test/scala/firrtlTests/annotationTests/EliminateTargetPathsSpec.scala
@@ -357,4 +357,19 @@ class EliminateTargetPathsSpec extends FirrtlPropSpec with FirrtlMatchers {
       outputLines should contain (line)
     }
   }
+
+  property("It should remove ResolvePaths annotations") {
+      val input =
+      """|circuit Foo:
+         |  module Bar:
+         |    skip
+         |  module Foo:
+         |    inst bar of Bar
+         |""".stripMargin
+
+    CircuitState(passes.ToWorkingIR.run(Parser.parse(input)), UnknownForm, Nil)
+      .resolvePaths(Seq(CircuitTarget("Foo").module("Foo").instOf("bar", "Bar")))
+      .annotations
+      .collect{ case a: firrtl.annotations.transforms.ResolvePaths => a } should be (empty)
+  }
 }


### PR DESCRIPTION
Change EliminateTargetPaths to remove ResolvePaths annotations in the
output AnnotationSeq. This prevents a bug whereby the upstream
ResolvePaths annotations from previous runs of EliminateTargetPaths
can result in unexpected duplication.

Adds a test that checks that ResolvePaths annotations are actually
removed.

Fixes #1308.

### Checklist

- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

No effect. If users are relying on the buggy behavior, then this would affect their designs.

### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
