### PR TITLE
Remove WIR nodes that "shadow" standard IR nodes

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -121,7 +121,7 @@ sealed abstract class FirrtlEmitter(form: CircuitForm) extends Transform with Em
       // Use list instead of set to maintain order
       val modules = mutable.ArrayBuffer.empty[DefModule]
       def onStmt(stmt: Statement): Unit = stmt match {
-        case DefInstance(_, _, name) => modules += map(name)
+        case DefInstance(_, _, name, _) => modules += map(name)
         case WDefInstance(_, _, name, _) => modules += map(name)
         case _: WDefInstanceConnector => throwInternalError(s"unrecognized statement: $stmt")
         case other => other.foreach(onStmt)

--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -220,12 +220,12 @@ object Utils extends LazyLogging {
       case WSubAccess(expr, index, _, _) => niceName(depth)(expr) + niceName(depth - 1)(index)
       case WSubField(expr, field, _, _) => niceName(depth)(expr) + "_" + field
       case WSubIndex(expr, index, _, _) => niceName(depth)(expr) + "_" + index
-      case Reference(name, _) if name(0) == '_' => name
-      case Reference(name, _) => "_" + name
-      case SubAccess(expr, index,  _) if depth <= 0 => niceName(depth)(expr)
-      case SubAccess(expr, index,  _) => niceName(depth)(expr) + niceName(depth - 1)(index)
-      case SubField(expr, field, _) => niceName(depth)(expr) + "_" + field
-      case SubIndex(expr, index, _) => niceName(depth)(expr) + "_" + index
+      case Reference(name, _, _, _) if name(0) == '_' => name
+      case Reference(name, _, _, _) => "_" + name
+      case SubAccess(expr, index, _, _) if depth <= 0 => niceName(depth)(expr)
+      case SubAccess(expr, index, _, _) => niceName(depth)(expr) + niceName(depth - 1)(index)
+      case SubField(expr, field, _, _) => niceName(depth)(expr) + "_" + field
+      case SubIndex(expr, index, _, _) => niceName(depth)(expr) + "_" + index
       case DoPrim(op, args, consts, _) if depth <= 0 => "_" + op
       case DoPrim(op, args, consts, _) => "_" + op + (args.map(niceName(depth - 1)) ++ consts.map("_" + _)).mkString("")
       case Mux(cond, tval, fval, _) if depth <= 0 => "_mux"
@@ -388,7 +388,7 @@ object Utils extends LazyLogging {
     */
   def inline(nodeMap: NodeMap, stop: String => Boolean = {x: String => false})(e: Expression): Expression = {
     def onExp(e: Expression): Expression = e map onExp match {
-      case Reference(name, _) if nodeMap.contains(name) && !stop(name) => onExp(nodeMap(name))
+      case Reference(name, _, _, _) if nodeMap.contains(name) && !stop(name) => onExp(nodeMap(name))
       case WRef(name, _, _, _) if nodeMap.contains(name) && !stop(name) => onExp(nodeMap(name))
       case other => other
     }

--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -214,12 +214,6 @@ object Utils extends LazyLogging {
   def niceName(e: Expression): String = niceName(1)(e)
   def niceName(depth: Int)(e: Expression): String = {
     e match {
-      case WRef(name, _, _, _) if name(0) == '_' => name
-      case WRef(name, _, _, _) => "_" + name
-      case WSubAccess(expr, index, _, _) if depth <= 0 => niceName(depth)(expr)
-      case WSubAccess(expr, index, _, _) => niceName(depth)(expr) + niceName(depth - 1)(index)
-      case WSubField(expr, field, _, _) => niceName(depth)(expr) + "_" + field
-      case WSubIndex(expr, index, _, _) => niceName(depth)(expr) + "_" + index
       case Reference(name, _, _, _) if name(0) == '_' => name
       case Reference(name, _, _, _) => "_" + name
       case SubAccess(expr, index, _, _) if depth <= 0 => niceName(depth)(expr)
@@ -297,11 +291,8 @@ object Utils extends LazyLogging {
     var ref = "???"
     def onExp(expr: Expression): Expression = {
       expr map onExp match {
-        case e: WRef => ref = e.name
         case e: Reference => ref = e.name
-        case e: WSubField => tokens += TargetToken.Field(e.name)
         case e: SubField => tokens += TargetToken.Field(e.name)
-        case e: WSubIndex => tokens += TargetToken.Index(e.value)
         case e: SubIndex => tokens += TargetToken.Index(e.value)
         case other => throwInternalError("Cannot call Utils.toTarget on non-referencing expression")
       }
@@ -389,7 +380,6 @@ object Utils extends LazyLogging {
   def inline(nodeMap: NodeMap, stop: String => Boolean = {x: String => false})(e: Expression): Expression = {
     def onExp(e: Expression): Expression = e map onExp match {
       case Reference(name, _, _, _) if nodeMap.contains(name) && !stop(name) => onExp(nodeMap(name))
-      case WRef(name, _, _, _) if nodeMap.contains(name) && !stop(name) => onExp(nodeMap(name))
       case other => other
     }
     onExp(e)

--- a/src/main/scala/firrtl/annotations/AnnotationUtils.scala
+++ b/src/main/scala/firrtl/annotations/AnnotationUtils.scala
@@ -66,10 +66,10 @@ object AnnotationUtils {
   def toSubComponents(s: String): Seq[TargetToken] = {
     import TargetToken._
     def exp2subcomp(e: ir.Expression): Seq[TargetToken] = e match {
-      case ir.Reference(name, _)      => Seq(Ref(name))
-      case ir.SubField(expr, name, _) => exp2subcomp(expr) :+ Field(name)
-      case ir.SubIndex(expr, idx, _)  => exp2subcomp(expr) :+ Index(idx)
-      case ir.SubAccess(expr, idx, _) => Utils.throwInternalError(s"For string $s, cannot convert a subaccess $e into a Target")
+      case ir.Reference(name, _, _, _)      => Seq(Ref(name))
+      case ir.SubField(expr, name, _, _) => exp2subcomp(expr) :+ Field(name)
+      case ir.SubIndex(expr, idx, _, _)  => exp2subcomp(expr) :+ Index(idx)
+      case ir.SubAccess(expr, idx, _, _) => Utils.throwInternalError(s"For string $s, cannot convert a subaccess $e into a Target")
     }
     exp2subcomp(toExp(s))
   }

--- a/src/main/scala/firrtl/annotations/Target.scala
+++ b/src/main/scala/firrtl/annotations/Target.scala
@@ -103,13 +103,9 @@ sealed trait Target extends Named {
 
 object Target {
   def asTarget(m: ModuleTarget)(e: Expression): ReferenceTarget = e match {
-    case w: WRef => m.ref(w.name)
     case r: ir.Reference => m.ref(r.name)
-    case w: WSubIndex => asTarget(m)(w.expr).index(w.value)
     case s: ir.SubIndex => asTarget(m)(s.expr).index(s.value)
-    case w: WSubField => asTarget(m)(w.expr).field(w.name)
     case s: ir.SubField => asTarget(m)(s.expr).field(s.name)
-    case w: WSubAccess => asTarget(m)(w.expr).field("@" + w.index.serialize)
     case s: ir.SubAccess => asTarget(m)(s.expr).field("@" + s.index.serialize)
     case d: DoPrim => m.ref("@" + d.serialize)
     case d: Mux => m.ref("@" + d.serialize)

--- a/src/main/scala/firrtl/annotations/TargetToken.scala
+++ b/src/main/scala/firrtl/annotations/TargetToken.scala
@@ -56,12 +56,6 @@ case object TargetToken {
     def toTokens: (Instance, OfModule) = (new TargetToken.Instance(i.name), new TargetToken.OfModule(i.module))
   }
 
-  implicit class fromWDefInstanceToTargetToken(wi: WDefInstance) {
-    def Instance: Instance = new TargetToken.Instance(wi.name)
-    def OfModule: OfModule = new TargetToken.OfModule(wi.module)
-    def toTokens: (Instance, OfModule) = (new TargetToken.Instance(wi.name), new TargetToken.OfModule(wi.module))
-  }
-
   val keyword2targettoken = Map(
     "inst" -> ((value: String) => Instance(value)),
     "of" -> ((value: String) => OfModule(value)),

--- a/src/main/scala/firrtl/annotations/transforms/EliminateTargetPaths.scala
+++ b/src/main/scala/firrtl/annotations/transforms/EliminateTargetPaths.scala
@@ -59,7 +59,7 @@ class EliminateTargetPaths extends Transform with DependencyAPIMigration with Pr
   private def onStmt(dupMap: DuplicationHelper)
                     (originalModule: String, newModule: String)
                     (s: Statement): Statement = s match {
-    case d@DefInstance(_, name, module) =>
+    case d@DefInstance(_, name, module, _) =>
       val ofModule = dupMap.getNewOfModule(originalModule, newModule, Instance(name), OfModule(module)).value
       d.copy(module = ofModule)
     case d@WDefInstance(_, name, module, _) =>

--- a/src/main/scala/firrtl/package.scala
+++ b/src/main/scala/firrtl/package.scala
@@ -15,4 +15,10 @@ package object firrtl {
 
   @deprecated("Use firrtl.stage.TargetDirAnnotation", "1.2")
   val TargetDirAnnotation = firrtl.options.TargetDirAnnotation
+
+  type WRef = ir.Reference
+  type WSubField = ir.SubField
+  type WSubIndex = ir.SubIndex
+  type WSubAccess = ir.SubAccess
+  type WDefInstance = ir.DefInstance
 }

--- a/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
+++ b/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
@@ -183,7 +183,7 @@ object RemoveCHIRRTL extends Transform with DependencyAPIMigration with Preserve
     var has_readwrite_mport: Option[Expression] = None
     var has_read_mport: Option[Expression] = None
     def remove_chirrtl_e(g: Flow)(e: Expression): Expression = e match {
-      case Reference(name, tpe) => refs get name match {
+      case Reference(name, tpe, _, _) => refs get name match {
         case Some(p) => g match {
           case SinkFlow =>
             has_write_mport = true
@@ -200,7 +200,7 @@ object RemoveCHIRRTL extends Transform with DependencyAPIMigration with Preserve
           case SourceFlow => e
         }
       }
-      case SubAccess(expr, index, tpe)  => SubAccess(
+      case SubAccess(expr, index, tpe, _) => SubAccess(
         remove_chirrtl_e(g)(expr), remove_chirrtl_e(SourceFlow)(index), tpe)
       case ex => ex map remove_chirrtl_e(g)
    }

--- a/src/main/scala/firrtl/passes/ToWorkingIR.scala
+++ b/src/main/scala/firrtl/passes/ToWorkingIR.scala
@@ -1,9 +1,8 @@
 package firrtl.passes
 
 import firrtl.ir._
-import firrtl.Mappers._
-import firrtl.options.{PreservesAll}
-import firrtl.{Transform, UnknownFlow, UnknownKind, WDefInstance, WRef, WSubAccess, WSubField, WSubIndex}
+import firrtl.options.PreservesAll
+import firrtl.Transform
 
 object ToWorkingIR extends Pass with PreservesAll[Transform] {
   override def prerequisites = firrtl.stage.Forms.MinimalHighForm

--- a/src/main/scala/firrtl/passes/ToWorkingIR.scala
+++ b/src/main/scala/firrtl/passes/ToWorkingIR.scala
@@ -5,24 +5,7 @@ import firrtl.Mappers._
 import firrtl.options.{PreservesAll}
 import firrtl.{Transform, UnknownFlow, UnknownKind, WDefInstance, WRef, WSubAccess, WSubField, WSubIndex}
 
-// These should be distributed into separate files
 object ToWorkingIR extends Pass with PreservesAll[Transform] {
-
   override def prerequisites = firrtl.stage.Forms.MinimalHighForm
-
-  def toExp(e: Expression): Expression = e map toExp match {
-    case ex: Reference => WRef(ex.name, ex.tpe, UnknownKind, UnknownFlow)
-    case ex: SubField => WSubField(ex.expr, ex.name, ex.tpe, UnknownFlow)
-    case ex: SubIndex => WSubIndex(ex.expr, ex.value, ex.tpe, UnknownFlow)
-    case ex: SubAccess => WSubAccess(ex.expr, ex.index, ex.tpe, UnknownFlow)
-    case ex => ex // This might look like a case to use case _ => e, DO NOT!
-  }
-
-  def toStmt(s: Statement): Statement = s map toExp match {
-    case sx: DefInstance => WDefInstance(sx.info, sx.name, sx.module, UnknownType)
-    case sx => sx map toStmt
-  }
-
-  def run (c:Circuit): Circuit =
-    c copy (modules = c.modules map (_ map toStmt))
+  def run(c:Circuit): Circuit = c
 }

--- a/src/main/scala/firrtl/proto/ToProto.scala
+++ b/src/main/scala/firrtl/proto/ToProto.scala
@@ -141,21 +141,21 @@ object ToProto {
   def convert(expr: ir.Expression): Firrtl.Expression.Builder = {
     val eb = Firrtl.Expression.newBuilder()
     expr match {
-      case ir.Reference(name, _) =>
+      case ir.Reference(name, _, _, _) =>
         val rb = Firrtl.Expression.Reference.newBuilder()
           .setId(name)
         eb.setReference(rb)
-      case ir.SubField(e, name, _) =>
+      case ir.SubField(e, name, _, _) =>
         val sb = Firrtl.Expression.SubField.newBuilder()
           .setExpression(convert(e))
           .setField(name)
         eb.setSubField(sb)
-      case ir.SubIndex(e, value, _) =>
+      case ir.SubIndex(e, value, _, _) =>
         val sb = Firrtl.Expression.SubIndex.newBuilder()
           .setExpression(convert(e))
           .setIndex(convertToIntegerLiteral(value))
         eb.setSubIndex(sb)
-      case ir.SubAccess(e, index, _) =>
+      case ir.SubAccess(e, index, _, _) =>
         val sb = Firrtl.Expression.SubAccess.newBuilder()
           .setExpression(convert(e))
           .setIndex(convert(index))
@@ -231,7 +231,7 @@ object ToProto {
               .setReset(convert(reset))
               .setInit(convert(init))
             sb.setRegister(rb)
-          case ir.DefInstance(_, name, module) =>
+          case ir.DefInstance(_, name, module, _) =>
             val ib = Firrtl.Statement.Instance.newBuilder()
               .setId(name)
               .setModuleId(module)

--- a/src/main/scala/firrtl/transforms/Dedup.scala
+++ b/src/main/scala/firrtl/transforms/Dedup.scala
@@ -133,7 +133,9 @@ object DedupModules {
       case WDefInstance(i, n, m, t) =>
         val newmod = renameOfModule(n, m)
         WDefInstance(reinfo(i), rename(n), newmod, retype(n)(t))
-      case DefInstance(i, n, m) => DefInstance(reinfo(i), rename(n), renameOfModule(n, m))
+      case DefInstance(i, n, m, t) =>
+        val newmod = renameOfModule(n, m)
+        WDefInstance(reinfo(i), rename(n), newmod, retype(n)(t))
       case d: DefMemory =>
         val oldType = MemPortUtils.memType(d)
         val newType = retype(d.name)(oldType)

--- a/src/main/scala/tutorial/lesson2-working-ir/AnalyzeCircuit.scala
+++ b/src/main/scala/tutorial/lesson2-working-ir/AnalyzeCircuit.scala
@@ -127,10 +127,6 @@ class AnalyzeCircuit extends Transform {
     // Map the functions walkStatement(ledger) and walkExpression(ledger)
     val visited = s map walkStatement(ledger) map walkExpression(ledger)
     visited match {
-      // IR node [[DefInstance]] is previously replaced by WDefInstance, a
-      //  "working" IR node
-      case DefInstance(info, name, module) =>
-        Utils.error("All DefInstances should have been replaced by WDefInstances")
       // Working IR Node [[WDefInstance]] is what the compiler uses
       // See src/main/scala/firrtl/WIR.scala for all working IR nodes
       case WDefInstance(info, name, module, tpe) =>

--- a/src/main/scala/tutorial/lesson2-working-ir/AnalyzeCircuit.scala
+++ b/src/main/scala/tutorial/lesson2-working-ir/AnalyzeCircuit.scala
@@ -4,9 +4,9 @@ package tutorial
 package lesson2
 
 // Compiler Infrastructure
-import firrtl.{Transform, LowForm, CircuitState, Utils}
+import firrtl.{Transform, LowForm, CircuitState}
 // Firrtl IR classes
-import firrtl.ir.{DefModule, Statement, DefInstance, Expression, Mux}
+import firrtl.ir.{DefModule, Statement, Expression, Mux}
 // Firrtl compiler's working IR classes (WIR)
 import firrtl.WDefInstance
 // Map functions

--- a/src/test/scala/firrtl/testutils/FirrtlSpec.scala
+++ b/src/test/scala/firrtl/testutils/FirrtlSpec.scala
@@ -306,12 +306,12 @@ class TestFirrtlFlatSpec extends FirrtlFlatSpec {
 
   it should "be supported on Circuit" in {
     assert(c search {
-      case Connect(_, Reference("out",_), Reference("in",_)) => true
+      case Connect(_, Reference("out",_, _, _), Reference("in", _, _, _)) => true
     })
   }
   it should "be supported on CircuitStates" in {
     assert(state search {
-      case Connect(_, Reference("out",_), Reference("in",_)) => true
+      case Connect(_, Reference("out", _, _, _), Reference("in",_, _, _)) => true
     })
   }
   it should "be supported on the results of compilers" in {

--- a/src/test/scala/firrtlTests/ChirrtlMemSpec.scala
+++ b/src/test/scala/firrtlTests/ChirrtlMemSpec.scala
@@ -258,7 +258,7 @@ circuit foo :
         |""".stripMargin
     val res = (new HighFirrtlCompiler).compile(CircuitState(parse(input), ChirrtlForm), Seq()).circuit
     assert(res search {
-      case Connect(_, SubField(SubField(Reference("mem", _), "bar", _), "clk", _), DoPrim(AsClock, Seq(Reference("clock", _)), _, _)) => true
+      case Connect(_, SubField(SubField(Reference("mem", _, _, _), "bar", _, _), "clk", _, _), DoPrim(AsClock, Seq(Reference("clock", _, _, _)), _, _)) => true
     })
   }
 }


### PR DESCRIPTION
**Type of improvement:** API simplification + pass reusability improvement
**API impact:** API modification (see below)
**Backend Code Generation Impact:** none
**Desired merge strategy:** rebase
**Release notes:**
_See extended commit message of ba40a5c2cdbe5e485bbcefe1411ab551b78c7cfa for lengthy release notes._

Fixes #1097 
Helps with #559 
Removes incompatibility of WIR with ProtoBuf from #832

This PR absorbs the extra fields of `WRef`, `WSubField`, `WSubIndex`, `WSubAccess`, and `WDefInstance` into the corresponding standard IR nodes. The point of this PR is to show the minimal set of changes to accommodate this, so I haven't included other commits that do things like remove unreachable code and port built-in passes to reduce the use of the `W____` versions.

**Type of improvement:** API simplification + pass reusability improvement
**Backend Code Generation Impact:** None

### API Impact

**TLDR:** Code that used WIR will not change at all. Code that used non-WIR IR will have to update pattern matching signatures to hold the new fields, but this applies to very little (or no) user code.

This uses type aliases and new `unapply` and `apply` methods of objects to act as a compatibility layer, so the API impact is minimal.

There is exactly one code-breaking API change: the signatures of non-WIR `Reference`, `SubField`, et cetera change when pattern matching. There is no way to solve this with an extra `unapply`, so any code that pattern matches against non-WIR nodes will need to change the type signature of the pattern:

```
case Reference(_, _) => // old
case Reference(_, _, _, _) => // new
```

Fortunately, nearly all non-core passes rely on WIR. **Any code that was using WIR before will not have to change at all!**
