### PR TITLE
Disable unidoc -Xfatal-warning for Scala 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -132,11 +132,23 @@ lazy val publishSettings = Seq(
   }
 )
 
+
+def scalacDocOptionsVersion(scalaVersion: String): Seq[String] = {
+  Seq() ++ {
+    // If we're building with Scala > 2.11, enable the compile option
+    //  to flag warnings as errors. This must be disabled for 2.11 since
+    //  references to the Java class library from Java 9 on generate warnings.
+    //  https://github.com/scala/bug/issues/10675
+    CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, scalaMajor: Long)) if scalaMajor < 12 => Seq()
+      case _ => Seq("-Xfatal-warnings")
+    }
+  }
+}
 lazy val docSettings = Seq(
   doc in Compile := (doc in ScalaUnidoc).value,
   autoAPIMappings := true,
   scalacOptions in Compile in doc ++= Seq(
-    "-Xfatal-warnings",
     "-feature",
     "-diagrams",
     "-diagrams-max-classes", "25",
@@ -154,7 +166,7 @@ lazy val docSettings = Seq(
         }
       s"https://github.com/freechipsproject/firrtl/tree/$branch€{FILE_PATH}.scala"
     }
-  ) ++ scalacOptionsVersion(scalaVersion.value)
+  ) ++ scalacOptionsVersion(scalaVersion.value) ++ scalacDocOptionsVersion(scalaVersion.value)
 )
 
 lazy val firrtl = (project in file("."))


### PR DESCRIPTION
This addresses issue #1492.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement

- bug fix
- documentation

### API Impact

No API impact.

### Backend Code Generation Impact

No code generation impact.

### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you mark as `Please Merge`?
