### PR TITLE
Provide an annotation mix-in that marks RTs as dontTouch

### DIFF
--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -690,8 +690,12 @@ class ConstantPropagation extends Transform with ResolvedAnnotationPaths {
   }
 
   def execute(state: CircuitState): CircuitState = {
-    val dontTouches: Seq[(OfModule, String)] = state.annotations.collect {
-      case DontTouchAnnotation(Target(_, Some(m), Seq(Ref(c)))) => m.OfModule -> c
+    val dontTouchRTs = state.annotations.flatMap {
+      case anno: HasDontTouches => anno.dontTouches
+      case o => Nil
+    }
+    val dontTouches: Seq[(OfModule, String)] = dontTouchRTs.map {
+      case Target(_, Some(m), Seq(Ref(c))) => m.OfModule -> c
     }
     // Map from module name to component names
     val dontTouchMap: Map[OfModule, Set[String]] =

--- a/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
+++ b/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
@@ -337,8 +337,9 @@ class DeadCodeElimination extends Transform with ResolvedAnnotationPaths with Re
     Seq(classOf[DontTouchAnnotation], classOf[OptimizableExtModuleAnnotation])
 
   def execute(state: CircuitState): CircuitState = {
-    val dontTouches: Seq[LogicNode] = state.annotations.collect {
-      case DontTouchAnnotation(component: ReferenceTarget) if component.isLocal => LogicNode(component)
+    val dontTouches: Seq[LogicNode] = state.annotations.flatMap {
+      case anno: HasDontTouches => anno.dontTouches.filter(_.isLocal).map(LogicNode(_))
+      case o => Nil
     }
     val doTouchExtMods: Seq[String] = state.annotations.collect {
       case OptimizableExtModuleAnnotation(ModuleName(name, _)) => name

--- a/src/main/scala/firrtl/transforms/OptimizationAnnotations.scala
+++ b/src/main/scala/firrtl/transforms/OptimizationAnnotations.scala
@@ -10,7 +10,7 @@ case object NoDCEAnnotation extends NoTargetAnnotation
 
 /** Lets an annotation mark its ReferenceTarget members as DontTouch
   *
-  * This permits a transform to run and remove it's associated annotations,
+  * This permits a transform to run and remove its associated annotations,
   * thus making their ReferenceTargets new candidates for optimization. This
   * removes the need for the pass writer to reason about pre-existing
   * DontTouchAnnotations that may touch the same node.

--- a/src/main/scala/firrtl/transforms/OptimizationAnnotations.scala
+++ b/src/main/scala/firrtl/transforms/OptimizationAnnotations.scala
@@ -50,8 +50,6 @@ object DontTouchAnnotation {
     throw new DontTouchNotFoundException(module, component)
 }
 
-
-
 /** An [[firrtl.ir.ExtModule]] that can be optimized
   *
   * Firrtl does not know the semantics of an external module. This annotation provides some

--- a/src/main/scala/firrtl/transforms/OptimizationAnnotations.scala
+++ b/src/main/scala/firrtl/transforms/OptimizationAnnotations.scala
@@ -8,11 +8,33 @@ import firrtl.passes.PassException
 /** Indicate that DCE should not be run */
 case object NoDCEAnnotation extends NoTargetAnnotation
 
+/** Lets an annotation mark its ReferenceTarget members as DontTouch
+  *
+  * This permits a transform to run and remove it's associated annotations,
+  * thus making their ReferenceTargets new candidates for optimization. This
+  * removes the need for the pass writer to reason about pre-existing
+  * DontTouchAnnotations that may touch the same node.
+  */
+trait HasDontTouches { self: Annotation =>
+  def dontTouches: Iterable[ReferenceTarget]
+}
+
+/**
+  * A globalized form of HasDontTouches which applies to all ReferenceTargets
+  * provided with the annotation
+  */
+trait DontTouchAllTargets extends HasDontTouches { self: Annotation =>
+  def dontTouches(): Iterable[ReferenceTarget] = getTargets.collect {
+    case rT: ReferenceTarget => rT
+  }
+}
+
 /** A component that should be preserved
   *
   * DCE treats the component as a top-level sink of the circuit
   */
-case class DontTouchAnnotation(target: ReferenceTarget) extends SingleTargetAnnotation[ReferenceTarget] {
+case class DontTouchAnnotation(target: ReferenceTarget)
+    extends SingleTargetAnnotation[ReferenceTarget] with DontTouchAllTargets {
   def targets = Seq(target)
   def duplicate(n: ReferenceTarget) = this.copy(n)
 }
@@ -27,6 +49,8 @@ object DontTouchAnnotation {
   def errorNotFound(module: String, component: String) =
     throw new DontTouchNotFoundException(module, component)
 }
+
+
 
 /** An [[firrtl.ir.ExtModule]] that can be optimized
   *

--- a/src/main/scala/firrtl/transforms/OptimizationAnnotations.scala
+++ b/src/main/scala/firrtl/transforms/OptimizationAnnotations.scala
@@ -24,7 +24,7 @@ trait HasDontTouches { self: Annotation =>
   * provided with the annotation
   */
 trait DontTouchAllTargets extends HasDontTouches { self: Annotation =>
-  def dontTouches(): Iterable[ReferenceTarget] = getTargets.collect {
+  def dontTouches: Iterable[ReferenceTarget] = getTargets.collect {
     case rT: ReferenceTarget => rT
   }
 }

--- a/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+++ b/src/test/scala/firrtlTests/ConstantPropagationTests.scala
@@ -792,7 +792,20 @@ class ConstantPropagationIntegrationSpec extends LowTransformSpec {
     execute(input, check, Seq(dontTouch("Top.z")))
   }
 
-  "ConstProp" should "NOT optimize across dontTouch on registers" in {
+  it should "NOT optimize across nodes marked dontTouch by other annotations" in {
+      val input =
+        """circuit Top :
+          |  module Top :
+          |    input x : UInt<1>
+          |    output y : UInt<1>
+          |    node z = x
+          |    y <= z""".stripMargin
+      val check = input
+      val dontTouchRT = annotations.ModuleTarget("Top", "Top").ref("z")
+    execute(input, check, Seq(AnnotationWithDontTouches(dontTouchRT)))
+  }
+
+  it should "NOT optimize across dontTouch on registers" in {
       val input =
         """circuit Top :
           |  module Top :

--- a/src/test/scala/firrtlTests/DCETests.scala
+++ b/src/test/scala/firrtlTests/DCETests.scala
@@ -15,7 +15,7 @@ case class AnnotationWithDontTouches(target: ReferenceTarget)
     extends SingleTargetAnnotation[ReferenceTarget] with HasDontTouches {
   def targets = Seq(target)
   def duplicate(n: ReferenceTarget) = this.copy(n)
-  def dontTouches(): Seq[ReferenceTarget] = targets
+  def dontTouches: Seq[ReferenceTarget] = targets
 }
 
 class DCETests extends FirrtlFlatSpec {

--- a/src/test/scala/firrtlTests/DCETests.scala
+++ b/src/test/scala/firrtlTests/DCETests.scala
@@ -11,6 +11,13 @@ import firrtl.passes.memlib.SimpleTransform
 import java.io.File
 import java.nio.file.Paths
 
+case class AnnotationWithDontTouches(target: ReferenceTarget)
+    extends SingleTargetAnnotation[ReferenceTarget] with HasDontTouches {
+  def targets = Seq(target)
+  def duplicate(n: ReferenceTarget) = this.copy(n)
+  def dontTouches(): Seq[ReferenceTarget] = targets
+}
+
 class DCETests extends FirrtlFlatSpec {
   // Not using executeTest because it is for positive testing, we need to check that stuff got
   // deleted
@@ -62,6 +69,24 @@ class DCETests extends FirrtlFlatSpec {
         |    node a = x
         |    z <= x""".stripMargin
     exec(input, check, Seq(dontTouch("Top.a")))
+  }
+  "Unread wire marked dont touch by another annotation" should "NOT be deleted" in {
+    val input =
+      """circuit Top :
+        |  module Top :
+        |    input x : UInt<1>
+        |    output z : UInt<1>
+        |    wire a : UInt<1>
+        |    z <= x
+        |    a <= x""".stripMargin
+    val check =
+      """circuit Top :
+        |  module Top :
+        |    input x : UInt<1>
+        |    output z : UInt<1>
+        |    node a = x
+        |    z <= x""".stripMargin
+    exec(input, check, Seq(AnnotationWithDontTouches(ModuleTarget("Top", "Top").ref("a"))))
   }
   "Unread register" should "be deleted" in {
     val input =


### PR DESCRIPTION
In Golden Gate & FireSim we have a bunch of passes that run conditionally to do things like synthesize debug primitives or event counters. In chisel elaboration, we preemptively mark these nodes as DontTouch even though these synthesis passes may not be run, precluding potential optimizations. 

This PR adds a small trait hierarchy that lets an annotation mark its RTs as DontTouch, so that the Annotation can be easily removed by it's associated Transform later.  This presents new optimization opportunities to the downstream compiler, without having to reason about separate DontTouchAnnotations that may already be present on the same targets. 

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement
- new feature/API

### API Impact

- API expanding.

### Backend Code Generation Impact

- No changes to existing verilog. 

### Desired Merge Strategy

- Squash: The PR will be squashed and merged

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you mark as `Please Merge`?
