### PR TITLE
Remove last connect semantics from reset inference

### DIFF
--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -49,7 +49,8 @@ class ResolveAndCheck extends CoreTransform {
     new passes.TrimIntervals(),
     new passes.InferWidths,
     passes.CheckWidths,
-    new firrtl.transforms.InferResets)
+    new firrtl.transforms.InferResets,
+    passes.CheckTypes)
 }
 
 /** Expands aggregate connects, removes dynamic accesses, and when

--- a/src/main/scala/firrtl/passes/RemoveValidIf.scala
+++ b/src/main/scala/firrtl/passes/RemoveValidIf.scala
@@ -13,6 +13,7 @@ object RemoveValidIf extends Pass {
   val SIntZero = SIntLiteral(BigInt(0), IntWidth(1))
   val ClockZero = DoPrim(PrimOps.AsClock, Seq(UIntZero), Seq.empty, ClockType)
   val FixedZero = FixedLiteral(BigInt(0), IntWidth(1), IntWidth(0))
+  val AsyncZero = DoPrim(PrimOps.AsAsyncReset, Seq(UIntZero), Nil, AsyncResetType)
 
   /** Returns an [[firrtl.ir.Expression Expression]] equal to zero for a given [[firrtl.ir.GroundType GroundType]]
     * @note Accepts [[firrtl.ir.Type Type]] but dyanmically expects [[firrtl.ir.GroundType GroundType]]
@@ -22,6 +23,7 @@ object RemoveValidIf extends Pass {
     case _: SIntType => SIntZero
     case ClockType => ClockZero
     case _: FixedType => FixedZero
+    case AsyncResetType => AsyncZero
     case other => throwInternalError(s"Unexpected type $other")
   }
 

--- a/src/main/scala/firrtl/transforms/InferResets.scala
+++ b/src/main/scala/firrtl/transforms/InferResets.scala
@@ -36,7 +36,11 @@ object InferResets {
   private case class TypeDriver(tpe: Type, target: () => ReferenceTarget) extends ResetDriver {
     override def toString: String = s"TypeDriver(${tpe.serialize}, $target)"
   }
-
+  // When a [[ResetType]] is invalidated, we record the InvalidDrive
+  // If there are no types but invalid drivers, we default to BoolType
+  private case object InvalidDriver extends ResetDriver {
+    def defaultType: Type = Utils.BoolType
+  }
 
   // Type hierarchy representing the path to a leaf type in an aggregate type structure
   // Used by this [[InferResets]] to pinpoint instances of [[ResetType]] and their inferred type
@@ -136,6 +140,16 @@ class InferResets extends Transform {
             for ((i, j) <- points) {
               markResetDriver(locs(i), exps(j))
             }
+          case IsInvalid(_, lhs) =>
+            val exprs = Utils.create_exps(lhs)
+            for (expr <- exprs) {
+              // Ignore leaves that are not of type ResetType
+              // Unlike in markResetDriver, flow is irrelevant for invalidation
+              if (expr.tpe == ResetType) {
+                val target = makeTarget(expr)
+                map.getOrElseUpdate(target, mutable.ListBuffer()) += InvalidDriver
+              }
+            }
           case WDefInstance(_, inst, module, _) =>
             instMap += (inst -> module)
           case Conditionally(_, _, con, alt) =>
@@ -143,12 +157,10 @@ class InferResets extends Transform {
             val altMap = new DriverMap
             onStmt(conMap)(con)
             onStmt(altMap)(alt)
-            // Default to outerscope if not found in alt
-            val altLookup = altMap.orElse(map).lift
             for (key <- conMap.keys ++ altMap.keys) {
               val ds = map.getOrElseUpdate(key, mutable.ListBuffer())
               conMap.get(key).foreach(ds ++= _)
-              altLookup(key).foreach(ds ++= _)
+              altMap.get(key).foreach(ds ++= _)
             }
           case other => other.foreach(onStmt(map))
         }
@@ -167,17 +179,22 @@ class InferResets extends Transform {
     val res = mutable.Map[ReferenceTarget, Type]()
     val errors = new Errors
     def rec(target: ReferenceTarget): Type = {
-      val drivers = map(target)
+      val drivers = map.getOrElse(target, Nil)
       res.getOrElseUpdate(target, {
-        val tpes = drivers.map {
-          case TargetDriver(t) => TypeDriver(rec(t), () => t)
-          case td: TypeDriver => td
+        val tpes = drivers.flatMap {
+          case TargetDriver(t) => Some(TypeDriver(rec(t), () => t))
+          case td: TypeDriver  => Some(td)
+          case InvalidDriver   => None
         }.groupBy(_.tpe)
-        if (tpes.keys.size != 1) {
-          // Multiple types of driver!
-          errors.append(DifferingDriverTypesException(target, tpes.toSeq))
+        tpes.keys.size match {
+          // This can occur if something of type Reset has no driver
+          case 0 => InvalidDriver.defaultType
+          case 1 => tpes.keys.head
+          case _ =>
+            // Multiple types of driver!
+            errors.append(DifferingDriverTypesException(target, tpes.toSeq))
+            tpes.keys.head
         }
-        tpes.keys.head
       })
     }
     for ((target, _) <- map) {

--- a/src/main/scala/firrtl/transforms/InferResets.scala
+++ b/src/main/scala/firrtl/transforms/InferResets.scala
@@ -15,7 +15,9 @@ import scala.collection.mutable
 import scala.util.Try
 
 object InferResets {
+  @deprecated("This is no longer in use and will be removed", "1.3")
   final class DifferingDriverTypesException private (msg: String) extends PassException(msg)
+  @deprecated("This is no longer in use and will be removed", "1.3")
   object DifferingDriverTypesException {
     def apply(target: ReferenceTarget, tpes: Seq[(Type, Seq[TypeDriver])]): DifferingDriverTypesException = {
       val xs = tpes.map { case (t, ds) => s"${ds.map(_.target().serialize).mkString(", ")} of type ${t.serialize}" }

--- a/src/main/scala/firrtl/transforms/InferResets.scala
+++ b/src/main/scala/firrtl/transforms/InferResets.scala
@@ -54,6 +54,7 @@ object InferResets {
     def defaultType: Type = Utils.BoolType
   }
 
+  // Private type hierarchy used as DiGraph nodes for type inference
   private sealed trait Node
   private case class Var(target: ReferenceTarget) extends Node {
     override def toString = target.serialize

--- a/src/main/scala/firrtl/transforms/InferResets.scala
+++ b/src/main/scala/firrtl/transforms/InferResets.scala
@@ -29,7 +29,7 @@ object InferResets {
   final class InferResetsException private (msg: String) extends PassException(msg)
   object InferResetsException {
     private[InferResets] def apply(path: Seq[Node]): InferResetsException = {
-      val ps = path.collect { case Var(t) => t.serialize }.mkString("\n  ", "\n  ", "")
+      val ps = path.collect { case Var(t) => t.serialize }.mkString("\n    - ", "\n    - ", "")
       val msg = s"Reset-typed components connected to both AsyncReset and UInt<1>. Offending path:$ps"
       new InferResetsException(msg)
     }

--- a/src/main/scala/firrtl/transforms/InferResets.scala
+++ b/src/main/scala/firrtl/transforms/InferResets.scala
@@ -108,19 +108,18 @@ class InferResets extends Transform {
       def onStmt(map: DriverMap)(stmt: Statement): Unit = {
         // Mark driver of a ResetType leaf
         def markResetDriver(lhs: Expression, rhs: Expression): Unit = {
-          val lflip = Utils.to_flip(Utils.gender(lhs))
-          if ((lflip == Default && lhs.tpe == ResetType) ||
-              (lflip == Flip    && rhs.tpe == ResetType)) {
-            val (loc, exp) = lflip match {
-              case Default => (lhs, rhs)
-              case Flip    => (rhs, lhs)
-            }
-            val target = makeTarget(loc)
+          val con = Utils.flow(lhs) match {
+            case SinkFlow   if lhs.tpe == ResetType => Some((lhs, rhs))
+            case SourceFlow if rhs.tpe == ResetType => Some((rhs, lhs))
+            // If sink is not ResetType, do nothing
+            case _                                  => None
+          }
+          con.foreach { case (loc, exp) =>
             val driver = exp.tpe match {
               case ResetType => TargetDriver(makeTarget(exp))
               case tpe       => TypeDriver(tpe, () => makeTarget(exp))
             }
-            map.getOrElseUpdate(target, mutable.ListBuffer()) += driver
+            map.getOrElseUpdate(makeTarget(loc), mutable.ListBuffer()) += driver
           }
         }
         stmt match {
@@ -179,8 +178,8 @@ class InferResets extends Transform {
     val res = mutable.Map[ReferenceTarget, Type]()
     val errors = new Errors
     def rec(target: ReferenceTarget): Type = {
-      val drivers = map.getOrElse(target, Nil)
       res.getOrElseUpdate(target, {
+        val drivers = map.getOrElse(target, Nil)
         val tpes = drivers.flatMap {
           case TargetDriver(t) => Some(TypeDriver(rec(t), () => t))
           case td: TypeDriver  => Some(td)

--- a/src/main/scala/firrtl/transforms/InferResets.scala
+++ b/src/main/scala/firrtl/transforms/InferResets.scala
@@ -36,11 +36,7 @@ object InferResets {
   private case class TypeDriver(tpe: Type, target: () => ReferenceTarget) extends ResetDriver {
     override def toString: String = s"TypeDriver(${tpe.serialize}, $target)"
   }
-  // When a [[ResetType]] is invalidated, we record the InvalidDrive
-  // If there are no types but invalid drivers, we default to BoolType
-  private case object InvalidDriver extends ResetDriver {
-    def defaultType: Type = Utils.BoolType
-  }
+
 
   // Type hierarchy representing the path to a leaf type in an aggregate type structure
   // Used by this [[InferResets]] to pinpoint instances of [[ResetType]] and their inferred type
@@ -88,7 +84,7 @@ class InferResets extends Transform {
 
   // Collect all drivers for circuit elements of type ResetType
   private def analyze(c: Circuit): Map[ReferenceTarget, List[ResetDriver]] = {
-    type DriverMap = mutable.HashMap[ReferenceTarget, List[ResetDriver]]
+    type DriverMap = mutable.HashMap[ReferenceTarget, mutable.ListBuffer[ResetDriver]]
     def onMod(mod: DefModule): DriverMap = {
       val instMap = mutable.Map[String, String]()
       // We need to convert submodule port targets into targets on the Module port itself
@@ -108,18 +104,19 @@ class InferResets extends Transform {
       def onStmt(map: DriverMap)(stmt: Statement): Unit = {
         // Mark driver of a ResetType leaf
         def markResetDriver(lhs: Expression, rhs: Expression): Unit = {
-          val con = Utils.flow(lhs) match {
-            case SinkFlow   if lhs.tpe == ResetType => Some((lhs, rhs))
-            case SourceFlow if rhs.tpe == ResetType => Some((rhs, lhs))
-            // If sink is not ResetType, do nothing
-            case _                                  => None
-          }
-          con.foreach { case (loc, exp) =>
+          val lflip = Utils.to_flip(Utils.gender(lhs))
+          if ((lflip == Default && lhs.tpe == ResetType) ||
+              (lflip == Flip    && rhs.tpe == ResetType)) {
+            val (loc, exp) = lflip match {
+              case Default => (lhs, rhs)
+              case Flip    => (rhs, lhs)
+            }
+            val target = makeTarget(loc)
             val driver = exp.tpe match {
               case ResetType => TargetDriver(makeTarget(exp))
               case tpe       => TypeDriver(tpe, () => makeTarget(exp))
             }
-            map(makeTarget(loc)) = driver :: Nil
+            map.getOrElseUpdate(target, mutable.ListBuffer()) += driver
           }
         }
         stmt match {
@@ -139,16 +136,6 @@ class InferResets extends Transform {
             for ((i, j) <- points) {
               markResetDriver(locs(i), exps(j))
             }
-          case IsInvalid(_, lhs) =>
-            val exprs = Utils.create_exps(lhs)
-            for (expr <- exprs) {
-              // Ignore leaves that are not of type ResetType
-              // Unlike in markResetDriver, flow is irrelevant for invalidation
-              if (expr.tpe == ResetType) {
-                val target = makeTarget(expr)
-                map(target) = InvalidDriver :: Nil
-              }
-            }
           case WDefInstance(_, inst, module, _) =>
             instMap += (inst -> module)
           case Conditionally(_, _, con, alt) =>
@@ -156,12 +143,12 @@ class InferResets extends Transform {
             val altMap = new DriverMap
             onStmt(conMap)(con)
             onStmt(altMap)(alt)
-            // Default to outerscope if not found on either side
-            val conLookup = conMap.orElse(map).lift
+            // Default to outerscope if not found in alt
             val altLookup = altMap.orElse(map).lift
             for (key <- conMap.keys ++ altMap.keys) {
-              val values = conLookup(key).getOrElse(Nil) ++ altLookup(key).getOrElse(Nil)
-              map(key) = values
+              val ds = map.getOrElseUpdate(key, mutable.ListBuffer())
+              conMap.get(key).foreach(ds ++= _)
+              altLookup(key).foreach(ds ++= _)
             }
           case other => other.foreach(onStmt(map))
         }
@@ -180,22 +167,17 @@ class InferResets extends Transform {
     val res = mutable.Map[ReferenceTarget, Type]()
     val errors = new Errors
     def rec(target: ReferenceTarget): Type = {
+      val drivers = map(target)
       res.getOrElseUpdate(target, {
-        val drivers = map.getOrElse(target, Nil)
-        val tpes = drivers.flatMap {
-          case TargetDriver(t) => Some(TypeDriver(rec(t), () => t))
-          case td: TypeDriver  => Some(td)
-          case InvalidDriver   => None
+        val tpes = drivers.map {
+          case TargetDriver(t) => TypeDriver(rec(t), () => t)
+          case td: TypeDriver => td
         }.groupBy(_.tpe)
-        tpes.keys.size match {
-          // This can occur if something of type Reset has no driver
-          case 0 => InvalidDriver.defaultType
-          case 1 => tpes.keys.head
-          case _ =>
-            // Multiple types of driver!
-            errors.append(DifferingDriverTypesException(target, tpes.toSeq))
-            tpes.keys.head
+        if (tpes.keys.size != 1) {
+          // Multiple types of driver!
+          errors.append(DifferingDriverTypesException(target, tpes.toSeq))
         }
+        tpes.keys.head
       })
     }
     for ((target, _) <- map) {

--- a/src/test/scala/firrtlTests/InferResetsSpec.scala
+++ b/src/test/scala/firrtlTests/InferResetsSpec.scala
@@ -4,7 +4,7 @@ package firrtlTests
 
 import firrtl._
 import firrtl.ir._
-import firrtl.passes.{CheckHighForm, CheckTypes, CheckInitialization}
+import firrtl.passes.{CheckHighForm, CheckTypes}
 import firrtl.transforms.InferResets
 import FirrtlCheckers._
 
@@ -37,6 +37,7 @@ class InferResetsSpec extends FirrtlFlatSpec {
       |    y <= asFixedPoint(r, 0)
       |    z <= asAsyncReset(r)""".stripMargin
     )
+    println(result.getEmittedCircuit)
     result should containLine ("wire r : UInt<1>")
     result should containLine ("r <= a")
     result should containLine ("v <= asUInt(r)")
@@ -124,68 +125,44 @@ class InferResetsSpec extends FirrtlFlatSpec {
     result should containTree { case Port(_, "buzz_bar_1_b", Input, AsyncResetType) => true }
   }
 
-  it should "not crash if a ResetType has no drivers" in {
-    a [CheckInitialization.RefNotInitializedException] shouldBe thrownBy {
-      compile(s"""
-        |circuit test :
-        |  module test :
-        |    output out : Reset
-        |    wire w : Reset
-        |    out <= w
-        |    out <= UInt(1)
-        |""".stripMargin
-      )
-    }
-  }
-
-  it should "allow last connect semantics to pick the right type for Reset" in {
-    val result =
+  it should "NOT allow last connect semantics to pick the right type for Reset" in {
+    an [InferResets.DifferingDriverTypesException] shouldBe thrownBy {
       compile(s"""
         |circuit top :
         |  module top :
         |    input reset0 : AsyncReset
         |    input reset1 : UInt<1>
         |    output out : Reset
-        |    wire w0 : Reset
         |    wire w1 : Reset
-        |    w0 <= reset0
-        |    w1 <= reset1
-        |    out <= w0
+        |    wire w2 : Reset
+        |    w1 <= reset0
+        |    w2 <= reset1
         |    out <= w1
+        |    out <= w2
         |""".stripMargin
       )
-    result should containTree { case DefWire(_, "w0", AsyncResetType) => true }
-    result should containTree { case DefWire(_, "w1", BoolType)       => true }
-    result should containTree { case Port(_, "out", Output, BoolType) => true }
+    }
   }
 
-  it should "support last connect semantics across whens" in {
-    val result =
+  it should "NOT support last connect semantics across whens" in {
+    an [InferResets.DifferingDriverTypesException] shouldBe thrownBy {
       compile(s"""
         |circuit top :
         |  module top :
         |    input reset0 : AsyncReset
-        |    input reset1 : AsyncReset
-        |    input reset2 : UInt<1>
-        |    input en : UInt<1>
+        |    input reset1 : UInt<1>
+        |    input en0 : UInt<1>
         |    output out : Reset
-        |    wire w0 : Reset
         |    wire w1 : Reset
         |    wire w2 : Reset
-        |    w0 <= reset0
-        |    w1 <= reset1
-        |    w2 <= reset2
-        |    out <= w2
-        |    when en :
-        |      out <= w0
-        |    else :
-        |      out <= w1
+        |    w1 <= reset0
+        |    w2 <= reset1
+        |    out <= w1
+        |    when en0 :
+        |      out <= w2
         |""".stripMargin
       )
-    result should containTree { case DefWire(_, "w0", AsyncResetType) => true }
-    result should containTree { case DefWire(_, "w1", AsyncResetType) => true }
-    result should containTree { case DefWire(_, "w2", BoolType)       => true }
-    result should containTree { case Port(_, "out", Output, AsyncResetType) => true }
+    }
   }
 
   it should "not allow different Reset Types to drive a single Reset" in {
@@ -207,42 +184,6 @@ class InferResetsSpec extends FirrtlFlatSpec {
         |""".stripMargin
       )
     }
-  }
-
-  it should "allow concrete reset types to overrule invalidation" in {
-    val result = compile(s"""
-      |circuit test :
-      |  module test :
-      |    input in : AsyncReset
-      |    output out : Reset
-      |    out is invalid
-      |    out <= in
-      |""".stripMargin)
-    result should containTree { case Port(_, "out", Output, AsyncResetType) => true }
-  }
-
-  it should "default to BoolType for Resets that are only invalidated" in {
-    val result = compile(s"""
-      |circuit test :
-      |  module test :
-      |    output out : Reset
-      |    out is invalid
-      |""".stripMargin)
-    result should containTree { case Port(_, "out", Output, BoolType) => true }
-  }
-
-  it should "not error if component of ResetType is invalidated and connected to an AsyncResetType" in {
-    val result = compile(s"""
-      |circuit test :
-      |  module test :
-      |    input cond : UInt<1>
-      |    input in : AsyncReset
-      |    output out : Reset
-      |    out is invalid
-      |    when cond :
-      |      out <= in
-      |""".stripMargin)
-    result should containTree { case Port(_, "out", Output, AsyncResetType) => true }
   }
 
   it should "allow ResetType to drive AsyncResets or UInt<1>" in {

--- a/src/test/scala/firrtlTests/InferResetsSpec.scala
+++ b/src/test/scala/firrtlTests/InferResetsSpec.scala
@@ -138,7 +138,7 @@ class InferResetsSpec extends FirrtlFlatSpec {
     }
   }
 
-  it should "allow NOT last connect semantics to pick the right type for Reset" in {
+  it should "NOT allow last connect semantics to pick the right type for Reset" in {
     an [InferResets.InferResetsException] shouldBe thrownBy {
       compile(s"""
         |circuit top :
@@ -420,7 +420,7 @@ class InferResetsSpec extends FirrtlFlatSpec {
     result should containTree { case DefWire(_, "w", AsyncResetType) => true }
   }
 
-  it should "infer from connections, ignoring \"winning\" invalidation" in {
+  it should "infer from connections, ignoring the fact that the invalidation wins" in {
     val result = compile(s"""
       |circuit top :
       |  module top :
@@ -492,7 +492,7 @@ class InferResetsSpec extends FirrtlFlatSpec {
   }
 
   it should "not crash on combinational loops" in {
-    an [CheckCombLoops.CombLoopException] shouldBe thrownBy {
+    a [CheckCombLoops.CombLoopException] shouldBe thrownBy {
       val result = compile(s"""
         |circuit top :
         |  module top :
@@ -510,4 +510,3 @@ class InferResetsSpec extends FirrtlFlatSpec {
     }
   }
 }
-

--- a/src/test/scala/firrtlTests/InferResetsSpec.scala
+++ b/src/test/scala/firrtlTests/InferResetsSpec.scala
@@ -4,7 +4,7 @@ package firrtlTests
 
 import firrtl._
 import firrtl.ir._
-import firrtl.passes.{CheckHighForm, CheckTypes}
+import firrtl.passes.{CheckHighForm, CheckTypes, CheckInitialization}
 import firrtl.transforms.InferResets
 import FirrtlCheckers._
 
@@ -37,7 +37,6 @@ class InferResetsSpec extends FirrtlFlatSpec {
       |    y <= asFixedPoint(r, 0)
       |    z <= asAsyncReset(r)""".stripMargin
     )
-    println(result.getEmittedCircuit)
     result should containLine ("wire r : UInt<1>")
     result should containLine ("r <= a")
     result should containLine ("v <= asUInt(r)")
@@ -125,7 +124,21 @@ class InferResetsSpec extends FirrtlFlatSpec {
     result should containTree { case Port(_, "buzz_bar_1_b", Input, AsyncResetType) => true }
   }
 
-  it should "NOT allow last connect semantics to pick the right type for Reset" in {
+  it should "not crash if a ResetType has no drivers" in {
+    a [CheckInitialization.RefNotInitializedException] shouldBe thrownBy {
+      compile(s"""
+        |circuit test :
+        |  module test :
+        |    output out : Reset
+        |    wire w : Reset
+        |    out <= w
+        |    out <= UInt(1)
+        |""".stripMargin
+      )
+    }
+  }
+
+  it should "allow NOT last connect semantics to pick the right type for Reset" in {
     an [InferResets.DifferingDriverTypesException] shouldBe thrownBy {
       compile(s"""
         |circuit top :
@@ -133,12 +146,12 @@ class InferResetsSpec extends FirrtlFlatSpec {
         |    input reset0 : AsyncReset
         |    input reset1 : UInt<1>
         |    output out : Reset
+        |    wire w0 : Reset
         |    wire w1 : Reset
-        |    wire w2 : Reset
-        |    w1 <= reset0
-        |    w2 <= reset1
+        |    w0 <= reset0
+        |    w1 <= reset1
+        |    out <= w0
         |    out <= w1
-        |    out <= w2
         |""".stripMargin
       )
     }
@@ -150,16 +163,21 @@ class InferResetsSpec extends FirrtlFlatSpec {
         |circuit top :
         |  module top :
         |    input reset0 : AsyncReset
-        |    input reset1 : UInt<1>
-        |    input en0 : UInt<1>
+        |    input reset1 : AsyncReset
+        |    input reset2 : UInt<1>
+        |    input en : UInt<1>
         |    output out : Reset
+        |    wire w0 : Reset
         |    wire w1 : Reset
         |    wire w2 : Reset
-        |    w1 <= reset0
-        |    w2 <= reset1
-        |    out <= w1
-        |    when en0 :
-        |      out <= w2
+        |    w0 <= reset0
+        |    w1 <= reset1
+        |    w2 <= reset2
+        |    out <= w2
+        |    when en :
+        |      out <= w0
+        |    else :
+        |      out <= w1
         |""".stripMargin
       )
     }
@@ -184,6 +202,42 @@ class InferResetsSpec extends FirrtlFlatSpec {
         |""".stripMargin
       )
     }
+  }
+
+  it should "allow concrete reset types to overrule invalidation" in {
+    val result = compile(s"""
+      |circuit test :
+      |  module test :
+      |    input in : AsyncReset
+      |    output out : Reset
+      |    out is invalid
+      |    out <= in
+      |""".stripMargin)
+    result should containTree { case Port(_, "out", Output, AsyncResetType) => true }
+  }
+
+  it should "default to BoolType for Resets that are only invalidated" in {
+    val result = compile(s"""
+      |circuit test :
+      |  module test :
+      |    output out : Reset
+      |    out is invalid
+      |""".stripMargin)
+    result should containTree { case Port(_, "out", Output, BoolType) => true }
+  }
+
+  it should "not error if component of ResetType is invalidated and connected to an AsyncResetType" in {
+    val result = compile(s"""
+      |circuit test :
+      |  module test :
+      |    input cond : UInt<1>
+      |    input in : AsyncReset
+      |    output out : Reset
+      |    out is invalid
+      |    when cond :
+      |      out <= in
+      |""".stripMargin)
+    result should containTree { case Port(_, "out", Output, AsyncResetType) => true }
   }
 
   it should "allow ResetType to drive AsyncResets or UInt<1>" in {

--- a/src/test/scala/firrtlTests/InferResetsSpec.scala
+++ b/src/test/scala/firrtlTests/InferResetsSpec.scala
@@ -139,7 +139,7 @@ class InferResetsSpec extends FirrtlFlatSpec {
   }
 
   it should "allow NOT last connect semantics to pick the right type for Reset" in {
-    an [InferResets.DifferingDriverTypesException] shouldBe thrownBy {
+    an [InferResets.InferResetsException] shouldBe thrownBy {
       compile(s"""
         |circuit top :
         |  module top :
@@ -158,7 +158,7 @@ class InferResetsSpec extends FirrtlFlatSpec {
   }
 
   it should "NOT support last connect semantics across whens" in {
-    an [InferResets.DifferingDriverTypesException] shouldBe thrownBy {
+    an [InferResets.InferResetsException] shouldBe thrownBy {
       compile(s"""
         |circuit top :
         |  module top :
@@ -184,7 +184,7 @@ class InferResetsSpec extends FirrtlFlatSpec {
   }
 
   it should "not allow different Reset Types to drive a single Reset" in {
-    an [InferResets.DifferingDriverTypesException] shouldBe thrownBy {
+    an [InferResets.InferResetsException] shouldBe thrownBy {
       val result = compile(s"""
         |circuit top :
         |  module top :


### PR DESCRIPTION
**TLDR**
* Reverts support for last connect semantics in reset inference (reverts https://github.com/freechipsproject/firrtl/pull/1291, note this was never released)
* Makes reset inference a forward and backward propagation
    * This mainly catches user error in InferResets instead of CheckTypes and can change the type of wires or ports that are **only** invalidated but drive stuff (not necessarily the winning connection though). Note that this case crashes in `1.2.2`.
* Fixes bugs
    * Handling of invalidation on components of type `Reset`
    * Connections or invalidation of submodule ports could override everything done inside the module itself
    * Support AsyncResetType in RemoveValidIfs
* This is orthogonal from possible improvements to the feature like https://github.com/freechipsproject/firrtl/issues/1376. This makes the `1.2.x` branch work in a reasonable way.

**Note** this looks big, but the positive line change is almost entirely new tests

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
- new feature/API

### API Impact

This modifies the reset inference API. It reverts support for last connect semantics in inference. This made it to `1.2.x`, but has not yet been released.

This also fixes many bugs present in the current latest release `1.2.2`, especially with regards to invalidation and inference. It does make a change from `1.2.2`, namely that invalidated components that drive another component that itself is driven by something else may get a different type. **While this may seem like cause for concern, as far as I can tell, every case of this crashes on v1.2.2**; not to mention that such components are only invalidated so their types don't really have much impact on anything.

I think the best way to understand this PR is with the new tests:

1. 
```scala
  it should "infer based on what a component *drives* not just what drives it" in {
    val result = compile(s"""
      |circuit top :
      |  module top :
      |    input in : AsyncReset
      |    output out : Reset
      |    wire w : Reset
      |    w is invalid
      |    out <= w
      |    out <= in
      |""".stripMargin)
    result should containTree { case DefWire(_, "w", AsyncResetType) => true }
  }
```
This first one above is the "API change" that technically would differ from `1.2.2`, but it crashes in `1.2.2`. My argument is that it's not an API that means anything because it only matters in the context of components that are **only ever invalidated**, thus the reset should be optimized away anyway, and if optimizations are disabled, the flop will never be reset.

2.
```scala
  it should "infer from connections, ignoring \"winning\" invalidation" in {
    val result = compile(s"""
      |circuit top :
      |  module top :
      |    input in : AsyncReset
      |    output out : Reset
      |    out <= in
      |    out is invalid
      |""".stripMargin)
    result should containTree { case Port(_, "out", Output, AsyncResetType) => true }
  }
```
With the unreleased last connect semantics, `out` would be a `UInt<1>` instead of `AsyncReset`. Note that as above, it is invalidated so it doesn't do anything. Also note that this crashes in `1.2.2`.

3. 
```scala
  // The backwards type propagation constrains `w` to be the same as both `out0` and `out1`
  it should "not allow an invalidated Wire to drive both a UInt<1> and an AsyncReset" in {
    an [InferResets.InferResetsException] shouldBe thrownBy {
      val result = compile(s"""
        |circuit top :
        |  module top :
        |    input in0 : AsyncReset
        |    input in1 : UInt<1>
        |    output out0 : Reset
        |    output out1 : Reset
        |    wire w : Reset
        |    w is invalid
        |    out0 <= w
        |    out1 <= w
        |    out0 <= in0
        |    out1 <= in1
        |""".stripMargin
      )
    }
  }
```
This also crashes on `v1.2.2`. It would be legal if last connect semantics were accepted, but due to backwards type inference introduced in this PR, `w` is not allowed to drive both a `UInt<1>` and an `AsyncReset`.

4. 

```scala
  // This tests for a bug unrelated to support or lackthereof for last connect in inference
  it should "take into account both internal and external constraints on Module port types" in {
    val result = compile(s"""
      |circuit top :
      |  module child :
      |    input i : AsyncReset
      |    output o : Reset
      |    o <= i
      |  module top :
      |    input in : AsyncReset
      |    output out : AsyncReset
      |    inst c of child
      |    c.o is invalid
      |    c.i <= in
      |    out <= c.o
      |""".stripMargin)
    result should containTree { case Port(_, "o", Output, AsyncResetType) => true }
  }
```
Unrelated bugfix that can lead to very strange behavior.

5.

```scala
  it should "not crash on combinational loops" in {
    an [CheckCombLoops.CombLoopException] shouldBe thrownBy {
      val result = compile(s"""
        |circuit top :
        |  module top :
        |    input in : AsyncReset
        |    output out : Reset
        |    wire w0 : Reset
        |    wire w1 : Reset
        |    w0 <= in
        |    w0 <= w1
        |    w1 <= w0
        |    out <= in
        |""".stripMargin,
        compiler = new LowFirrtlCompiler
      )
    }
  }
```
This crashes on `1.2.2` and `1.2.x` alike.

### Backend Code Generation Impact

It could change the types of some registers, but only if the reset signal **is invalid**.

### Desired Merge Strategy

- Squash: The PR will be squashed and merged

The history is ugly but I want it on the PR to keep some context. This should be squashed so that it doesn't show up in the actual git history.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you mark as `Please Merge`?
