### PR TITLE
fix transform Inline Nots

### DIFF
--- a/src/main/scala/firrtl/AddDescriptionNodes.scala
+++ b/src/main/scala/firrtl/AddDescriptionNodes.scala
@@ -79,6 +79,7 @@ class AddDescriptionNodes extends Transform with PreservesAll[Transform] {
          Dependency[firrtl.transforms.InlineBitExtractionsTransform],
          Dependency[firrtl.transforms.PropagatePresetAnnotations],
          Dependency[firrtl.transforms.InlineCastsTransform],
+         Dependency[firrtl.transforms.InlineNotsTransform],
          Dependency[firrtl.transforms.LegalizeClocksTransform],
          Dependency[firrtl.transforms.FlattenRegUpdate],
          Dependency(passes.VerilogModulusCleanup),

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -241,10 +241,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
         if (e.tpe == AsyncResetType) {
           throw EmitterException("Cannot emit async reset muxes directly")
         }
-        e.cond match {
-          case DoPrim(Not, Seq(sel), _,_) => emit(Seq(sel," ? ",cast(e.fval)," : ",cast(e.tval)),top + 1)
-          case _ => emit(Seq(e.cond," ? ",cast(e.tval)," : ",cast(e.fval)),top + 1)
-        }
+        emit(Seq(e.cond," ? ",cast(e.tval)," : ",cast(e.fval)),top + 1)
       }
       case (e: ValidIf) => emit(Seq(cast(e.value)),top + 1)
       case (e: WRef) => w write e.serialize

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -241,7 +241,10 @@ class VerilogEmitter extends SeqTransform with Emitter {
         if (e.tpe == AsyncResetType) {
           throw EmitterException("Cannot emit async reset muxes directly")
         }
-        emit(Seq(e.cond," ? ",cast(e.tval)," : ",cast(e.fval)),top + 1)
+        e.cond match {
+          case DoPrim(Not, Seq(sel), _,_) => emit(Seq(sel," ? ",cast(e.fval)," : ",cast(e.tval)),top + 1)
+          case _ => emit(Seq(e.cond," ? ",cast(e.tval)," : ",cast(e.fval)),top + 1)
+        }
       }
       case (e: ValidIf) => emit(Seq(cast(e.value)),top + 1)
       case (e: WRef) => w write e.serialize

