### PR TITLE
Allow self renames

### DIFF
--- a/src/main/scala/firrtl/RenameMap.scala
+++ b/src/main/scala/firrtl/RenameMap.scala
@@ -484,19 +484,15 @@ final class RenameMap private (val underlying: mutable.HashMap[CompleteTarget, S
     * @param tos
     */
   private def completeRename(from: CompleteTarget, tos: Seq[CompleteTarget]): Unit = {
-    (from, tos) match {
-      case (x, Seq(y)) if x == y =>
-      case _ =>
-        tos.foreach{recordSensitivity(from, _)}
-        val existing = underlying.getOrElse(from, Vector.empty)
-        val updated = existing ++ tos
-        underlying(from) = updated
-        getCache.clear()
-        traverseTokensCache.clear()
-        traverseHierarchyCache.clear()
-        traverseLeftCache.clear()
-        traverseRightCache.clear()
-    }
+    tos.foreach{recordSensitivity(from, _)}
+    val existing = underlying.getOrElse(from, Vector.empty)
+    val updated = (existing ++ tos).distinct
+    underlying(from) = updated
+    getCache.clear()
+    traverseTokensCache.clear()
+    traverseHierarchyCache.clear()
+    traverseLeftCache.clear()
+    traverseRightCache.clear()
   }
 
   /* DEPRECATED ACCESSOR/SETTOR METHODS WITH [[firrtl.ir.Named Named]] */

--- a/src/main/scala/firrtl/RenameMap.scala
+++ b/src/main/scala/firrtl/RenameMap.scala
@@ -33,12 +33,16 @@ object RenameMap {
   *
   * Transforms that modify names should return a [[RenameMap]] with the [[CircuitState]]
   * These are mutable datastructures for convenience
+  * @define noteSelfRename @note Self renames *will* be recorded
+  * @define noteDistinct @note Rename to/tos will be made distinct
   */
 // TODO This should probably be refactored into immutable and mutable versions
 final class RenameMap private (val underlying: mutable.HashMap[CompleteTarget, Seq[CompleteTarget]] = mutable.HashMap[CompleteTarget, Seq[CompleteTarget]](), val chained: Option[RenameMap] = None) {
 
   /** Chain a [[RenameMap]] with this [[RenameMap]]
     * @param next the map to chain with this map
+    * $noteSelfRename
+    * $noteDistinct
     */
   def andThen(next: RenameMap): RenameMap = {
     if (next.chained.isEmpty) {
@@ -52,6 +56,8 @@ final class RenameMap private (val underlying: mutable.HashMap[CompleteTarget, S
     * [[firrtl.annotations.CircuitTarget CircuitTarget]]
     * @param from
     * @param to
+    * $noteSelfRename
+    * $noteDistinct
     */
   def record(from: CircuitTarget, to: CircuitTarget): Unit = completeRename(from, Seq(to))
 
@@ -59,6 +65,8 @@ final class RenameMap private (val underlying: mutable.HashMap[CompleteTarget, S
     * [[firrtl.annotations.CircuitTarget CircuitTarget]]s
     * @param from
     * @param tos
+    * $noteSelfRename
+    * $noteDistinct
     */
   def record(from: CircuitTarget, tos: Seq[CircuitTarget]): Unit = completeRename(from, tos)
 
@@ -66,6 +74,8 @@ final class RenameMap private (val underlying: mutable.HashMap[CompleteTarget, S
     * IsMember]]
     * @param from
     * @param to
+    * $noteSelfRename
+    * $noteDistinct
     */
   def record(from: IsMember, to: IsMember): Unit = completeRename(from, Seq(to))
 
@@ -73,6 +83,8 @@ final class RenameMap private (val underlying: mutable.HashMap[CompleteTarget, S
     * [[firrtl.annotations.IsMember IsMember]]s
     * @param from
     * @param tos
+    * $noteSelfRename
+    * $noteDistinct
     */
   def record(from: IsMember, tos: Seq[IsMember]): Unit = completeRename(from, tos)
 
@@ -81,6 +93,8 @@ final class RenameMap private (val underlying: mutable.HashMap[CompleteTarget, S
     * and ([[firrtl.annotations.IsMember IsMember]] -> Seq[ [[firrtl.annotations.IsMember IsMember]] ]) key/value
     * allowed
     * @param map
+    * $noteSelfRename
+    * $noteDistinct
     */
   def recordAll(map: collection.Map[CompleteTarget, Seq[CompleteTarget]]): Unit =
     map.foreach{
@@ -479,7 +493,7 @@ final class RenameMap private (val underlying: mutable.HashMap[CompleteTarget, S
     }
   }
 
-  /** Fully renames from to tos
+  /** Fully rename `from` to `tos`
     * @param from
     * @param tos
     */

--- a/src/test/scala/firrtlTests/RenameMapSpec.scala
+++ b/src/test/scala/firrtlTests/RenameMapSpec.scala
@@ -752,4 +752,18 @@ class RenameMapSpec extends FirrtlFlatSpec {
       Some(Seq(bar2))
     }
   }
+
+  it should "record a self-rename" in {
+    val top = CircuitTarget("Top").module("Top")
+    val foo = top.instOf("foo", "Mod")
+    val bar = top.instOf("bar", "Mod")
+
+    val r = RenameMap()
+
+    r.record(foo, bar)
+    r.record(foo, foo)
+
+    r.get(foo) should not be (empty)
+    r.get(foo).get should contain allOf (foo, bar)
+  }
 }

--- a/src/test/scala/firrtlTests/RenameMapSpec.scala
+++ b/src/test/scala/firrtlTests/RenameMapSpec.scala
@@ -766,4 +766,18 @@ class RenameMapSpec extends FirrtlFlatSpec {
     r.get(foo) should not be (empty)
     r.get(foo).get should contain allOf (foo, bar)
   }
+
+  it should "not record the same rename multiple times" in {
+    val top = CircuitTarget("Top").module("Top")
+    val foo = top.instOf("foo", "Mod")
+    val bar = top.instOf("bar", "Mod")
+
+    val r = RenameMap()
+
+    r.record(foo, bar)
+    r.record(foo, bar)
+
+    r.get(foo) should not be (empty)
+    r.get(foo).get should contain theSameElementsAs Seq(bar)
+  }
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
- new feature/API

### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

This changes the behavior of rename map recording to record self-renames and to record renames distinctly. 

Previously, if you recorded a self-rename, it would just not record. Additionally, the rename map would record the same rename multiple times.

### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None. 

### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- ~~[ ] Did you mark as `Please Merge`?~~
