### PR TITLE
Dedup: check if moduleOpt exists before getting

### DIFF
--- a/src/main/scala/firrtl/transforms/Dedup.scala
+++ b/src/main/scala/firrtl/transforms/Dedup.scala
@@ -296,8 +296,10 @@ object DedupModules {
     val module2Annotations = mutable.HashMap.empty[String, mutable.HashSet[Annotation]]
     annotations.foreach { a =>
       a.getTargets.foreach { t =>
-        val annos = module2Annotations.getOrElseUpdate(t.moduleOpt.get, mutable.HashSet.empty[Annotation])
-        annos += a
+        if (t.moduleOpt.isDefined) {
+          val annos = module2Annotations.getOrElseUpdate(t.moduleOpt.get, mutable.HashSet.empty[Annotation])
+          annos += a
+        }
       }
     }
     def fastSerializedHash(s: Statement): Int ={


### PR DESCRIPTION
### Checklist

- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

<!-- Choose one or more from the following: -->
bug fix: annotations with `CircuitTarget`s cause dedup to fail with `None.get` since `CircuitTarget`s don't have a module. This change adds a check before getting the module

### API Impact
none
<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

### Backend Code Generation Impact
none
<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

### Desired Merge Strategy
squash
<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
