### PR TITLE
[mergify] Update match string for labeling backported PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -38,7 +38,7 @@ pull_request_rules:
   - name: label Mergify backport PR
     conditions:
       - base=1.2.x
-      - body~=This is an automated backport of pull request \#\d+ done by Mergify.io
+      - body~=This is an automated backport of pull request \#\d+ done by Mergify
     actions:
       label:
         add: [Backport]


### PR DESCRIPTION
More in the quest to make the backport flow work again. The body of backport PR messages got changed in Mergifyio/mergify-engine#768, so I updated the match string to work again.

This fixes the cause of #1438 not getting the "Backport" label.