### PR TITLE
Remove RenameMap logging from EliminateTargetPaths

### DIFF
--- a/src/main/scala/firrtl/annotations/transforms/EliminateTargetPaths.scala
+++ b/src/main/scala/firrtl/annotations/transforms/EliminateTargetPaths.scala
@@ -171,9 +171,6 @@ class EliminateTargetPaths extends Transform {
       newCircuit.copy(modules = modulesx)
     }
 
-    logger.info("Renames:")
-    logger.info(renameMap.serialize)
-
     state.copy(circuit = newCircuitGC, renames = Some(renameMap), annotations = annotationsx)
   }
 }


### PR DESCRIPTION
I don't have a problem with logging the RenameMap, but it probably shouldn't be at the `info` level (since that's commonly used to see transform printing) and if we want it it should be done for every transform (not just `EliminateTargetPaths`

This was probably used for debugging https://github.com/freechipsproject/firrtl/pull/1394 during development?

### Contributor Checklist

- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement
 - code cleanup


### API Impact

None

### Backend Code Generation Impact

None

### Desired Merge Strategy

- Squash

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [x] Did you review?
- [x] Did you mark as `Please Merge`?
