### PR TITLE
Avoid generating out-of-bounds indices in ReplaceAccesses

### DIFF
--- a/src/main/scala/firrtl/passes/ReplaceAccesses.scala
+++ b/src/main/scala/firrtl/passes/ReplaceAccesses.scala
@@ -18,7 +18,10 @@ object ReplaceAccesses extends Pass with PreservesAll[Transform] {
   def run(c: Circuit): Circuit = {
     def onStmt(s: Statement): Statement = s map onStmt map onExp
     def onExp(e: Expression): Expression = e match {
-      case WSubAccess(ex, UIntLiteral(value, width), t, g) => WSubIndex(onExp(ex), value.toInt, t, g)
+      case WSubAccess(ex, UIntLiteral(value, _), t, g) => ex.tpe match {
+        case VectorType(_, len) if (value < len) => WSubIndex(onExp(ex), value.toInt, t, g)
+        case _ => e map onExp
+      }
       case _ => e map onExp
     }
 

--- a/src/test/scala/firrtlTests/ReplaceAccessesSpec.scala
+++ b/src/test/scala/firrtlTests/ReplaceAccessesSpec.scala
@@ -27,8 +27,29 @@ class ReplaceAccessesMultiDim extends ReplaceAccessesSpec {
   module Top :
     input clock : Clock
     output out : UInt<1>
-    reg r_vec : UInt<1>[4][2], clock
+    reg r_vec : UInt<1>[4][3], clock
     out <= r_vec[UInt<2>(2)][UInt<1>(1)]
+"""
+    val check =
+      """circuit Top :
+  module Top :
+    input clock : Clock
+    output out : UInt<1>
+    reg r_vec : UInt<1>[4][3], clock with :
+      reset => (UInt<1>(0), r_vec)
+    out <= r_vec[2][1]
+"""
+    (parse(exec(input))) should be (parse(check))
+  }
+
+  "ReplacesAccesses" should "NOT generate out-of-bounds indices" in {
+    val input =
+      """circuit Top :
+  module Top :
+    input clock : Clock
+    output out : UInt<1>
+    reg r_vec : UInt<1>[4][2], clock
+    out <= r_vec[UInt<3>(1)][UInt<3>(8)]
 """
     val check =
       """circuit Top :
@@ -37,7 +58,7 @@ class ReplaceAccessesMultiDim extends ReplaceAccessesSpec {
     output out : UInt<1>
     reg r_vec : UInt<1>[4][2], clock with :
       reset => (UInt<1>(0), r_vec)
-    out <= r_vec[2][1]
+    out <= r_vec[1][UInt<3>(8)]
 """
     (parse(exec(input))) should be (parse(check))
   }


### PR DESCRIPTION
**Type of improvement:** bug fix
**API impact:** none
**Backend code-generation impact:** avoids generating illegal Low FIRRTL
**Summary:** This PR adds bounds check to `ReplaceAccesses` to make the static-index-to-dynamic-index optimization avoid generating illegal FIRRTL.

Currently, `ReplaceAccesses` optimizes _every_ `WSubAccess`es that is indexed by a hardware expression that (eventually) resolves to a literal. However, dynamic accesses allow out-of-bounds indices (with undefined result), while static out-of-bounds indices are illegal in FIRRTL.

Therefore, the following legal code:
```
input i : UInt<1>[2]
o <= i[UInt<2>(3)]
```

Would be turned into the following broken code before this PR:
```
input i : UInt<1>[2]
o <= i[3]
```

I also updated the unit test of `ReplaceAccesses`, since it was actually testing that `ReplaceAccesses` generated illegal code.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you mark as `Please Merge`?
