### PR TITLE
Fix conversion of Reference-containing expressions to ReferenceTargets

### DIFF
--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -298,7 +298,7 @@ object Utils extends LazyLogging {
     def onExp(expr: Expression): Expression = {
       expr map onExp match {
         case e: WRef => ref = e.name
-        case e: Reference => tokens += TargetToken.Ref(e.name)
+        case e: Reference => ref = e.name
         case e: WSubField => tokens += TargetToken.Field(e.name)
         case e: SubField => tokens += TargetToken.Field(e.name)
         case e: WSubIndex => tokens += TargetToken.Index(e.value)


### PR DESCRIPTION
**Type of Improvement:** bug fix
**API impact:** none
**Backend code generation impact:** none in Verilog (only corrects potential for faulty annotations)

The `toTarget` utility currently handles `Reference` wrong by putting the name of the root `Reference` into the `component` path rather than actually using it as the `ref`. This PR fixes that behavior.