--- a/src/main/scala/firrtl/passes/Passes.scala
+++ b/src/main/scala/firrtl/passes/Passes.scala
@@ -287,6 +287,7 @@ object VerilogPrep extends Pass with PreservesAll[Transform] {
          Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
          Dependency[firrtl.transforms.InlineBitExtractionsTransform],
          Dependency[firrtl.transforms.InlineCastsTransform],
+         Dependency[firrtl.transforms.InlineNotsTransform],
          Dependency[firrtl.transforms.LegalizeClocksTransform],
          Dependency[firrtl.transforms.FlattenRegUpdate],
          Dependency(passes.VerilogModulusCleanup),

--- a/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
+++ b/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
@@ -32,6 +32,7 @@ object VerilogModulusCleanup extends Pass with PreservesAll[Transform] {
          Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
          Dependency[firrtl.transforms.InlineBitExtractionsTransform],
          Dependency[firrtl.transforms.InlineCastsTransform],
+         Dependency[firrtl.transforms.InlineNotsTransform],
          Dependency[firrtl.transforms.LegalizeClocksTransform],
          Dependency[firrtl.transforms.FlattenRegUpdate] )
 

--- a/src/main/scala/firrtl/stage/Forms.scala
+++ b/src/main/scala/firrtl/stage/Forms.scala
@@ -82,6 +82,7 @@ object Forms {
          Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
          Dependency[firrtl.transforms.InlineBitExtractionsTransform],
          Dependency[firrtl.transforms.InlineCastsTransform],
+         Dependency[firrtl.transforms.InlineNotsTransform],
          Dependency[firrtl.transforms.LegalizeClocksTransform],
          Dependency[firrtl.transforms.FlattenRegUpdate],
          Dependency(passes.VerilogModulusCleanup),

--- a/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
+++ b/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
@@ -115,6 +115,7 @@ class FlattenRegUpdate extends Transform {
          Dependency[ReplaceTruncatingArithmetic],
          Dependency[InlineBitExtractionsTransform],
          Dependency[InlineCastsTransform],
+         Dependency[InlineNotsTransform],
          Dependency[LegalizeClocksTransform] )
 
   override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized

--- a/src/main/scala/firrtl/transforms/InlineBitExtractions.scala
+++ b/src/main/scala/firrtl/transforms/InlineBitExtractions.scala
@@ -99,7 +99,8 @@ class InlineBitExtractionsTransform extends Transform with PreservesAll[Transfor
   override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
     Seq( Dependency[BlackBoxSourceHelper],
          Dependency[FixAddingNegativeLiterals],
-         Dependency[ReplaceTruncatingArithmetic] )
+         Dependency[ReplaceTruncatingArithmetic],
+         Dependency[InlineNotsTransform] )  // after InlineNots to clean up not(not(...)) rename
 
   override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 

--- a/src/main/scala/firrtl/transforms/InlineNots.scala
+++ b/src/main/scala/firrtl/transforms/InlineNots.scala
@@ -1,0 +1,102 @@
+package firrtl
+package transforms
+
+import firrtl.ir._
+import firrtl.Mappers._
+import firrtl.options.{Dependency, PreservesAll}
+import firrtl.PrimOps.{Bits, Not}
+import firrtl.Utils.{isBitExtract, isTemp}
+import firrtl.WrappedExpression._
+
+import scala.collection.mutable
+
+object InlineNotsTransform {
+
+  /** Returns true if Expression is a Not PrimOp, false otherwise */
+  private def isNot(expr: Expression): Boolean = expr match {
+    case DoPrim(Not, args,_,_) => args.forall(isSimpleExpr)
+    case _ => false
+  }
+
+  // Checks if an Expression is made up of only Nots terminated by a Literal or Reference.
+  // private because it's not clear if this definition of "Simple Expression" would be useful elsewhere.
+  // Note that this can have false negatives but MUST NOT have false positives.
+  private def isSimpleExpr(expr: Expression): Boolean = expr match {
+    case _: WRef | _: Literal | _: WSubField => true
+    case DoPrim(Not, args, _,_) => args.forall(isSimpleExpr)
+    case _ => false
+  }
+
+  /** Mapping from references to the [[firrtl.ir.Expression Expression]]s that drive them */
+  type Netlist = mutable.HashMap[WrappedExpression, Expression]
+
+  /** Recursively replace [[WRef]]s with new [[Expression]]s
+    *
+    * @param netlist a '''mutable''' HashMap mapping references to [[firrtl.ir.DefNode DefNode]]s to their connected
+    * [[firrtl.ir.Expression Expression]]s. It is '''not''' mutated in this function
+    * @param expr the Expression being transformed
+    * @return Returns expr with Nots inlined
+    */
+  def onExpr(netlist: Netlist)(expr: Expression): Expression = {
+    expr.map(onExpr(netlist)) match {
+      case e @ WRef(name, _,_,_) =>
+        netlist.get(we(e))
+               .filter(isNot)
+               .getOrElse(e)
+      // replace bits-of-not with not-of-bits to enable later bit extraction transform
+      case lhs @ DoPrim(op, Seq(lval), lcons, ltpe) if isBitExtract(op) && isSimpleExpr(lval) =>
+        netlist.getOrElse(we(lval), lval) match {
+          case DoPrim(Not, Seq(rhs), rcons, rtpe) =>
+            DoPrim(Not, Seq(DoPrim(op, Seq(rhs), lcons, ltpe)), rcons, ltpe)
+          case _ => lhs  // Not a candiate
+        }
+      // replace back-to-back inversions with a straight rename
+      case lhs @ DoPrim(Not, Seq(inv), _, invtpe) if isSimpleExpr(lhs) && isSimpleExpr(inv) && (lhs.tpe == invtpe) && (bitWidth(lhs.tpe) == bitWidth(inv.tpe)) =>
+        netlist.getOrElse(we(inv), inv) match {
+          case DoPrim(Not, Seq(rhs), _, rtpe) if (invtpe == rtpe) && (bitWidth(inv.tpe) == bitWidth(rhs.tpe)) =>
+            DoPrim(Bits, Seq(rhs), Seq(bitWidth(lhs.tpe)-1,0), rtpe)
+          case _ => lhs  // Not a candiate
+        }
+      case other => other // Not a candidate
+    }
+  }
+
+  /** Inline nots in a Statement
+    *
+    * @param netlist a '''mutable''' HashMap mapping references to [[firrtl.ir.DefNode DefNode]]s to their connected
+    * [[firrtl.ir.Expression Expression]]s. This function '''will''' mutate it if stmt is a [[firrtl.ir.DefNode
+    * DefNode]] with a Temporary name and a value that is a [[PrimOp]] Not
+    * @param stmt the Statement being searched for nodes and transformed
+    * @return Returns stmt with nots inlined
+    */
+  def onStmt(netlist: Netlist)(stmt: Statement): Statement =
+    stmt.map(onStmt(netlist)).map(onExpr(netlist)) match {
+      case node @ DefNode(_, name, value) if isTemp(name) =>
+        netlist(we(WRef(name))) = value
+        node
+      case other => other
+    }
+
+  /** Inline nots in a Module */
+  def onMod(mod: DefModule): DefModule = mod.map(onStmt(new Netlist))
+}
+
+/** Inline nodes that are simple nots */
+class InlineNotsTransform extends Transform with PreservesAll[Transform] {
+  def inputForm = UnknownForm
+  def outputForm = UnknownForm
+
+  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
+    Seq( Dependency[BlackBoxSourceHelper],
+         Dependency[FixAddingNegativeLiterals],
+         Dependency[ReplaceTruncatingArithmetic] )
+
+  override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
+
+  override val dependents = Seq.empty
+
+  def execute(state: CircuitState): CircuitState = {
+    val modulesx = state.circuit.modules.map(InlineNotsTransform.onMod(_))
+    state.copy(circuit = state.circuit.copy(modules = modulesx))
+  }
+}

--- a/src/main/scala/firrtl/transforms/LegalizeClocks.scala
+++ b/src/main/scala/firrtl/transforms/LegalizeClocks.scala
@@ -68,7 +68,8 @@ class LegalizeClocksTransform extends Transform with PreservesAll[Transform] {
          Dependency[FixAddingNegativeLiterals],
          Dependency[ReplaceTruncatingArithmetic],
          Dependency[InlineBitExtractionsTransform],
-         Dependency[InlineCastsTransform] )
+         Dependency[InlineCastsTransform],
+         Dependency[InlineNotsTransform] )
 
   override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 

--- a/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
+++ b/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
@@ -241,6 +241,7 @@ class VerilogRename extends RemoveKeywordCollisions(v_keywords) with PreservesAl
          Dependency[ReplaceTruncatingArithmetic],
          Dependency[InlineBitExtractionsTransform],
          Dependency[InlineCastsTransform],
+         Dependency[InlineNotsTransform],
          Dependency[LegalizeClocksTransform],
          Dependency[FlattenRegUpdate],
          Dependency(passes.VerilogModulusCleanup) )

