### PR TITLE
Check for name collisions of Modules

### DIFF
--- a/src/main/scala/firrtl/passes/Checks.scala
+++ b/src/main/scala/firrtl/passes/Checks.scala
@@ -35,6 +35,8 @@ trait CheckHighFormLike { this: Pass =>
     s"$info: [module $mname] Invalid access to non-reference.")
   class ModuleNameNotUniqueException(info: Info, mname: String) extends PassException(
     s"$info: Repeat definition of module $mname")
+  class DefnameConflictException(info: Info, mname: String, defname: String) extends PassException(
+    s"$info: defname $defname of extmodule $mname conflicts with an existing module")
   class ModuleNotDefinedException(info: Info, mname: String, name: String) extends PassException(
     s"$info: Module $name is not defined.")
   class IncorrectNumArgsException(info: Info, mname: String, op: String, n: Int) extends PassException(
@@ -75,8 +77,15 @@ trait CheckHighFormLike { this: Pass =>
     val moduleGraph = new ModuleGraph
     val moduleNames = (c.modules map (_.name)).toSet
 
+    val intModuleNames = c.modules.view.collect({ case m: Module => m.name }).toSet
+
     c.modules.view.groupBy(_.name).filter(_._2.length > 1).flatMap(_._2).foreach {
       m => errors.append(new ModuleNameNotUniqueException(m.info, m.name))
+    }
+
+    c.modules.collect {
+      case ExtModule(info, name, _, defname, _) if (intModuleNames.contains(defname)) =>
+        errors.append(new DefnameConflictException(info, name, defname))
     }
 
     def checkHighFormPrimop(info: Info, mname: String, e: DoPrim): Unit = {

--- a/src/test/scala/firrtlTests/CheckSpec.scala
+++ b/src/test/scala/firrtlTests/CheckSpec.scala
@@ -333,6 +333,23 @@ class CheckSpec extends FlatSpec with Matchers {
     }
   }
 
+  s"Defnames that conflict with pure-FIRRTL module names" should "throw an exception" in {
+    val input =
+      s"""|circuit bar :
+          |  module bar :
+          |    input i : UInt<8>
+          |    output o : UInt<8>
+          |    o <= i
+          |  extmodule dup :
+          |    input i : UInt<8>
+          |    output o : UInt<8>
+          |    defname = bar
+          |""".stripMargin
+    assertThrows[CheckHighForm.DefnameConflictException] {
+      checkHighInput(input)
+    }
+  }
+
 }
 
 object CheckSpec {

--- a/src/test/scala/firrtlTests/CheckSpec.scala
+++ b/src/test/scala/firrtlTests/CheckSpec.scala
@@ -307,6 +307,32 @@ class CheckSpec extends FlatSpec with Matchers {
       }
     }
   }
+
+  s"Duplicate module names" should "throw an exception" in {
+    val input =
+      s"""|circuit bar :
+          |  module bar :
+          |    input i : UInt<8>
+          |    output o : UInt<8>
+          |    o <= i
+          |  module dup :
+          |    input i : UInt<8>
+          |    output o : UInt<8>
+          |    o <= i
+          |  module dup :
+          |    input i : UInt<8>
+          |    output o : UInt<8>
+          |    o <= not(i)
+          |""".stripMargin
+    assertThrows[CheckHighForm.ModuleNameNotUniqueException] {
+      try {
+        checkHighInput(input)
+      } catch {
+        case e: firrtl.passes.PassExceptions => throw e.exceptions.head
+      }
+    }
+  }
+
 }
 
 object CheckSpec {


### PR DESCRIPTION
Currently, there is no checking of whether module names collide (see #1436). There is also no checking of whether `ExtModule` `defname`s collide with pure-FIRRTL module names (see #1096).

**Type of improvement:** bugfix
**API impact:** none
**Backend code generation impact:** avoids generating some illegal code and some code that randomly chooses from among aliased modules
**Desired merge strategy:** merge commit

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you mark as `Please Merge`?
