### PR TITLE
Support Java API doc Scaladoc/Unidoc References

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -136,6 +136,18 @@ lazy val publishSettings = Seq(
 lazy val docSettings = Seq(
   doc in Compile := (doc in ScalaUnidoc).value,
   autoAPIMappings := true,
+  apiMappings ++= {
+    Option(System.getProperty("sun.boot.class.path")).flatMap { classPath =>
+      classPath.split(java.io.File.pathSeparator).find(_.endsWith(java.io.File.separator + "rt.jar"))
+    }.map { jarPath =>
+      Map(
+        file(jarPath) -> url("https://docs.oracle.com/javase/8/docs/api")
+      )
+    }.getOrElse {
+      streams.value.log.warn("Failed to add bootstrap class path of Java to apiMappings")
+      Map.empty[File,URL]
+    }
+  },
   scalacOptions in Compile in doc ++= Seq(
     "-diagrams",
     "-diagrams-max-classes", "25",

--- a/src/main/scala/firrtl/options/Exceptions.scala
+++ b/src/main/scala/firrtl/options/Exceptions.scala
@@ -11,6 +11,8 @@ class PhaseException(val message: String, cause: Throwable = null) extends Runti
 /** Indicate an error related to a bad [[firrtl.annotations.Annotation Annotation]] or it's command line option
   * equivalent. This exception is always caught and converted to an error message by a [[Stage]]. Do not use this for
   * communicating generic exception information.
+  * @param message exception message [[scala.Predef.String String]]
+  * @param cause the reason for this exception (a Java [[java.lang.Throwable Throwable]])
   */
 class OptionsException(val message: String, cause: Throwable = null) extends IllegalArgumentException(message, cause)
 


### PR DESCRIPTION
This enables automatic Scaladoc linking to Java API docs using the same strategy that Scala upstream uses.

Linking to Scala API documentation already works.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
- documentation
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

None.

### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you mark as `Please Merge`?
