### PR TITLE
Verilog emitter transforms: InlineBitReductions/Expansions

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -321,6 +321,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
        case DoPrim(Not, args, _,_) => args.foreach(checkArgumentLegality)
        case DoPrim(op, args, _,_) if isCast(op) => args.foreach(checkArgumentLegality)
        case DoPrim(op, args, _,_) if isBitExtract(op) => args.foreach(checkArgumentLegality)
+       case DoPrim(op, args, _,_) if isBitReduce(op) => args.foreach(checkArgumentLegality)
        case _ => throw EmitterException(s"Can't emit ${e.getClass.getName} as PrimOp argument")
      }
 
@@ -982,6 +983,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
     new ReplaceTruncatingArithmetic,
     new InlineNotsTransform,
     new InlineBitExtractionsTransform,  // here after InlineNots to clean up not(not(...)) rename
+    new InlineBitReductionsTransform,
     new InlineCastsTransform,
     new LegalizeClocksTransform,
     new FlattenRegUpdate,

--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -221,6 +221,18 @@ object Utils extends LazyLogging {
     case _ => false
   }
 
+  /** Returns true if Expression is a bit expansion PrimOp, false otherwise */
+  def isBitExpand(expr: Expression): Boolean = expr match {
+    case DoPrim(Pad, Seq(arg), _, tpe) => tpe match {
+      case (_: SIntType) => arg.tpe match {
+        case (_: UIntType) if (bitWidth(arg.tpe) == 1) => true
+        case _ => false
+      }
+      case _ => false
+    }
+    case _ => false
+  }
+
   /** Provide a nice name to create a temporary **/
   def niceName(e: Expression): String = niceName(1)(e)
   def niceName(depth: Int)(e: Expression): String = {

--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -210,6 +210,17 @@ object Utils extends LazyLogging {
     case _ => false
   }
 
+  /** Returns true if PrimOp is a BitReduction, false otherwise */
+  def isBitReduce(op: PrimOp): Boolean = op match {
+    case Andr | Orr | Xorr => true
+    case _ => false
+  }
+  /** Returns true if Expression is a bit-wise reduction PrimOp, false otherwise */
+  def isBitReduce(expr: Expression): Boolean = expr match {
+    case DoPrim(op, _,_, UIntType(_)) if isBitReduce(op) => true
+    case _ => false
+  }
+
   /** Provide a nice name to create a temporary **/
   def niceName(e: Expression): String = niceName(1)(e)
   def niceName(depth: Int)(e: Expression): String = {

--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -186,6 +186,7 @@ class ConstantPropagation extends Transform with ResolvedAnnotationPaths {
     def simplify(e: Expression, lhs: Literal, rhs: Expression) = lhs match {
       case UIntLiteral(v, IntWidth(w)) if v == BigInt(1) && w == BigInt(1) && bitWidth(rhs.tpe) == BigInt(1) => rhs
       case UIntLiteral(v, IntWidth(w)) if v == BigInt(0) && w == BigInt(1) && bitWidth(rhs.tpe) == BigInt(1) => DoPrim(Not, Seq(rhs), Nil, e.tpe)
+      case UIntLiteral(v, IntWidth(w)) if v == ((BigInt(1) << bitWidth(rhs.tpe).toInt) - 1) => DoPrim(Andr, Seq(rhs), Nil, e.tpe)
       case _ => e
     }
     def matchingArgsValue(e: DoPrim, arg: Expression) = UIntLiteral(1)
@@ -196,6 +197,7 @@ class ConstantPropagation extends Transform with ResolvedAnnotationPaths {
     def simplify(e: Expression, lhs: Literal, rhs: Expression) = lhs match {
       case UIntLiteral(v, IntWidth(w)) if v == BigInt(0) && w == BigInt(1) && bitWidth(rhs.tpe) == BigInt(1) => rhs
       case UIntLiteral(v, IntWidth(w)) if v == BigInt(1) && w == BigInt(1) && bitWidth(rhs.tpe) == BigInt(1) => DoPrim(Not, Seq(rhs), Nil, e.tpe)
+      case UIntLiteral(v, IntWidth(w)) if v == BigInt(0) => DoPrim(Orr, Seq(rhs), Nil, e.tpe)
       case _ => e
     }
     def matchingArgsValue(e: DoPrim, arg: Expression) = UIntLiteral(0)

--- a/src/main/scala/firrtl/transforms/InlineBitExtractions.scala
+++ b/src/main/scala/firrtl/transforms/InlineBitExtractions.scala
@@ -70,7 +70,7 @@ object InlineBitExtractionsTransform {
     }
   }
 
-  /** Inline bits in a Statement
+  /** Inline Bits in a Statement
     *
     * @param netlist a '''mutable''' HashMap mapping references to [[firrtl.ir.DefNode DefNode]]s to their connected
     * [[firrtl.ir.Expression Expression]]s. This function '''will''' mutate it if stmt is a [[firrtl.ir.DefNode
@@ -86,11 +86,11 @@ object InlineBitExtractionsTransform {
       case other => other
     }
 
-  /** Replaces bits in a Module */
+  /** Replaces Bits in a Module */
   def onMod(mod: DefModule): DefModule = mod.map(onStmt(new Netlist))
 }
 
-/** Inline nodes that are simple bits */
+/** Inline nodes that are simple Bits */
 class InlineBitExtractionsTransform extends Transform {
   def inputForm = UnknownForm
   def outputForm = UnknownForm

--- a/src/main/scala/firrtl/transforms/InlineBitReductions.scala
+++ b/src/main/scala/firrtl/transforms/InlineBitReductions.scala
@@ -1,0 +1,93 @@
+package firrtl
+package transforms
+
+import firrtl.ir._
+import firrtl.Mappers._
+import firrtl.PrimOps.{Andr, Not, Orr, Xorr}
+import firrtl.Utils.{isBitReduce, isTemp}
+import firrtl.WrappedExpression._
+
+import scala.collection.mutable
+
+object InlineBitReductionsTransform {
+
+  // Checks if an Expression is made up of only bit reductions terminated by a Literal or Reference.
+  // private because it's not clear if this definition of "Simple Expression" would be useful elsewhere.
+  // Note that this can have false negatives but MUST NOT have false positives.
+  private def isSimpleExpr(expr: Expression): Boolean = expr match {
+    case _: WRef | _: Literal | _: WSubField => true
+    case DoPrim(op, args, _,_) if isBitReduce(op) => args.forall(isSimpleExpr)
+    case _ => false
+  }
+
+  /** Mapping from references to the [[firrtl.ir.Expression Expression]]s that drive them */
+  type Netlist = mutable.HashMap[WrappedExpression, Expression]
+
+  /** Recursively replace [[WRef]]s with new [[Expression]]s
+    *
+    * @param netlist a '''mutable''' HashMap mapping references to [[firrtl.ir.DefNode DefNode]]s to their connected
+    * [[firrtl.ir.Expression Expression]]s. It is '''not''' mutated in this function
+    * @param expr the Expression being transformed
+    * @return Returns expr with Andr/Orr/Xorr inlined
+    */
+  def onExpr(netlist: Netlist)(expr: Expression): Expression = {
+    expr.map(onExpr(netlist)) match {
+      case e @ WRef(name, _,_,_) =>
+        netlist.get(we(e))
+               .filter(isBitReduce)
+               .getOrElse(e)
+      // De Morgan's: replace &~ with ~|
+      case lhs @ DoPrim(Andr, Seq(inv), _, ltpe) =>
+        netlist.getOrElse(we(inv), inv) match {
+          case DoPrim(Not, Seq(rhs), _, rtpe) =>
+            DoPrim(Not, Seq(DoPrim(Orr, Seq(rhs), Seq(), ltpe)), Seq(), ltpe)
+          case _ => lhs  // Not a candiate
+        }
+      // De Morgan's: replace |~ with ~&
+      case lhs @ DoPrim(Orr, Seq(inv), _, ltpe) =>
+        netlist.getOrElse(we(inv), inv) match {
+          case DoPrim(Not, Seq(rhs), _, rtpe) =>
+            DoPrim(Not, Seq(DoPrim(Andr, Seq(rhs), Seq(), ltpe)), Seq(), ltpe)
+          case _ => lhs  // Not a candiate
+        }
+      // commutative: replace ^~ with ~^
+      case lhs @ DoPrim(Xorr, Seq(inv), _, ltpe) =>
+        netlist.getOrElse(we(inv), inv) match {
+          case DoPrim(Not, Seq(rhs), _, rtpe) =>
+            DoPrim(Not, Seq(DoPrim(Xorr, Seq(rhs), Seq(), ltpe)), Seq(), ltpe)
+          case _ => lhs  // Not a candiate
+        }
+      case other => other // Not a candidate
+    }
+  }
+
+  /** Inline bit reductions in a Statement
+    *
+    * @param netlist a '''mutable''' HashMap mapping references to [[firrtl.ir.DefNode DefNode]]s to their connected
+    * [[firrtl.ir.Expression Expression]]s. This function '''will''' mutate it if stmt is a [[firrtl.ir.DefNode
+    * DefNode]] with a Temporary name and a value that is a [[PrimOp]] bit reduction
+    * @param stmt the Statement being searched for nodes and transformed
+    * @return Returns stmt with bit reductions inlined
+    */
+  def onStmt(netlist: Netlist)(stmt: Statement): Statement =
+    stmt.map(onStmt(netlist)).map(onExpr(netlist)) match {
+      case node @ DefNode(_, name, value) if isTemp(name) =>
+        netlist(we(WRef(name))) = value
+        node
+      case other => other
+    }
+
+  /** Replaces bit reductions in a Module */
+  def onMod(mod: DefModule): DefModule = mod.map(onStmt(new Netlist))
+}
+
+/** Inline nodes that are simple bit reductions */
+class InlineBitReductionsTransform extends Transform {
+  def inputForm = UnknownForm
+  def outputForm = UnknownForm
+
+  def execute(state: CircuitState): CircuitState = {
+    val modulesx = state.circuit.modules.map(InlineBitReductionsTransform.onMod(_))
+    state.copy(circuit = state.circuit.copy(modules = modulesx))
+  }
+}

--- a/src/test/scala/firrtlTests/VerilogEmitterTests.scala
+++ b/src/test/scala/firrtlTests/VerilogEmitterTests.scala
@@ -268,18 +268,31 @@ class DoPrimVerilog extends FirrtlFlatSpec {
       """circuit InlineBitExpansion :
         |  module InlineBitExpansion :
         |    input a: UInt<1>
-        |    output b: UInt<4>
+        |    input b: UInt<4>
         |    output c: UInt<4>
-        |    b <= mux(a, UInt<4>("hf"), UInt<4>("h0"))
-        |    c <= mux(a, UInt<4>("h0"), UInt<4>("hf"))""".stripMargin
+        |    output d: UInt<4>
+        |    output e: UInt<4>
+        |    output f: UInt<4>
+        |    node g = mux(a, UInt<4>("hf"), UInt<4>("h0"))
+        |    c <= g
+        |    d <= mux(a, UInt<4>("h0"), UInt<4>("hf"))
+        |    e <= and(b, mux(a, UInt<4>("hf"), UInt<4>("h0")))
+        |    f <= or(b, mux(a, UInt<4>("h0"), UInt<4>("hf")))""".stripMargin
     val check =
       """module InlineBitExpansion(
         |  input   a,
-        |  output [3:0] b,
-        |  output [3:0] c
+        |  input  [3:0] b,
+        |  output [3:0] c,
+        |  output [3:0] d,
+        |  output [3:0] e,
+        |  output [3:0] f
         |);
-        |  assign b = a ? 4'hf : 4'h0;
-        |  assign c = a ? 4'h0 : 4'hf;
+        |  wire [3:0] g;
+        |  assign g = {4{a}};
+        |  assign c = {4{a}};
+        |  assign d = ~{4{a}};
+        |  assign e = b & g;
+        |  assign f = b | ~{4{a}};
         |endmodule
         |""".stripMargin.split("\n") map normalized
     executeTest(input, check, compiler)


### PR DESCRIPTION
### Checklist
- [X] Did you specify the type of improvement?
- [X] Did you state the API impact?
- [X] Did you specify the code generation impact?
- [X] Did you request a desired merge strategy?

### Type of Improvement
- backend code generation

### API Impact
none

### Backend Code Generation Impact
The goal of this PR is to compact the generated Verilog to have fewer intermediate terms.
We accomplish this by inlining bit reduction and expansion as described in https://github.com/freechipsproject/firrtl/issues/1338.

This reduces the output Verilog line count by between a few percent depending on the logic:
- ICache: -0% from 917 to 913
- FPU: -4% from 9389 to 8983
- RocketCore: -2% from 8111 to 7973

### Related Features
similar to #1270 and #1296

### Desired Merge Strategy
- Squash: The PR will be squashed and merged (choose this if you have no preference.