### PR TITLE
Change annotation logging

### DIFF
--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -295,10 +295,8 @@ trait Transform extends TransformLike[CircuitState] with DependencyAPI[Transform
     val remappedAnnotations = propagateAnnotations(state.annotations, result.annotations, result.renames)
 
     logger.info(s"Form: ${result.form}")
-    logger.debug(s"Annotations:")
-    remappedAnnotations.foreach { a =>
-      logger.debug(a.serialize)
-    }
+    logger.trace(s"Annotations:")
+    logger.trace(JsonProtocol.serialize(remappedAnnotations))
     logger.trace(s"Circuit:\n${result.circuit.serialize}")
     logger.info(s"======== Finished Transform $name ========\n")
     CircuitState(result.circuit, result.form, remappedAnnotations, None)

--- a/src/main/scala/firrtl/annotations/Annotation.scala
+++ b/src/main/scala/firrtl/annotations/Annotation.scala
@@ -14,9 +14,9 @@ trait Annotation extends Product {
   /** Update the target based on how signals are renamed */
   def update(renames: RenameMap): Seq[Annotation]
 
-  /** Pretty Print
+  /** Optional pretty print
     *
-    * @note In [[logger.LogLevel.Debug]] this is called on every Annotation after every Transform
+    * @note rarely used
     */
   def serialize: String = this.toString
 

--- a/src/main/scala/firrtl/stage/transforms/UpdateAnnotations.scala
+++ b/src/main/scala/firrtl/stage/transforms/UpdateAnnotations.scala
@@ -3,7 +3,7 @@
 package firrtl.stage.transforms
 
 import firrtl.{AnnotationSeq, CircuitState, RenameMap, Transform, Utils}
-import firrtl.annotations.{Annotation, DeletedAnnotation}
+import firrtl.annotations.{Annotation, DeletedAnnotation, JsonProtocol}
 import firrtl.options.Translator
 
 import scala.collection.mutable
@@ -21,9 +21,8 @@ class UpdateAnnotations(val underlying: Transform) extends Transform with Wrappe
     val remappedAnnotations = propagateAnnotations(state.annotations, result.annotations, result.renames)
 
     logger.info(s"Form: ${result.form}")
-
-    logger.debug(s"Annotations:")
-    remappedAnnotations.foreach( a => logger.debug(a.serialize) )
+    logger.trace(s"Annotations:")
+    logger.trace(JsonProtocol.serialize(remappedAnnotations))
 
     logger.trace(s"Circuit:\n${result.circuit.serialize}")
     logger.info(s"======== Finished Transform $name ========\n")


### PR DESCRIPTION
* Change from log-level debug to trace
* Serialize as JSON rather than .serialize on each annotation

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

<!-- Choose one or more from the following: -->
- logging cleanup

### API Impact

It doesn't affect any Scala code, but changes the logging format. When annotations were new, it made sense to log them at the `debug` level because it was far less verbose than the circuit, these days they are extremely verbose. I also changed it to use JSON serialization instead of the relatively unused pretty printing `serialize` method. This makes it possible to take the output of logging and feed it back into the compiler which is very useful.

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

### Backend Code Generation Impact

No impact
<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

### Desired Merge Strategy

Don't Care

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you mark as `Please Merge`?
