### PR TITLE
Make InlineInstances invalidate ResolveKinds

### DIFF
--- a/src/main/scala/firrtl/passes/Inline.scala
+++ b/src/main/scala/firrtl/passes/Inline.scala
@@ -25,9 +25,11 @@ case class InlineAnnotation(target: Named) extends SingleTargetAnnotation[Named]
   * pass can infinitely recurse.
   */
 class InlineInstances extends Transform with RegisteredTransform {
-   def inputForm = LowForm
-   def outputForm = LowForm
-   private [firrtl] val inlineDelim: String = "_"
+  def inputForm = LowForm
+  def outputForm = LowForm
+  private [firrtl] val inlineDelim: String = "_"
+
+  override def invalidates(a: Transform): Boolean = a == ResolveKinds
 
   val options = Seq(
     new ShellOption[Seq[String]](

--- a/src/test/scala/firrtlTests/InlineInstancesTests.scala
+++ b/src/test/scala/firrtlTests/InlineInstancesTests.scala
@@ -2,9 +2,14 @@
 
 package firrtlTests
 
+import firrtl._
 import firrtl.annotations._
-import firrtl.passes.{InlineAnnotation, InlineInstances}
+import firrtl.passes.{InlineAnnotation, InlineInstances, ResolveKinds}
 import firrtl.transforms.NoCircuitDedupAnnotation
+import firrtl.stage.TransformManager
+import firrtl.options.Dependency
+
+import FirrtlCheckers._
 
 /**
  * Tests inline instances transformation
@@ -536,6 +541,28 @@ class InlineInstancesTests extends LowTransformSpec {
          DummyAnno(top.instOf("i_bar", "NestedNoInline").ref("foo_b"))
        )
      )
+  }
+
+  "InlineInstances" should "properly invalidate ResolveKinds" in {
+    val input =
+      """circuit Top :
+        |  module Top :
+        |    input a : UInt<32>
+        |    output b : UInt<32>
+        |    inst i of Inline
+        |    i.a <= a
+        |    b <= i.b
+        |  module Inline :
+        |    input a : UInt<32>
+        |    output b : UInt<32>
+        |    b <= a""".stripMargin
+
+    val state = CircuitState(parse(input), ChirrtlForm, Seq(inline("Inline")))
+    val manager = new TransformManager(Seq(Dependency[InlineInstances], Dependency(ResolveKinds)))
+    val result = manager.execute(state)
+
+    result shouldNot containTree { case WRef("i_a", _, PortKind, _) => true }
+    result should    containTree { case WRef("i_a", _, WireKind, _) => true }
   }
 }
 


### PR DESCRIPTION
Fixes #1453

I've marked this for backporting which obviously will conflict, but I want mergify to make the PR to link it properly to this one, then I'll fix it manually.

I tried to make the `inputForm` and `outputForm` `UnknownForm` and then instead use `prerequisites` but it didn't work, I got:
```
[info] firrtlTests.InlineInstancesTests *** ABORTED ***                                                                                                                           
[info]   java.lang.RuntimeException: Illegal to compare UnknownForm                                                                                                               
[info]   at scala.sys.package$.error(package.scala:30)                                                                                                                            
[info]   at firrtl.UnknownForm$.compare(Compiler.scala:175)                                                                                                                       
[info]   at firrtl.UnknownForm$.compare(Compiler.scala:174)                                                                                                                       
[info]   at scala.math.Ordered.$greater$eq(Ordered.scala:91)                                                                                                                      
[info]   at scala.math.Ordered.$greater$eq$(Ordered.scala:91)                                                                                                                     
[info]   at firrtl.CircuitForm.$greater$eq(Compiler.scala:104)                                                                                                                    
[info]   at firrtl.Compiler.$anonfun$transformsLegal$1(Compiler.scala:491)                                                                                                        
[info]   at firrtl.Compiler.$anonfun$transformsLegal$1$adapted(Compiler.scala:491)                                                                                                
[info]   at scala.collection.Iterator$$anon$10.next(Iterator.scala:459)                                                                                                           
[info]   at scala.collection.Iterator.foreach(Iterator.scala:941)   
```

Is this the expected/intentional behavior @seldridge?

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

Bug fix
<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
InlineInstances now invalidates ResolveKinds which is the correct behavior, otherwise you have some `WRefs` with the wrong kind.

### Backend Code Generation Impact

None
<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

### Desired Merge Strategy

Dont care
<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you mark as `Please Merge`?
