### PR TITLE
add IsModule, IsMember, CompleteTarget serializers

### DIFF
--- a/src/main/scala/firrtl/annotations/JsonProtocol.scala
+++ b/src/main/scala/firrtl/annotations/JsonProtocol.scala
@@ -78,6 +78,18 @@ object JsonProtocol {
     { case JString(s) => Target.deserialize(s).asInstanceOf[ReferenceTarget] },
     { case named: ReferenceTarget => JString(named.serialize) }
   ))
+  class IsModuleSerializer extends CustomSerializer[IsModule](format => (
+    { case JString(s) => Target.deserialize(s).asInstanceOf[IsModule] },
+    { case named: IsModule => JString(named.serialize) }
+  ))
+  class IsMemberSerializer extends CustomSerializer[IsMember](format => (
+    { case JString(s) => Target.deserialize(s).asInstanceOf[IsMember] },
+    { case named: IsMember => JString(named.serialize) }
+  ))
+  class CompleteTargetSerializer extends CustomSerializer[CompleteTarget](format => (
+    { case JString(s) => Target.deserialize(s).asInstanceOf[CompleteTarget] },
+    { case named: CompleteTarget => JString(named.serialize) }
+  ))
 
   /** Construct Json formatter for annotations */
   def jsonFormat(tags: Seq[Class[_]]) = {
@@ -86,7 +98,8 @@ object JsonProtocol {
       new ModuleNameSerializer + new ComponentNameSerializer + new TargetSerializer +
       new GenericTargetSerializer + new CircuitTargetSerializer + new ModuleTargetSerializer +
       new InstanceTargetSerializer + new ReferenceTargetSerializer + new TransformSerializer  +
-      new LoadMemoryFileTypeSerializer
+      new LoadMemoryFileTypeSerializer + new IsModuleSerializer + new IsMemberSerializer +
+      new CompleteTargetSerializer
   }
 
   /** Serialize annotations to a String for emission */


### PR DESCRIPTION
### Checklist

- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement
bug fix: annotations with `IsModule` fields result in errors like
```
Exception in thread "main" firrtl.annotations.InvalidAnnotationFileException: annos.json
Caused by: firrtl.annotations.InvalidAnnotationJSONException: No usable value for foo
No constructor for type IsModule, JString(~Foo|Bar)
```

Mixing in `HasSerializationHints` and adding `classOf[IsModule]` type hint does not fix the issue for me.

Not really familiar with the whole JsonProtocol stuff. I'm kinda just pattern matching here. please let me know if I'm doing this wrong and there is a way to do this with the type hint stuff. Also I'm assuming the same will happen for annotations with `IsMember` and `CompleteTarget` since there aren't serializers for those, but haven't tested it.

### API Impact
no change
<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

### Backend Code Generation Impact
no change. it looks like the contents of annotation json files do not change either
<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

### Desired Merge Strategy
Squash
<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
