### PR TITLE
Cleanup Named Targets

### DIFF
--- a/src/main/scala/firrtl/annotations/transforms/CleanupNamedTargets.scala
+++ b/src/main/scala/firrtl/annotations/transforms/CleanupNamedTargets.scala
@@ -1,0 +1,66 @@
+// See LICENSE for license details.
+
+package firrtl.annotations.transforms
+
+import firrtl._
+import firrtl.annotations.{CircuitTarget, ModuleTarget, MultiTargetAnnotation, ReferenceTarget, SingleTargetAnnotation}
+import firrtl.ir
+import firrtl.options.{Dependency, PreservesAll}
+import firrtl.traversals.Foreachers._
+
+import scala.collection.immutable.{Set => ISet}
+
+/** Replaces all [[firrtl.annotations.ReferenceTarget ReferenceTargets]] pointing at instances with
+  * [[firrtl.annotations.InstanceTarget InstanceTargets]].
+  *
+  * @note This exists because of [[firrtl.annotations.Named Named]] where a [[firrtl.annotations.ComponentName
+  * ComponentName]] is the only way to refer to an instance, but this is resolved incorrectly to a
+  * [[firrtl.annotations.ReferenceTarget ReferenceTarget]].
+  */
+class CleanupNamedTargets extends Transform with DependencyAPIMigration {
+
+  override def prerequisites = Seq(Dependency(passes.RemoveCHIRRTL))
+
+  override def optionalPrerequisites = Seq.empty
+
+  override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Transform) = false
+
+  private def onStatement(statement: ir.Statement)
+                         (implicit references: ISet[ReferenceTarget],
+                          renameMap: RenameMap,
+                          module: ModuleTarget): Unit = statement match {
+    case ir.DefInstance(_, a, b, _) if references(module.instOf(a, b).asReference) =>
+      renameMap.record(module.instOf(a, b).asReference, module.instOf(a, b))
+    case a => statement.foreach(onStatement)
+  }
+
+  private def onModule(module: ir.DefModule)
+                      (implicit references: ISet[ReferenceTarget],
+                       renameMap: RenameMap,
+                       circuit: CircuitTarget): Unit = {
+    implicit val mTarget = circuit.module(module.name)
+    module.foreach(onStatement)
+  }
+
+  override protected def execute(state: CircuitState): CircuitState = {
+
+    implicit val rTargets: ISet[ReferenceTarget] = state.annotations.flatMap {
+      case a: SingleTargetAnnotation[_] => Some(a.target)
+      case a: MultiTargetAnnotation     => a.targets.flatten
+      case _                            => None
+    }.collect {
+      case a: ReferenceTarget => a
+    }.toSet
+
+    implicit val renameMap = RenameMap()
+
+    implicit val cTarget = CircuitTarget(state.circuit.main)
+
+    state.circuit.foreach(onModule)
+
+    state.copy(renames = Some(renameMap))
+  }
+
+}

--- a/src/main/scala/firrtl/stage/Forms.scala
+++ b/src/main/scala/firrtl/stage/Forms.scala
@@ -20,7 +20,8 @@ object Forms {
     Seq( Dependency(passes.CheckChirrtl),
          Dependency(passes.CInferTypes),
          Dependency(passes.CInferMDir),
-         Dependency(passes.RemoveCHIRRTL) )
+         Dependency(passes.RemoveCHIRRTL),
+         Dependency[annotations.transforms.CleanupNamedTargets] )
 
   val WorkingIR: Seq[TransformDependency] = MinimalHighForm :+ Dependency(passes.ToWorkingIR)
 

