### PR TITLE
Include Dead Modules in InstanceGraph.staticInstanceCount

### DIFF
--- a/src/test/scala/firrtlTests/analyses/InstanceGraphTests.scala
+++ b/src/test/scala/firrtlTests/analyses/InstanceGraphTests.scala
@@ -1,5 +1,6 @@
 package firrtlTests.analyses
 
+import firrtl.annotations.TargetToken.OfModule
 import firrtl.analyses.InstanceGraph
 import firrtl.graph.DiGraph
 import firrtl.WDefInstance
@@ -194,5 +195,53 @@ circuit Top :
     val instGraph = new InstanceGraph(circuit)
     val hier = instGraph.fullHierarchy
     hier.keys.toSeq.map(_.name) should equal (Seq("Top", "a", "b", "c", "d", "e"))
+  }
+
+  behavior of "InstanceGraph.staticInstanceCount"
+
+  it should "report that there is one instance of the top module" in {
+    val input =
+      """|circuit Foo:
+         |  module Foo:
+         |    skip
+         |""".stripMargin
+    val iGraph = new InstanceGraph(ToWorkingIR.run(parse(input)))
+    val expectedCounts = Map(OfModule("Foo") -> 1)
+    iGraph.staticInstanceCount should be (expectedCounts)
+  }
+
+  it should "report correct number of instances for a sample circuit" in {
+    val input =
+      """|circuit Foo:
+         |  module Baz:
+         |    skip
+         |  module Bar:
+         |    inst baz1 of Baz
+         |    inst baz2 of Baz
+         |    inst baz3 of Baz
+         |    skip
+         |  module Foo:
+         |    inst bar1 of Bar
+         |    inst bar2 of Bar
+         |""".stripMargin
+    val iGraph = new InstanceGraph(ToWorkingIR.run(parse(input)))
+    val expectedCounts = Map(OfModule("Foo") -> 1,
+                             OfModule("Bar") -> 2,
+                             OfModule("Baz") -> 3)
+    iGraph.staticInstanceCount should be (expectedCounts)
+  }
+
+  it should "report zero instances for dead modules" in {
+    val input =
+      """|circuit Foo:
+         |  module Bar:
+         |    skip
+         |  module Foo:
+         |    skip
+         |""".stripMargin
+    val iGraph = new InstanceGraph(ToWorkingIR.run(parse(input)))
+    val expectedCounts = Map(OfModule("Foo") -> 1,
+                             OfModule("Bar") -> 0)
+    iGraph.staticInstanceCount should be (expectedCounts)
   }
 }


### PR DESCRIPTION
This changes the API of `InstanceGraph.staticInstanceCount` to include counts of modules never instantiated (dead modules). Previously, dead modules were not included at all in the count leading to some confusion on my part.

I assumed that this was what the API was supposed to be as this allows a user to differentiate between modules not instantiated (modules with a count of zero) and modules which don't exist (modules which are not in the key list). *Therefore, I'm treating this as a bug-fix.* However, I can see a situation where the old behavior is also reasonable. I hit this when I was trying to use `staticInstanceCount` to find dead modules and was surprised at the current behavior.

@albert-magyar: what is the desired API in your view, here?

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
- new feature/API

### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

This changes the behavior of `InstanceGraph.staticInstanceCount` to return counts of modules *not* instantiated. This is technically an API change.

### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [x] Did you review?
- ~~[ ] Did you mark as `Please Merge`?~~
