### PR TITLE
Firrtl fix asyncreset emission

### DIFF
--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -502,7 +502,7 @@ class ConstantPropagation extends Transform with ResolvedAnnotationPaths {
           }
 
           // Updates nodeMap after analyzing the returned value from regConstant
-          def updateNodeMap(e: Expression): Unit = regConstant(e) match {
+          def updateNodeMapIfConstant(e: Expression): Unit = regConstant(e) match {
             case RegCPEntry(BoundConstant(`lname`), litBinding) => litBinding match {
               case UnboundConstant => nodeMap(lname) = padCPExp(zero) // only self-assigns -> replace with zero
               case BoundConstant(lit) => nodeMap(lname) = padCPExp(lit) // self + lit assigns -> replace with lit
@@ -516,9 +516,9 @@ class ConstantPropagation extends Transform with ResolvedAnnotationPaths {
 
           asyncResetRegs.get(lname) match {
             // Normal Register
-            case None => updateNodeMap(rhs)
+            case None => updateNodeMapIfConstant(rhs)
             // Async Register
-            case Some(reg: DefRegister) => updateNodeMap(Mux(reg.reset, reg.init, rhs))
+            case Some(reg: DefRegister) => updateNodeMapIfConstant(Mux(reg.reset, reg.init, rhs))
           }
 
         // Mark instance inputs connected to a constant

--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -406,7 +406,7 @@ class ConstantPropagation extends Transform with ResolvedAnnotationPaths {
     // (can have more than 1 of the same submodule)
     val constSubInputs = mutable.HashMap.empty[OfModule, mutable.HashMap[String, Seq[Literal]]]
     // AsyncReset registers don't have reset turned into a mux so we must be careful
-    val asyncResetRegs = mutable.HashSet.empty[String]
+    val asyncResetRegs = mutable.HashMap.empty[String, DefRegister]
 
     // Register constant propagation is intrinsically more complicated, as it is not feed-forward.
     // Therefore, we must store some memoized information about how nodes can be canditates for
@@ -468,7 +468,7 @@ class ConstantPropagation extends Transform with ResolvedAnnotationPaths {
       stmtx match {
         case x: DefNode if !dontTouches.contains(x.name) => propagateRef(x.name, x.value)
         case reg: DefRegister if reg.reset.tpe == AsyncResetType =>
-          asyncResetRegs += reg.name
+          asyncResetRegs(reg.name) = reg
         case Connect(_, WRef(wname, wtpe, WireKind, _), expr: Literal) if !dontTouches.contains(wname) =>
           val exprx = constPropExpression(nodeMap, instMap, constSubOutputs)(pad(expr, wtpe))
           propagateRef(wname, exprx)
@@ -478,7 +478,7 @@ class ConstantPropagation extends Transform with ResolvedAnnotationPaths {
           constOutputs(pname) = paddedLit
         // Const prop registers that are driven by a mux tree containing only instances of one constant or self-assigns
         // This requires that reset has been made explicit
-        case Connect(_, lref @ WRef(lname, ltpe, RegKind, _), rhs) if !dontTouches(lname) && !asyncResetRegs(lname) =>
+        case Connect(_, lref @ WRef(lname, ltpe, RegKind, _), rhs) if !dontTouches(lname) =>
 
          /* Checks if an RHS expression e of a register assignment is convertible to a constant assignment.
           * Here, this means that e must be 1) a literal, 2) a self-connect, or 3) a mux tree of
@@ -500,9 +500,9 @@ class ConstantPropagation extends Transform with ResolvedAnnotationPaths {
             case Mux(_, tval, fval, _) => regConstant(tval).resolve(regConstant(fval))
             case _ => RegCPEntry(NonConstant, NonConstant)
           }
-          def zero = passes.RemoveValidIf.getGroundZero(ltpe)
-          def padCPExp(e: Expression) = constPropExpression(nodeMap, instMap, constSubOutputs)(pad(e, ltpe))
-          regConstant(rhs) match {
+
+          // Updates nodeMap after analyzing the returned value from regConstant
+          def updateNodeMap(e: Expression): Unit = regConstant(e) match {
             case RegCPEntry(BoundConstant(`lname`), litBinding) => litBinding match {
               case UnboundConstant => nodeMap(lname) = padCPExp(zero) // only self-assigns -> replace with zero
               case BoundConstant(lit) => nodeMap(lname) = padCPExp(lit) // self + lit assigns -> replace with lit
@@ -511,6 +511,16 @@ class ConstantPropagation extends Transform with ResolvedAnnotationPaths {
             case RegCPEntry(UnboundConstant, BoundConstant(lit)) => nodeMap(lname) = padCPExp(lit) // only lit assigns
             case _ =>
           }
+          def zero = passes.RemoveValidIf.getGroundZero(ltpe)
+          def padCPExp(e: Expression) = constPropExpression(nodeMap, instMap, constSubOutputs)(pad(e, ltpe))
+
+          asyncResetRegs.get(lname) match {
+            // Normal Register
+            case None => updateNodeMap(rhs)
+            // Async Register
+            case Some(reg: DefRegister) => updateNodeMap(Mux(reg.reset, reg.init, rhs))
+          }
+
         // Mark instance inputs connected to a constant
         case Connect(_, lref @ WSubField(WRef(inst, _, InstanceKind, _), port, ptpe, _), lit: Literal) =>
           val paddedLit = constPropExpression(nodeMap, instMap, constSubOutputs)(pad(lit, ptpe)).asInstanceOf[Literal]

--- a/src/test/scala/firrtlTests/AsyncResetSpec.scala
+++ b/src/test/scala/firrtlTests/AsyncResetSpec.scala
@@ -4,16 +4,19 @@ package firrtlTests
 
 import firrtl._
 import FirrtlCheckers._
+import firrtl.annotations.{Annotation, CircuitTarget, ReferenceTarget}
+import firrtl.transforms.DontTouchAnnotation
+import logger.{LogLevel, LogLevelAnnotation}
 
 class AsyncResetSpec extends FirrtlFlatSpec {
-  def compile(input: String): CircuitState =
-    (new VerilogCompiler).compileAndEmit(CircuitState(parse(input), ChirrtlForm), List.empty)
-  def compileBody(body: String) = {
+  def compile(input: String, annos: AnnotationSeq = Nil): CircuitState =
+    (new VerilogCompiler).compileAndEmit(CircuitState(parse(input), ChirrtlForm, annos), List.empty)
+  def compileBody(body: String, annos: AnnotationSeq = Nil) = {
     val str = """
       |circuit Test :
       |  module Test :
       |""".stripMargin + body.split("\n").mkString("    ", "\n    ", "")
-    compile(str)
+    compile(str, annos)
   }
 
   "AsyncReset" should "generate async-reset always blocks" in {
@@ -352,7 +355,7 @@ class AsyncResetSpec extends FirrtlFlatSpec {
     result shouldNot containLine("always @(posedge clock or posedge reset) begin")
   }
 
-  "Constantly assigned and initialized asynchronously reset registers" should "properly constantprop" in {
+  "Constantly assigned and initialized asynchronously reset registers with donttouch" should "properly constantprop" in {
     val result = compileBody(
       s"""
          |input clock : Clock
@@ -360,9 +363,14 @@ class AsyncResetSpec extends FirrtlFlatSpec {
          |output z : UInt<1>
          |reg r : UInt<1>, clock with : (reset => (reset, UInt(0)))
          |r <= UInt(0)
-         |z <= r""".stripMargin
+         |z <= r""".stripMargin,
+      Seq(DontTouchAnnotation(CircuitTarget("Test").module("Test").ref("r")))
     )
-    result shouldNot containLine("always @(posedge clock or posedge reset) begin")
+    result should containLines (
+      "always @(posedge clock) begin",
+      "r <= 1'h0;",
+      "end"
+    )
   }
 }
 

--- a/src/test/scala/firrtlTests/AsyncResetSpec.scala
+++ b/src/test/scala/firrtlTests/AsyncResetSpec.scala
@@ -339,7 +339,20 @@ class AsyncResetSpec extends FirrtlFlatSpec {
     result shouldNot containLine("always @(posedge clock or posedge reset) begin")
   }
 
-  "Constantly assigned asyncronously reset registers" should "properly constantprop" in {
+  "Constantly assigned asynchronously reset registers" should "properly constantprop" in {
+    val result = compileBody(
+      s"""
+         |input clock : Clock
+         |input reset : AsyncReset
+         |output z : UInt<1>
+         |reg r : UInt<1>, clock with : (reset => (reset, r))
+         |r <= UInt(0)
+         |z <= r""".stripMargin
+    )
+    result shouldNot containLine("always @(posedge clock or posedge reset) begin")
+  }
+
+  "Constantly assigned and initialized asynchronously reset registers" should "properly constantprop" in {
     val result = compileBody(
       s"""
          |input clock : Clock

--- a/src/test/scala/firrtlTests/AsyncResetSpec.scala
+++ b/src/test/scala/firrtlTests/AsyncResetSpec.scala
@@ -319,6 +319,38 @@ class AsyncResetSpec extends FirrtlFlatSpec {
     )
   }
 
+  "Unassigned asyncronously reset registers" should "properly constantprop" in {
+    val result = compileBody(
+      s"""
+         |input clock : Clock
+         |input reset : AsyncReset
+         |output z : UInt<1>[4]
+         |wire literal : UInt<1>[2]
+         |literal[0] <= UInt<1>("h01")
+         |literal[1] <= UInt<1>("h01")
+         |wire complex_literal : UInt<1>[4]
+         |complex_literal[0] <= literal[0]
+         |complex_literal[1] <= literal[1]
+         |complex_literal[2] <= UInt<1>("h00")
+         |complex_literal[3] <= UInt<1>("h00")
+         |reg r : UInt<1>[4], clock with : (reset => (reset, complex_literal))
+         |z <= r""".stripMargin
+    )
+    result shouldNot containLine("always @(posedge clock or posedge reset) begin")
+  }
+
+  "Constantly assigned asyncronously reset registers" should "properly constantprop" in {
+    val result = compileBody(
+      s"""
+         |input clock : Clock
+         |input reset : AsyncReset
+         |output z : UInt<1>
+         |reg r : UInt<1>, clock with : (reset => (reset, UInt(0)))
+         |r <= UInt(0)
+         |z <= r""".stripMargin
+    )
+    result shouldNot containLine("always @(posedge clock or posedge reset) begin")
+  }
 }
 
 class AsyncResetExecutionTest extends ExecutionTest("AsyncResetTester", "/features")


### PR DESCRIPTION
Currently this is the previous code contained in #1355 , my plan is to rework it so this is contained in the Verilog emitter, which I'll get to tomorrow.

### Checklist

- [x] Did you specify the type of improvement?
- [x] Did you specify the code generation impact?

### Type of Improvement

<!-- Choose one or more from the following: -->
   - bug fix

### Backend Code Generation Impact

Makes emission of constant-assigned asynchronous registers marked don't touch to not have latches inferred.

See discussion at #1355 