### PR TITLE
Add method to CheckCompLoops which returns its full netlist

### DIFF
--- a/src/main/scala/firrtl/transforms/CheckCombLoops.scala
+++ b/src/main/scala/firrtl/transforms/CheckCombLoops.scala
@@ -279,17 +279,24 @@ class CheckCombLoops extends Transform with RegisteredTransform with PreservesAl
       val sources = tos.map(to => mt.ref(to.name))
       CombinationalPath(sink, sources.toSeq)
     }
-    (state.copy(annotations = state.annotations ++ annos), errors, simplifiedModuleGraphs)
+    (state.copy(annotations = state.annotations ++ annos), errors, simplifiedModuleGraphs, moduleGraphs)
   }
 
   /**
     * Returns a Map from Module name to port connectivity
     */
   def analyze(state: CircuitState): collection.Map[String,DiGraph[String]] = {
-    val (result, errors, connectivity) = run(state)
+    val (result, errors, connectivity, _) = run(state)
     connectivity.map {
       case (k, v) => (k, v.transformNodes(ln => ln.name))
     }
+  }
+
+  /**
+    * Returns a Map from Module name to complete netlist connectivity
+    */
+  def analyzeFull(state: CircuitState): collection.Map[String,DiGraph[LogicNode]] = {
+    run(state)._4
   }
 
   def execute(state: CircuitState): CircuitState = {
@@ -298,7 +305,7 @@ class CheckCombLoops extends Transform with RegisteredTransform with PreservesAl
       logger.warn("Skipping Combinational Loop Detection")
       state
     } else {
-      val (result, errors, connectivity) = run(state)
+      val (result, errors, connectivity, _) = run(state)
       errors.trigger()
       result
     }


### PR DESCRIPTION
There are many instances where have a netlist representation of the design is a really useful analysis for some sort of transformation. In these cases the transform writer ends up writing something that looks much like the initial netlist-graph generation  of CheckCombLoops. This PR adds a method to return the complete graphs for use by an enclosing transformation.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement
- new feature/API

### API Impact
- Expands CheckCombLoops's API.

### Backend Code Generation Impact
- No verilog changes.

### Desired Merge Strategy
- Squash

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [x] Did you review?
- [ ] Did you mark as `Please Merge`?
