### PR TITLE
Explicitly initialize firrtl.stage.Forms to prevent multi-thread collisions

### DIFF
--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -295,10 +295,8 @@ trait Transform extends TransformLike[CircuitState] with DependencyAPI[Transform
     val remappedAnnotations = propagateAnnotations(state.annotations, result.annotations, result.renames)
 
     logger.info(s"Form: ${result.form}")
-    logger.debug(s"Annotations:")
-    remappedAnnotations.foreach { a =>
-      logger.debug(a.serialize)
-    }
+    logger.trace(s"Annotations:")
+    logger.trace(JsonProtocol.serialize(remappedAnnotations))
     logger.trace(s"Circuit:\n${result.circuit.serialize}")
     logger.info(s"======== Finished Transform $name ========\n")
     CircuitState(result.circuit, result.form, remappedAnnotations, None)

--- a/src/main/scala/firrtl/annotations/Annotation.scala
+++ b/src/main/scala/firrtl/annotations/Annotation.scala
@@ -14,9 +14,9 @@ trait Annotation extends Product {
   /** Update the target based on how signals are renamed */
   def update(renames: RenameMap): Seq[Annotation]
 
-  /** Pretty Print
+  /** Optional pretty print
     *
-    * @note In [[logger.LogLevel.Debug]] this is called on every Annotation after every Transform
+    * @note rarely used
     */
   def serialize: String = this.toString
 

--- a/src/main/scala/firrtl/options/Stage.scala
+++ b/src/main/scala/firrtl/options/Stage.scala
@@ -62,8 +62,6 @@ abstract class Stage extends Phase {
   * @param stage the stage to run
   */
 class StageMain(val stage: Stage) {
-  // Force initialization of the Forms object - https://github.com/freechipsproject/firrtl/issues/1462
-  private val _dummyForms = firrtl.stage.Forms
   /** The main function that serves as this stage's command line interface.
     * @param args command line arguments
     */

--- a/src/main/scala/firrtl/options/Stage.scala
+++ b/src/main/scala/firrtl/options/Stage.scala
@@ -63,7 +63,7 @@ abstract class Stage extends Phase {
   */
 class StageMain(val stage: Stage) {
   // Force initialization of the Forms object - https://github.com/freechipsproject/firrtl/issues/1462
-  val _dummyForms = firrtl.stage.Forms
+  private val _dummyForms = firrtl.stage.Forms
   /** The main function that serves as this stage's command line interface.
     * @param args command line arguments
     */

--- a/src/main/scala/firrtl/options/Stage.scala
+++ b/src/main/scala/firrtl/options/Stage.scala
@@ -62,7 +62,8 @@ abstract class Stage extends Phase {
   * @param stage the stage to run
   */
 class StageMain(val stage: Stage) {
-
+  // Force initialization of the Forms object - https://github.com/freechipsproject/firrtl/issues/1462
+  val _dummyForms = firrtl.stage.Forms
   /** The main function that serves as this stage's command line interface.
     * @param args command line arguments
     */

--- a/src/main/scala/firrtl/package.scala
+++ b/src/main/scala/firrtl/package.scala
@@ -3,6 +3,9 @@
 import firrtl.annotations.Annotation
 
 package object firrtl {
+  // Force initialization of the Forms object - https://github.com/freechipsproject/firrtl/issues/1462
+  private val _dummyForms = firrtl.stage.Forms
+
   implicit def seqToAnnoSeq(xs: Seq[Annotation]) = AnnotationSeq(xs)
   implicit def annoSeqToSeq(as: AnnotationSeq): Seq[Annotation] = as.underlying
 

--- a/src/main/scala/firrtl/stage/Forms.scala
+++ b/src/main/scala/firrtl/stage/Forms.scala
@@ -14,17 +14,17 @@ import firrtl.stage.TransformManager.TransformDependency
 
 object Forms {
 
-  lazy val ChirrtlForm: Seq[TransformDependency] = Seq.empty
+  val ChirrtlForm: Seq[TransformDependency] = Seq.empty
 
-  lazy val MinimalHighForm: Seq[TransformDependency] = ChirrtlForm ++
+  val MinimalHighForm: Seq[TransformDependency] = ChirrtlForm ++
     Seq( Dependency(passes.CheckChirrtl),
          Dependency(passes.CInferTypes),
          Dependency(passes.CInferMDir),
          Dependency(passes.RemoveCHIRRTL) )
 
-  lazy val WorkingIR: Seq[TransformDependency] = MinimalHighForm :+ Dependency(passes.ToWorkingIR)
+  val WorkingIR: Seq[TransformDependency] = MinimalHighForm :+ Dependency(passes.ToWorkingIR)
 
-  lazy val Resolved: Seq[TransformDependency] = WorkingIR ++
+  val Resolved: Seq[TransformDependency] = WorkingIR ++
     Seq( Dependency(passes.CheckHighForm),
          Dependency(passes.ResolveKinds),
          Dependency(passes.InferTypes),
@@ -38,15 +38,15 @@ object Forms {
          Dependency(passes.CheckWidths),
          Dependency[firrtl.transforms.InferResets] )
 
-  lazy val Deduped: Seq[TransformDependency] = Resolved :+ Dependency[firrtl.transforms.DedupModules]
+  val Deduped: Seq[TransformDependency] = Resolved :+ Dependency[firrtl.transforms.DedupModules]
 
-  lazy val HighForm: Seq[TransformDependency] = ChirrtlForm ++
+  val HighForm: Seq[TransformDependency] = ChirrtlForm ++
     MinimalHighForm ++
     WorkingIR ++
     Resolved ++
     Deduped
 
-  lazy val MidForm: Seq[TransformDependency] = HighForm ++
+  val MidForm: Seq[TransformDependency] = HighForm ++
     Seq( Dependency(passes.PullMuxes),
          Dependency(passes.ReplaceAccesses),
          Dependency(passes.ExpandConnects),
@@ -56,7 +56,7 @@ object Forms {
          Dependency(passes.ConvertFixedToSInt),
          Dependency(passes.ZeroWidth) )
 
-  lazy val LowForm: Seq[TransformDependency] = MidForm ++
+  val LowForm: Seq[TransformDependency] = MidForm ++
     Seq( Dependency(passes.LowerTypes),
          Dependency(passes.Legalize),
          Dependency(firrtl.transforms.RemoveReset),
@@ -64,19 +64,19 @@ object Forms {
          Dependency[checks.CheckResets],
          Dependency[firrtl.transforms.RemoveWires] )
 
-  lazy val LowFormMinimumOptimized: Seq[TransformDependency] = LowForm ++
+  val LowFormMinimumOptimized: Seq[TransformDependency] = LowForm ++
     Seq( Dependency(passes.RemoveValidIf),
          Dependency(passes.memlib.VerilogMemDelays),
          Dependency(passes.SplitExpressions) )
 
-  lazy val LowFormOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
+  val LowFormOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
     Seq( Dependency[firrtl.transforms.ConstantPropagation],
          Dependency(passes.PadWidths),
          Dependency[firrtl.transforms.CombineCats],
          Dependency(passes.CommonSubexpressionElimination),
          Dependency[firrtl.transforms.DeadCodeElimination] )
 
-  lazy val VerilogMinimumOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
+  val VerilogMinimumOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
     Seq( Dependency[firrtl.transforms.BlackBoxSourceHelper],
          Dependency[firrtl.transforms.FixAddingNegativeLiterals],
          Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
@@ -89,6 +89,6 @@ object Forms {
          Dependency(passes.VerilogPrep),
          Dependency[firrtl.AddDescriptionNodes] )
 
-  lazy val VerilogOptimized: Seq[TransformDependency] = LowFormOptimized ++ VerilogMinimumOptimized
+  val VerilogOptimized: Seq[TransformDependency] = LowFormOptimized ++ VerilogMinimumOptimized
 
 }

--- a/src/main/scala/firrtl/stage/transforms/UpdateAnnotations.scala
+++ b/src/main/scala/firrtl/stage/transforms/UpdateAnnotations.scala
@@ -3,7 +3,7 @@
 package firrtl.stage.transforms
 
 import firrtl.{AnnotationSeq, CircuitState, RenameMap, Transform, Utils}
-import firrtl.annotations.{Annotation, DeletedAnnotation}
+import firrtl.annotations.{Annotation, DeletedAnnotation, JsonProtocol}
 import firrtl.options.Translator
 
 import scala.collection.mutable
@@ -21,9 +21,8 @@ class UpdateAnnotations(val underlying: Transform) extends Transform with Wrappe
     val remappedAnnotations = propagateAnnotations(state.annotations, result.annotations, result.renames)
 
     logger.info(s"Form: ${result.form}")
-
-    logger.debug(s"Annotations:")
-    remappedAnnotations.foreach( a => logger.debug(a.serialize) )
+    logger.trace(s"Annotations:")
+    logger.trace(JsonProtocol.serialize(remappedAnnotations))
 
     logger.trace(s"Circuit:\n${result.circuit.serialize}")
     logger.info(s"======== Finished Transform $name ========\n")

--- a/src/test/scala/firrtl/testutils/FirrtlSpec.scala
+++ b/src/test/scala/firrtl/testutils/FirrtlSpec.scala
@@ -28,6 +28,8 @@ class CheckLowForm extends SeqTransform {
 }
 
 trait FirrtlRunners extends BackendCompilationUtilities {
+  // Force initialization of the Forms object - see https://github.com/freechipsproject/firrtl/issues/1462
+  private val _dummyForms = firrtl.stage.Forms
 
   val cppHarnessResourceName: String = "/firrtl/testTop.cpp"
   /** Extra transforms to run by default */

--- a/src/test/scala/firrtl/testutils/FirrtlSpec.scala
+++ b/src/test/scala/firrtl/testutils/FirrtlSpec.scala
@@ -28,8 +28,6 @@ class CheckLowForm extends SeqTransform {
 }
 
 trait FirrtlRunners extends BackendCompilationUtilities {
-  // Force initialization of the Forms object - see https://github.com/freechipsproject/firrtl/issues/1462
-  private val _dummyForms = firrtl.stage.Forms
 
   val cppHarnessResourceName: String = "/firrtl/testTop.cpp"
   /** Extra transforms to run by default */


### PR DESCRIPTION
See https://github.com/freechipsproject/firrtl/issues/1462.
Convert `lazy val` members of firrtl.stage.Forms to plan `val`s.
Reference firrtl.stage.Forms in sufficient locations to ensure the object is initialized before its members are accessed.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

- bug fix

### API Impact

no API changes

### Backend Code Generation Impact

no code generation impact

### Desired Merge Strategy

 - Squash: The PR will be squashed and merged (choose this if you have no preference.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you mark as `Please Merge`?
