### PR TITLE
Fix InlineCasts

### DIFF
--- a/src/main/scala/firrtl/transforms/InlineCasts.scala
+++ b/src/main/scala/firrtl/transforms/InlineCasts.scala
@@ -6,7 +6,7 @@ package transforms
 import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.PrimOps.Pad
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 
 import firrtl.Utils.{isCast, isBitExtract, NodeMap}
 
@@ -66,7 +66,7 @@ object InlineCastsTransform {
 }
 
 /** Inline nodes that are simple casts */
-class InlineCastsTransform extends Transform with PreservesAll[Transform] {
+class InlineCastsTransform extends Transform {
   def inputForm = UnknownForm
   def outputForm = UnknownForm
 
@@ -80,6 +80,11 @@ class InlineCastsTransform extends Transform with PreservesAll[Transform] {
   override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
   override val dependents = Seq.empty
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case _: LegalizeClocksTransform => true
+    case _ => false
+  }
 
   def execute(state: CircuitState): CircuitState = {
     val modulesx = state.circuit.modules.map(InlineCastsTransform.onMod(_))

--- a/src/test/scala/firrtl/testutils/FirrtlSpec.scala
+++ b/src/test/scala/firrtl/testutils/FirrtlSpec.scala
@@ -5,7 +5,7 @@ package firrtl.testutils
 import java.io._
 import java.security.Permission
 
-import logger.LazyLogging
+import logger.{LazyLogging, LogLevel, LogLevelAnnotation}
 
 import org.scalatest._
 import org.scalatestplus.scalacheck._
@@ -13,6 +13,7 @@ import org.scalatestplus.scalacheck._
 import firrtl._
 import firrtl.ir._
 import firrtl.Parser.UseInfo
+import firrtl.options.{Dependency, PreservesAll}
 import firrtl.stage.{FirrtlFileAnnotation, InfoModeAnnotation, RunFirrtlTransformAnnotation}
 import firrtl.analyses.{GetNamespace, ModuleNamespaceAnnotation}
 import firrtl.annotations._
@@ -30,30 +31,46 @@ class CheckLowForm extends SeqTransform {
   )
 }
 
+case class RenameTopAnnotation(newTopName: String) extends NoTargetAnnotation
+
+object RenameTop extends Transform with PreservesAll[Transform] {
+  def inputForm = UnknownForm
+  def outputForm = UnknownForm
+
+  override val optionalPrerequisites = Seq(Dependency[RenameModules])
+
+  override val dependents = Seq(Dependency[VerilogEmitter], Dependency[MinimumVerilogEmitter])
+
+  def execute(state: CircuitState): CircuitState = {
+    val c = state.circuit
+    val ns = Namespace(c)
+
+    val newTopName = state.annotations.collectFirst({
+      case RenameTopAnnotation(name) =>
+        require(ns.tryName(name))
+        name
+    }).getOrElse(c.main)
+
+    state.annotations.collect {
+      case ModuleNamespaceAnnotation(mustNotCollideNS) => require(mustNotCollideNS.tryName(newTopName))
+    }
+
+    val modulesx = c.modules.map {
+      case m: Module if (m.name == c.main) => m.copy(name = newTopName)
+      case m => m
+    }
+
+    val renames = RenameMap()
+    renames.record(CircuitTarget(c.main), CircuitTarget(newTopName))
+    state.copy(circuit = c.copy(main = newTopName, modules = modulesx), renames = Some(renames))
+  }
+}
+
 trait FirrtlRunners extends BackendCompilationUtilities {
 
   val cppHarnessResourceName: String = "/firrtl/testTop.cpp"
   /** Extra transforms to run by default */
   val extraCheckTransforms = Seq(new CheckLowForm)
-
-  private class RenameTop(newTopPrefix: String) extends Transform {
-    def inputForm: LowForm.type = LowForm
-    def outputForm: LowForm.type = LowForm
-
-    def execute(state: CircuitState): CircuitState = {
-      val namespace = state.annotations.collectFirst {
-        case m: ModuleNamespaceAnnotation => m
-      }.get.namespace
-
-      val newTopName = namespace.newName(newTopPrefix)
-      val modulesx = state.circuit.modules.map {
-        case mod: Module if mod.name == state.circuit.main => mod.mapString(_ => newTopName)
-        case other => other
-      }
-
-      state.copy(circuit = state.circuit.copy(main = newTopName, modules = modulesx))
-    }
-  }
 
   /** Check equivalence of Firrtl transforms using yosys
     *
@@ -67,29 +84,35 @@ trait FirrtlRunners extends BackendCompilationUtilities {
                             customAnnotations: AnnotationSeq = Seq.empty,
                             resets: Seq[(Int, String, Int)] = Seq.empty): Unit = {
     val circuit = Parser.parse(input.split("\n").toIterator)
-    val compiler = new MinimumVerilogCompiler
     val prefix = circuit.main
     val testDir = createTestDirectory(prefix + "_equivalence_test")
-    val firrtlWriter = new PrintWriter(s"${testDir.getAbsolutePath}/$prefix.fir")
-    firrtlWriter.write(input)
-    firrtlWriter.close()
 
-    val customVerilog = compiler.compileAndEmit(CircuitState(circuit, HighForm, customAnnotations),
-      new GetNamespace +: new RenameTop(s"${prefix}_custom") +: customTransforms)
-    val namespaceAnnotation = customVerilog.annotations.collectFirst { case m: ModuleNamespaceAnnotation => m }.get
-    val customTop = customVerilog.circuit.main
-    val customFile = new PrintWriter(s"${testDir.getAbsolutePath}/$customTop.v")
-    customFile.write(customVerilog.getEmittedCircuit.value)
-    customFile.close()
+    def toAnnos(xforms: Seq[Transform]) = xforms.map(RunFirrtlTransformAnnotation(_))
 
-    val referenceVerilog = compiler.compileAndEmit(CircuitState(circuit, HighForm, Seq(namespaceAnnotation)),
-      Seq(new RenameModules, new RenameTop(s"${prefix}_reference")))
-    val referenceTop = referenceVerilog.circuit.main
-    val referenceFile = new PrintWriter(s"${testDir.getAbsolutePath}/$referenceTop.v")
-    referenceFile.write(referenceVerilog.getEmittedCircuit.value)
-    referenceFile.close()
+    def getBaseAnnos(topName: String) = {
+      val baseTransforms = RenameTop +: extraCheckTransforms
+      TargetDirAnnotation(testDir.toString) +:
+      InfoModeAnnotation("ignore") +:
+      RenameTopAnnotation(topName) +:
+      stage.FirrtlCircuitAnnotation(circuit) +:
+      stage.CompilerAnnotation("mverilog") +:
+      stage.OutputFileAnnotation(topName) +:
+      toAnnos(baseTransforms)
+    }
 
-    assert(yosysExpectSuccess(customTop, referenceTop, testDir, resets))
+    val customName = s"${prefix}_custom"
+    val customAnnos = getBaseAnnos(customName) ++: toAnnos((new GetNamespace) +: customTransforms) ++: customAnnotations
+
+    val customResult = (new firrtl.stage.FirrtlStage).run(customAnnos)
+    val nsAnno = customResult.collectFirst { case m: ModuleNamespaceAnnotation => m }.get
+
+    val refSuggestedName = s"${prefix}_ref"
+    val refAnnos = getBaseAnnos(refSuggestedName) ++: Seq(RunFirrtlTransformAnnotation(new RenameModules), nsAnno)
+
+    val refResult = (new firrtl.stage.FirrtlStage).run(refAnnos)
+    val refName = refResult.collectFirst({ case stage.FirrtlCircuitAnnotation(c) => c.main }).getOrElse(refSuggestedName)
+
+    assert(yosysExpectSuccess(customName, refName, testDir, resets))
   }
 
   /** Compiles input Firrtl to Verilog */

--- a/src/test/scala/firrtlTests/InlineCastsSpec.scala
+++ b/src/test/scala/firrtlTests/InlineCastsSpec.scala
@@ -1,0 +1,29 @@
+// See LICENSE for license details.
+
+package firrtlTests
+
+import firrtl.transforms.InlineCastsTransform
+import firrtl.testutils.FirrtlFlatSpec
+
+/*
+ * Note: InlineCasts is still part of mverilog, so this test must both:
+ * - Test that the InlineCasts fix is effective given the current mverilog
+ * - Provide a test that will be robust if and when InlineCasts is no longer run in mverilog
+ *
+ * This is why the test passes InlineCasts as a custom transform: to future-proof it so that
+ * it can do real LEC against no-InlineCasts. It currently is just a sanity check that the
+ * emitted Verilog is legal, but it will automatically become a more meaningful test when
+ * InlineCasts is not run in mverilog.
+ */
+class InlineCastsEquivalenceSpec extends FirrtlFlatSpec {
+  "InlineCastsTransform" should "not produce broken Verilog" in {
+    val input =
+      s"""circuit literalsel_fir:
+         |  module literalsel_fir:
+         |    input i: UInt<4>
+         |    output o: SInt<8>
+         |    o <= pad(asSInt(UInt<2>("h1")), 8)
+         |""".stripMargin
+    firrtlEquivalenceTest(input, Seq(new InlineCastsTransform))
+  }
+}


### PR DESCRIPTION
**Type of change:** bug fix
**API impact:** none
**Backend code-generation impact:** avoids emitting illegal part-selects
**Desired merge strategy:** rebase

This fixes a Verilog-generation bug that @ucbjrl ran across when doing some Verilog/RTLIL/FIRRTL flows with Yosys.

This FIRRTL:
```
circuit badcast:
  module badcast:
    input i: UInt<4>
    output o: SInt<8>
    o <= pad(asSInt(UInt<2>("h1")), 8)
```

Produces the broken Verilog expression `{{6{2'h1[1]}},2'h1};` due to overly aggressive inlining by `InlineCasts`. This PR fixes the issue by avoiding inlining cast-only nodes when they are the argument of an operator that generates a part-select, since this is generally unsafe.

I wrote a test case that tries to bridge the gap of being useful now (since `InlineCasts` is effectively mandatory) and in the future when there is a more-minimal Verilog flow. In order to do this with a sane transform order, I ported `firrtlEquivalenceTest` to use `FirrtlStage`, hence the big diff. This is a necessary prerequisite to write good tests for Verilog optimizations that themselves already rely on the `DependencyAPI`.

As far as milestones go, only the change to `InlineCasts` should be backported. I can fix this up manually.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you mark as `Please Merge`?