--- a/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
+++ b/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
@@ -132,7 +132,10 @@ class LoweringCompilersSpec extends AnyFlatSpec with Matchers {
 
   it should "replicate the old order" in {
     val tm = new TransformManager(Forms.MinimalHighForm, Forms.ChirrtlForm)
-    compare(legacyTransforms(new firrtl.ChirrtlToHighFirrtl), tm)
+    val patches = Seq(
+      Add(5, Seq(Dependency[firrtl.annotations.transforms.CleanupNamedTargets]))
+    )
+    compare(legacyTransforms(new firrtl.ChirrtlToHighFirrtl), tm, patches)
   }
 
   behavior of "IRToWorkingIR"

--- a/src/test/scala/firrtlTests/annotationTests/CleanupNamedTargetsSpec.scala
+++ b/src/test/scala/firrtlTests/annotationTests/CleanupNamedTargetsSpec.scala
@@ -14,7 +14,8 @@ import firrtl.annotations.{
   Target}
 import firrtl.annotations.transforms.CleanupNamedTargets
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 object CleanupNamedTargetsSpec {
 
@@ -28,7 +29,7 @@ object CleanupNamedTargetsSpec {
 
 }
 
-class CleanupNamedTargetsSpec extends FlatSpec with Matchers {
+class CleanupNamedTargetsSpec extends AnyFlatSpec with Matchers {
 
   import CleanupNamedTargetsSpec._
 

--- a/src/test/scala/firrtlTests/annotationTests/CleanupNamedTargetsSpec.scala
+++ b/src/test/scala/firrtlTests/annotationTests/CleanupNamedTargetsSpec.scala
@@ -1,0 +1,80 @@
+// See LICENSE for license details.
+
+package firrtlTests.annotationTests
+
+import firrtl.{AnnotationSeq, CircuitState, Parser, UnknownForm}
+import firrtl.annotations.{
+  CircuitName,
+  CircuitTarget,
+  ComponentName,
+  ModuleName,
+  MultiTargetAnnotation,
+  ReferenceTarget,
+  SingleTargetAnnotation,
+  Target}
+import firrtl.annotations.transforms.CleanupNamedTargets
+
+import org.scalatest.{FlatSpec, Matchers}
+
+object CleanupNamedTargetsSpec {
+
+  case class SingleReferenceAnnotation(target: ReferenceTarget) extends SingleTargetAnnotation[ReferenceTarget] {
+    override def duplicate(a: ReferenceTarget) = this.copy(target = a)
+  }
+
+  case class MultiReferenceAnnotation(targets: Seq[Seq[Target]]) extends MultiTargetAnnotation {
+    override def duplicate(a: Seq[Seq[Target]]) = this.copy(targets = a)
+  }
+
+}
+
+class CleanupNamedTargetsSpec extends FlatSpec with Matchers {
+
+  import CleanupNamedTargetsSpec._
+
+  class F {
+
+    val transform = new CleanupNamedTargets
+
+    val circuit =
+      """|circuit Foo:
+         |  module Bar:
+         |    skip
+         |  module Foo:
+         |    inst bar of Bar
+         |    wire baz: UInt<1>
+         |""".stripMargin
+
+    lazy val foo = CircuitTarget("Foo").module("Foo")
+
+    lazy val barTarget = ComponentName("bar", ModuleName("Foo", CircuitName("Foo"))).toTarget
+
+    lazy val bazTarget = ComponentName("baz", ModuleName("Foo", CircuitName("Foo"))).toTarget
+
+    def circuitState(a: AnnotationSeq): CircuitState = CircuitState(Parser.parse(circuit), UnknownForm, a, None)
+
+  }
+
+  behavior of "CleanupNamedTargets"
+
+  it should "convert a SingleTargetAnnotation[ReferenceTarget] of an instance to an InstanceTarget" in new F {
+    val annotations: AnnotationSeq = Seq(SingleReferenceAnnotation(barTarget))
+
+    transform.transform(circuitState(annotations)).renames.get.get(barTarget) should be {
+      Some(Seq(foo.instOf("bar", "Bar")))
+    }
+  }
+
+  it should "convert a MultiTargetAnnotation with a ReferenceTarget of an instance to an InstanceTarget" in new F {
+    val annotations: AnnotationSeq = Seq(MultiReferenceAnnotation(Seq(Seq(barTarget), Seq(bazTarget))))
+
+    val renames = transform.transform(circuitState(annotations)).renames.get
+
+    renames.get(barTarget) should be (Some(Seq(foo.instOf("bar", "Bar"))))
+
+    info("and not touch a true ReferenceAnnotation")
+    renames.get(bazTarget) should be (None)
+
+  }
+
+}


### PR DESCRIPTION
This adds a new transform, `CleanupNamedTargets`, that converts any `ReferenceTarget`s pointing at instances to `InstanceTarget`s. 

Fixes #1304.

### Checklist

- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

None.

### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!-- - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
