### PR TITLE
Check sign of primop constants where appropriate (bp #1421)

### DIFF
--- a/src/test/scala/firrtlTests/CheckSpec.scala
+++ b/src/test/scala/firrtlTests/CheckSpec.scala
@@ -267,7 +267,7 @@ class CheckSpec extends FlatSpec with Matchers {
     }
   }
 
-  for (op <- List("shl", "shr")) {
+  for (op <- List("shl", "shr", "pad", "head", "tail", "bpshl", "bpshr")) {
     s"$op by negative amount" should "result in an error" in {
       val amount = -1
       val input =
@@ -283,16 +283,19 @@ class CheckSpec extends FlatSpec with Matchers {
     }
   }
 
-  "LSB larger than MSB in bits" should "throw an exception" in {
-    val input =
-      """|circuit bar :
-         |  module bar :
-         |    input in : UInt<8>
-         |    output foo : UInt
-         |    foo <= bits(in, 3, 4)
-         |      """.stripMargin
-    val exception = intercept[PassException] {
-      checkHighInput(input)
+  // Check negative bits constant, too
+  for (args <- List((3, 4), (0, -1))) {
+    val opExp = s"bits(in, ${args._1}, ${args._2})"
+    s"Illegal bit extract ${opExp}" should "throw an exception" in {
+      val input =
+        s"""|circuit bar :
+            |  module bar :
+            |    input in : UInt<8>
+            |    output foo : UInt
+            |    foo <= ${opExp}""".stripMargin
+      val exception = intercept[PassException] {
+        checkHighInput(input)
+      }
     }
   }
 


### PR DESCRIPTION
* Backport #1421 to 1.2.x (BPSh_ instead if IncP/DecP)

* Avoid IndexOutOfBoundsException when Bits has too few consts

* Check for negative consts in all relevant primops

* Use BigInt for all checks on primop constants
