### PR TITLE
Added product impl for NoTargetAnnotation

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -325,12 +325,8 @@ class VerilogEmitter extends SeqTransform with Emitter {
      }
 
      def checkCatArgumentLegality(e: Expression): Unit = e match {
-       case _: UIntLiteral | _: SIntLiteral | _: WRef | _: WSubField =>
-       case DoPrim(Not, args, _,_) => args.foreach(checkArgumentLegality)
-       case DoPrim(op, args, _,_) if isCast(op) => args.foreach(checkArgumentLegality)
-       case DoPrim(op, args, _,_) if isBitExtract(op) => args.foreach(checkArgumentLegality)
        case DoPrim(Cat, args, _, _) => args foreach(checkCatArgumentLegality)
-       case _ => throw EmitterException(s"Can't emit ${e.getClass.getName} as PrimOp argument")
+       case _ => checkArgumentLegality(e)
      }
 
      def castCatArgs(a0: Expression, a1: Expression): Seq[Any] = {

--- a/src/main/scala/firrtl/annotations/Annotation.scala
+++ b/src/main/scala/firrtl/annotations/Annotation.scala
@@ -43,7 +43,10 @@ trait Annotation extends Product {
 trait NoTargetAnnotation extends Annotation {
   def update(renames: RenameMap): Seq[NoTargetAnnotation] = Seq(this)
   override def productArity: Int = 0
-  override def canEqual(that: Any): Boolean = true
+  override def canEqual(that: Any): Boolean = that match {
+    case _: NoTargetAnnotation => true
+    case _                     => false
+  }
   override def productElement(n: Int): Any = throw new java.lang.IndexOutOfBoundsException(s"Cannot access elements of NoTargetAnnotation: $n")
 }
 

--- a/src/main/scala/firrtl/annotations/Annotation.scala
+++ b/src/main/scala/firrtl/annotations/Annotation.scala
@@ -44,7 +44,7 @@ trait NoTargetAnnotation extends Annotation {
   def update(renames: RenameMap): Seq[NoTargetAnnotation] = Seq(this)
   override def productArity: Int = 0
   override def canEqual(that: Any): Boolean = true
-  override def productElement(n: Int): Any = throw new java.lang.IndexOutOfBoundsException(n)
+  override def productElement(n: Int): Any = throw new java.lang.IndexOutOfBoundsException(s"Cannot access elements of NoTargetAnnotation: $n")
 }
 
 /** An Annotation that targets a single [[Named]] thing */

--- a/src/main/scala/firrtl/annotations/Annotation.scala
+++ b/src/main/scala/firrtl/annotations/Annotation.scala
@@ -42,6 +42,9 @@ trait Annotation extends Product {
   */
 trait NoTargetAnnotation extends Annotation {
   def update(renames: RenameMap): Seq[NoTargetAnnotation] = Seq(this)
+  override def productArity: Int = 0
+  override def canEqual(that: Any): Boolean = true
+  override def productElement(n: Int): Any = 0
 }
 
 /** An Annotation that targets a single [[Named]] thing */

--- a/src/main/scala/firrtl/annotations/Annotation.scala
+++ b/src/main/scala/firrtl/annotations/Annotation.scala
@@ -44,7 +44,7 @@ trait NoTargetAnnotation extends Annotation {
   def update(renames: RenameMap): Seq[NoTargetAnnotation] = Seq(this)
   override def productArity: Int = 0
   override def canEqual(that: Any): Boolean = true
-  override def productElement(n: Int): Any = 0
+  override def productElement(n: Int): Any = throw java.lang.IndexOutOfBoundsException(n)
 }
 
 /** An Annotation that targets a single [[Named]] thing */

--- a/src/main/scala/firrtl/annotations/Annotation.scala
+++ b/src/main/scala/firrtl/annotations/Annotation.scala
@@ -44,7 +44,7 @@ trait NoTargetAnnotation extends Annotation {
   def update(renames: RenameMap): Seq[NoTargetAnnotation] = Seq(this)
   override def productArity: Int = 0
   override def canEqual(that: Any): Boolean = true
-  override def productElement(n: Int): Any = throw java.lang.IndexOutOfBoundsException(n)
+  override def productElement(n: Int): Any = throw new java.lang.IndexOutOfBoundsException(n)
 }
 
 /** An Annotation that targets a single [[Named]] thing */


### PR DESCRIPTION
### Checklist

- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?

### Type of Improvement

<!-- Choose one or more from the following: -->
   - bug fix

### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
I believe this only adds to the current API - it implements the unimplemented `Product` functions for `NoTargetAnnotation`s. Previously, most `NoTargetAnnotation`s are case classes (which implements `Product`), but if it wasn't a case class, you'd have to implement them yourself. The reason `Annotation` extends `Product` is to iterate over `Target`'s.

### Backend Code Generation Impact

None.
