### PR TITLE
Fix error message for NegWidthException

### DIFF
--- a/src/main/scala/firrtl/passes/Checks.scala
+++ b/src/main/scala/firrtl/passes/Checks.scala
@@ -39,7 +39,7 @@ trait CheckHighFormLike {
   class IncorrectNumConstsException(info: Info, mname: String, op: String, n: Int) extends PassException(
     s"$info: [module $mname] Primop $op requires $n integer arguments.")
   class NegWidthException(info: Info, mname: String) extends PassException(
-    s"$info: [module $mname] Width cannot be negative or zero.")
+    s"$info: [module $mname] Width cannot be negative.")
   class NegVecSizeException(info: Info, mname: String) extends PassException(
     s"$info: [module $mname] Vector type size cannot be negative.")
   class NegMemSizeException(info: Info, mname: String) extends PassException(


### PR DESCRIPTION
Type of change: better error message
API impact: none

The `NegWidthException` is only thrown for negative widths, but the message incorrectly implies that zero-width wires are illegal.