### PR TITLE
Make mergify open backport PRs & signal on failed cherry-picks

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -29,6 +29,7 @@ pull_request_rules:
       backport:
         branches:
           - 1.2.x
+        ignore_conflicts: True
       label:
         add: [Backported]
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -14,6 +14,7 @@ pull_request_rules:
       - base=master
       - label="Please Merge"
       - label!="DO NOT MERGE"
+      - label!="bp-conflict"
     actions:
       merge:
         method: squash
@@ -30,6 +31,7 @@ pull_request_rules:
         branches:
           - 1.2.x
         ignore_conflicts: True
+        label_conflicts: "bp-conflict"
       label:
         add: [Backported]
 
@@ -48,6 +50,7 @@ pull_request_rules:
       - base=1.2.x
       - label="Backport"
       - label!="DO NOT MERGE"
+      - label!="bp-conflict"
     actions:
       merge:
         method: squash


### PR DESCRIPTION
@jackkoenig @ucbjrl, this is why we didn't see a backports for #1421 (and possibly others).

Mergify added a new option that now makes it optional to open backport PRs when there are cherry-pick conflicts. It is false by default, which means anything that doesn't cleanly cherry-pick gets dropped by default.

By setting this to `True`, we should get a nice PR that tells us it fails like this [example in a plain link that hopefully doesn't become a GitHub "mention" and troll the owners of that repo (but honestly, who knows what magic GitHub does with anything these days).](https://github.com/Mailu/Mailu/pull/932)

Relevant mergify-engine PR from the last couple weeks: Mergifyio/mergify-engine#741