### PR TITLE
add testOnly

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -64,6 +64,12 @@ class firrtlCrossModule(crossVersion: String) extends ScalaModule with SbtModule
     ) ++ ivyCrossDeps
 
     def testFrameworks = Seq("org.scalatest.tools.Framework")
+
+    // a sbt-like testOnly command.
+    // for example, mill -i "firrtl[2.12.10].test.testOnly" "firrtlTests.AsyncResetSpec"
+    def testOnly(args: String*) = T.command {
+      super.runMain("org.scalatest.run", args: _*)
+    }
   }
 
   override def generatedSources = T {


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
   - new feature/API

### API Impact
Sorry, it's me again, this PR adds a `testOnly` command to run a single test like sbt did. Mill didn't support it out-of-box.

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

### Backend Code Generation Impact
None
<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you mark as `Please Merge`?
