### PR TITLE
Nuclear Option (-Xfatal-warnings) for Scaladoc Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,10 @@ jobs:
         - bash .install_yosys.sh
         - yosys -V
     - stage: test
+      name: "Unidoc builds (no warnings)"
+      script:
+        - sbt $SBT_ARGS unidoc
+    - stage: test
       name: "Tests: FIRRTL (2.12)"
       script:
         - verilator --version

--- a/build.sbt
+++ b/build.sbt
@@ -132,18 +132,6 @@ lazy val publishSettings = Seq(
 lazy val docSettings = Seq(
   doc in Compile := (doc in ScalaUnidoc).value,
   autoAPIMappings := true,
-  apiMappings ++= {
-    Option(System.getProperty("sun.boot.class.path")).flatMap { classPath =>
-      classPath.split(java.io.File.pathSeparator).find(_.endsWith(java.io.File.separator + "rt.jar"))
-    }.map { jarPath =>
-      Map(
-        file(jarPath) -> url("https://docs.oracle.com/javase/8/docs/api")
-      )
-    }.getOrElse {
-      streams.value.log.warn("Failed to add bootstrap class path of Java to apiMappings")
-      Map.empty[File,URL]
-    }
-  },
   scalacOptions in Compile in doc ++= Seq(
     "-diagrams",
     "-diagrams-max-classes", "25",

--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,9 @@ lazy val commonSettings = Seq(
   scalacOptions := scalacOptionsVersion(scalaVersion.value) ++ Seq(
     "-deprecation",
     "-unchecked",
+    "-language:reflectiveCalls",
+    "-language:existentials",
+    "-language:implicitConversions",
     "-Yrangepos",          // required by SemanticDB compiler plugin
     "-Ywarn-unused-import" // required by `RemoveUnused` rule
   ),
@@ -133,6 +136,8 @@ lazy val docSettings = Seq(
   doc in Compile := (doc in ScalaUnidoc).value,
   autoAPIMappings := true,
   scalacOptions in Compile in doc ++= Seq(
+    "-Xfatal-warnings",
+    "-feature",
     "-diagrams",
     "-diagrams-max-classes", "25",
     "-doc-version", version.value,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,4 +22,6 @@ addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.5")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.12")
 
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")
+
 libraryDependencies += "com.github.os72" % "protoc-jar" % "3.11.1"

--- a/src/main/scala/firrtl/transforms/Flatten.scala
+++ b/src/main/scala/firrtl/transforms/Flatten.scala
@@ -47,7 +47,7 @@ class Flatten extends Transform {
     *  @return modified circuit and ModuleNames to inline
     */
    def duplicateSubCircuitsFromAnno(c: Circuit, mods: Set[ModuleName], insts: Set[ComponentName]): (Circuit, Set[ModuleName]) = {
-     val modMap = c.modules.map(m => m.name->m) toMap
+     val modMap = c.modules.map(m => m.name->m).toMap
      val seedMods = mutable.Map.empty[String, String]
      val newModDefs = mutable.Set.empty[DefModule]
      val nsp = Namespace(c)


### PR DESCRIPTION
- Turns on -Xfatal-warnings when building unidoc. 
- Adds language feature options that we were using to the compiler
- Fixes a postfix operator usage in `transforms.Flatten`
- Adds `sbt unidoc` to CI tests

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Dependencies

- prerequisites: [#1470]

### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
- infrastructure
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

None.

### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you mark as `Please Merge`?
