### PR TITLE
Clone Verilator from GitHub, fix tag name

### DIFF
--- a/.install_verilator.sh
+++ b/.install_verilator.sh
@@ -2,11 +2,11 @@ set -e
 # Install Verilator (http://www.veripool.org/projects/verilator/wiki/Installing)
 if [ ! -f $INSTALL_DIR/bin/verilator ]; then 
   mkdir -p $INSTALL_DIR
-  git clone http://git.veripool.org/git/verilator
+  git clone https://github.com/verilator/verilator.git
   unset VERILATOR_ROOT
   cd verilator
   git pull
-  git checkout verilator_3_922
+  git checkout v3.922
   autoconf
   ./configure --prefix=$INSTALL_DIR
   make


### PR DESCRIPTION
The Verilator tag name changed... I also updated this to use GitHub as opposed to the old veripool git.

This is why some PRs seem to be failing, e.g., https://travis-ci.org/freechipsproject/firrtl/jobs/658792157?utm_medium=notification&utm_source=github_status.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

None.

### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you mark as `Please Merge`?
