### PR TITLE
Rename Modules Duplicated by EliminateTargetPaths

### DIFF
--- a/src/main/scala/firrtl/annotations/Target.scala
+++ b/src/main/scala/firrtl/annotations/Target.scala
@@ -185,6 +185,19 @@ object Target {
       }
     }.tryToComplete
   }
+
+  /** Returns the module that a [[Target]] "refers" to.
+    *
+    * For a [[ModuleTarget]] or a [[ReferenceTarget]], this is simply the deepest module. For an [[InstanceTarget]] this
+    * is *the module of the instance*.
+    *
+    * @note This differs from [[InstanceTarget.pathlessTarget]] which refers to the module instantiating the instance.
+    */
+  def referringModule(a: IsMember): ModuleTarget = a match {
+    case b: ModuleTarget    => b
+    case b: InstanceTarget  => b.ofModuleTarget
+    case b: ReferenceTarget => b.pathlessTarget.moduleTarget
+  }
 }
 
 /** Represents incomplete or non-standard [[Target]]s


### PR DESCRIPTION
Modifies `EliminateTargetPaths` to generate a rename map for `ModuleTargets` where the underlying module is duplicated. 

Fixes #1326 (more info there)

### Checklist

- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix                           
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

This adds a helper utility `Target.referringModule` which behaves like `IsMember.pathlessTarget` except that it returns the "of module" for an `InstanceTarget`. This proves useful when trying to get at "the module" that some target is pointing at.

### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

No Verilog impact.

### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!-- - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.
