### PR TITLE
sbt compatible publish for mill

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -122,4 +122,6 @@ class firrtlCrossModule(crossVersion: String) extends ScalaModule with SbtModule
       Developer("jackbackrack", "Jonathan Bachrach", "https://eecs.berkeley.edu/~jrb/")
     )
   )
+  // make mill publish sbt compatible package
+  def artifactName = "firrtl"
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement
- bug fix

### API Impact
None
### Backend Code Generation Impact
None
### Desired Merge Strategy

- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you mark as `Please Merge`?

Currently `mill` will only publish in `~/.ivy2/local/edu.berkeley.cs/firrtl-2.12.10_2.12/1.3-SNAPSHOT/`, which is non-compatible to sbt build.
This patch will overwrite `artifactName` from `firrtl-$crossVersion_$artifactScalaVersion` to `firrtl-$artifactScalaVersion`, giving the same directory with sbt.