--- a/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+++ b/src/test/scala/firrtlTests/ConstantPropagationTests.scala
@@ -735,6 +735,78 @@ class ConstantPropagationSingleModule extends ConstantPropagationSpec {
     (parse(exec(input))) should be(parse(check))
   }
 
+   "ConstProp" should "propagate boolean equality with true" in {
+    val input =
+      """circuit Top :
+        |  module Top :
+        |    input x : UInt<1>
+        |    output z : UInt<1>
+        |    z <= eq(x, UInt<1>("h1"))
+      """.stripMargin
+    val check =
+      """circuit Top :
+        |  module Top :
+        |    input x : UInt<1>
+        |    output z : UInt<1>
+        |    z <= x
+      """.stripMargin
+    (parse(exec(input))) should be(parse(check))
+  }
+
+   "ConstProp" should "propagate boolean equality with false" in {
+    val input =
+      """circuit Top :
+        |  module Top :
+        |    input x : UInt<1>
+        |    output z : UInt<1>
+        |    z <= eq(x, UInt<1>("h0"))
+      """.stripMargin
+    val check =
+      """circuit Top :
+        |  module Top :
+        |    input x : UInt<1>
+        |    output z : UInt<1>
+        |    z <= not(x)
+      """.stripMargin
+    (parse(exec(input))) should be(parse(check))
+  }
+
+   "ConstProp" should "propagate boolean non-equality with true" in {
+    val input =
+      """circuit Top :
+        |  module Top :
+        |    input x : UInt<1>
+        |    output z : UInt<1>
+        |    z <= neq(x, UInt<1>("h1"))
+      """.stripMargin
+    val check =
+      """circuit Top :
+        |  module Top :
+        |    input x : UInt<1>
+        |    output z : UInt<1>
+        |    z <= not(x)
+      """.stripMargin
+    (parse(exec(input))) should be(parse(check))
+  }
+
+   "ConstProp" should "propagate boolean non-equality with false" in {
+    val input =
+      """circuit Top :
+        |  module Top :
+        |    input x : UInt<1>
+        |    output z : UInt<1>
+        |    z <= neq(x, UInt<1>("h0"))
+      """.stripMargin
+    val check =
+      """circuit Top :
+        |  module Top :
+        |    input x : UInt<1>
+        |    output z : UInt<1>
+        |    z <= x
+      """.stripMargin
+    (parse(exec(input))) should be(parse(check))
+  }
+
   // Optimizing this mux gives: z <= pad(UInt<2>(0), 4)
   // Thus this checks that we then optimize that pad
   "ConstProp" should "optimize nested Expressions" in {

--- a/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
+++ b/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
@@ -202,7 +202,8 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       new firrtl.transforms.BlackBoxSourceHelper,
       new firrtl.transforms.FixAddingNegativeLiterals,
       new firrtl.transforms.ReplaceTruncatingArithmetic,
-      new firrtl.transforms.InlineBitExtractionsTransform,
+      new firrtl.transforms.InlineNotsTransform,
+      new firrtl.transforms.InlineBitExtractionsTransform,  // here after InlineNots to clean up not(not(...)) rename
       new firrtl.transforms.PropagatePresetAnnotations,
       new firrtl.transforms.InlineCastsTransform,
       new firrtl.transforms.LegalizeClocksTransform,
@@ -222,7 +223,8 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       new firrtl.transforms.BlackBoxSourceHelper,
       new firrtl.transforms.FixAddingNegativeLiterals,
       new firrtl.transforms.ReplaceTruncatingArithmetic,
-      new firrtl.transforms.InlineBitExtractionsTransform,
+      new firrtl.transforms.InlineNotsTransform,
+      new firrtl.transforms.InlineBitExtractionsTransform,  // here after InlineNots to clean up not(not(...)) rename
       new firrtl.transforms.PropagatePresetAnnotations,
       new firrtl.transforms.InlineCastsTransform,
       new firrtl.transforms.LegalizeClocksTransform,

--- a/src/test/scala/firrtlTests/VerilogEmitterTests.scala
+++ b/src/test/scala/firrtlTests/VerilogEmitterTests.scala
@@ -177,6 +177,44 @@ class DoPrimVerilog extends FirrtlFlatSpec {
         |""".stripMargin.split("\n") map normalized
     executeTest(input, check, compiler)
   }
+ "inline Not" should "emit correctly" in {
+    val compiler = new VerilogCompiler
+    val input =
+      """circuit InlineNot :
+        |  module InlineNot :
+        |    input a: UInt<1>
+        |    input b: UInt<1>
+        |    input c: UInt<4>
+        |    output d: UInt<1>
+        |    output e: UInt<1>
+        |    output f: UInt<1>
+        |    output g: UInt<1>
+        |    output h: UInt<1>
+        |    d <= and(a, not(b))
+        |    e <= or(a, not(b))
+        |    f <= not(not(not(bits(c, 2, 2))))
+        |    g <= mux(not(bits(c, 2, 2)), a, b)
+        |    h <= shr(not(bits(c, 2, 1)), 1)""".stripMargin
+    val check =
+      """module InlineNot(
+        |  input   a,
+        |  input   b,
+        |  input  [3:0] c,
+        |  output  d,
+        |  output  e,
+        |  output  f,
+        |  output  g,
+        |  output  h
+        |);
+        |  assign d = a & ~b;
+        |  assign e = a | ~b;
+        |  assign f = ~c[2];
+        |  assign g = c[2] ? b : a;
+        |  assign h = ~c[2];
+        |endmodule
+        |""".stripMargin.split("\n") map normalized
+    executeTest(input, check, compiler)
+  }
   "Rem" should "emit correctly" in {
     val compiler = new VerilogCompiler
     val input =

--- a/src/test/scala/firrtlTests/VerilogEmitterTests.scala
+++ b/src/test/scala/firrtlTests/VerilogEmitterTests.scala
@@ -185,32 +185,44 @@ class DoPrimVerilog extends FirrtlFlatSpec {
         |    input a: UInt<1>
         |    input b: UInt<1>
         |    input c: UInt<4>
-        |    output d: UInt<1>
+        |    input d: UInt<4>
         |    output e: UInt<1>
         |    output f: UInt<1>
         |    output g: UInt<1>
         |    output h: UInt<1>
-        |    d <= and(a, not(b))
-        |    e <= or(a, not(b))
-        |    f <= not(not(not(bits(c, 2, 2))))
-        |    g <= mux(not(bits(c, 2, 2)), a, b)
-        |    h <= shr(not(bits(c, 2, 1)), 1)""".stripMargin
+        |    output i: UInt<1>
+        |    output j: UInt<5>
+        |    e <= and(a, not(b))
+        |    f <= or(a, not(b))
+        |    g <= not(not(not(bits(c, 2, 2))))
+        |    h <= mux(not(bits(c, 2, 2)), a, b)
+        |    i <= shr(not(bits(c, 2, 1)), 1)
+        |    j <= add(c, not(d))""".stripMargin
     val check =
       """module InlineNot(
         |  input   a,
         |  input   b,
         |  input  [3:0] c,
-        |  output  d,
+        |  input  [3:0] d,
         |  output  e,
         |  output  f,
         |  output  g,
-        |  output  h
+        |  output  h,
+        |  output  i,
+        |  output [4:0] j
         |);
-        |  assign d = a & ~b;
-        |  assign e = a | ~b;
-        |  assign f = ~c[2];
-        |  assign g = c[2] ? b : a;
-        |  assign h = ~c[2];
+        |  wire _GEN_3;
+        |  wire [1:0] _GEN_7;
+        |  wire [3:0] _GEN_8;
+        |  assign e = a & ~b;
+        |  assign f = a | ~b;
+        |  assign _GEN_3 = ~c[2];
+        |  assign g = _GEN_3;
+        |  assign h = c[2] ? b : a;
+        |  assign _GEN_7 = ~c[2:1];
+        |  assign i = _GEN_7[1];
+        |  assign _GEN_8 = ~d;
+        |  assign j = c + _GEN_8;
         |endmodule
         |""".stripMargin.split("\n") map normalized
     executeTest(input, check, compiler)


### PR DESCRIPTION
### Contributor Checklist
- [X] Did you add Scaladoc to every public function/method?
- [X] Did you add at least one test demonstrating the PR?
- [X] Did you delete any extraneous printlns/debugging code?
- [X] Did you specify the type of improvement?
- [X] Did you state the API impact?
- [X] Did you specify the code generation impact?
- [X] Did you request a desired merge strategy?

### Type of Improvement
- bug fix
- backend code generation

### API Impact
none

### Backend Code Generation Impact
Fixes https://github.com/freechipsproject/firrtl/pull/1422 by checking that the type (including width) is the same for both the LHS and any RHS terms inlined.
Re-applies https://github.com/freechipsproject/firrtl/pull/1270 to latest master head.

### Desired Merge Strategy
- Squash: The PR will be squashed and merged (choose this if you have no preference).

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you mark as `Please Merge`?
