### PR TITLE
Remove deprecated gender

### DIFF
--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -522,11 +522,6 @@ object Utils extends LazyLogging {
     case SourceFlow => Input
     case SinkFlow => Output
   }
-  @deprecated("Migrate from 'Gender' to 'Flow. This method will be removed in 1.3", "1.2")
-  def to_gender(d: Direction): Gender = d match {
-    case Input => MALE
-    case Output => FEMALE
-  }
   def to_flow(d: Direction): Flow = d match {
     case Input => SourceFlow
     case Output => SinkFlow
@@ -583,38 +578,6 @@ object Utils extends LazyLogging {
     case ex: WSubAccess => kind(ex.expr)
     case ex => ExpKind
   }
-  @deprecated("Migrate from 'Gender' to 'Flow'. This method will be removed in 1.3", "1.2")
-  def gender(e: Expression): Gender = e match {
-    case ex: WRef => ex.gender
-    case ex: WSubField => ex.gender
-    case ex: WSubIndex => ex.gender
-    case ex: WSubAccess => ex.gender
-    case ex: DoPrim => MALE
-    case ex: UIntLiteral => MALE
-    case ex: SIntLiteral => MALE
-    case ex: Mux => MALE
-    case ex: ValidIf => MALE
-    case WInvalid => MALE
-    case ex => throwInternalError(s"gender: shouldn't be here - $e")
-  }
-  @deprecated("Migrate from 'Gender' to 'Flow'. This method will be removed in 1.3", "1.2")
-  def get_gender(s: Statement): Gender = s match {
-    case sx: DefWire => BIGENDER
-    case sx: DefRegister => BIGENDER
-    case sx: WDefInstance => MALE
-    case sx: DefNode => MALE
-    case sx: DefInstance => MALE
-    case sx: DefMemory => MALE
-    case sx: Block => UNKNOWNGENDER
-    case sx: Connect => UNKNOWNGENDER
-    case sx: PartialConnect => UNKNOWNGENDER
-    case sx: Stop => UNKNOWNGENDER
-    case sx: Print => UNKNOWNGENDER
-    case sx: IsInvalid => UNKNOWNGENDER
-    case EmptyStmt => UNKNOWNGENDER
-  }
-  @deprecated("Migrate from 'Gender' to 'Flow'. This method will be removed in 1.3", "1.2")
-  def get_gender(p: Port): Gender = if (p.direction == Input) MALE else FEMALE
   def flow(e: Expression): Flow = e match {
     case ex: WRef => ex.flow
     case ex: WSubField => ex.flow

--- a/src/main/scala/firrtl/WIR.scala
+++ b/src/main/scala/firrtl/WIR.scala
@@ -26,18 +26,7 @@ case object SinkFlow extends Flow
 case object DuplexFlow extends Flow
 case object UnknownFlow extends Flow
 
-private[firrtl] trait GenderFromFlow { this: Expression =>
-  val flow: Flow
-  @deprecated("Migrate from 'Gender' to 'Flow'. This method will be removed in 1.3.", "1.2")
-  def gender: Gender = flow match {
-    case SourceFlow  => MALE
-    case SinkFlow    => FEMALE
-    case DuplexFlow  => BIGENDER
-    case UnknownFlow => UNKNOWNGENDER
-  }
-}
-
-case class WRef(name: String, tpe: Type, kind: Kind, flow: Flow) extends Expression with GenderFromFlow {
+case class WRef(name: String, tpe: Type, kind: Kind, flow: Flow) extends Expression {
   def serialize: String = name
   def mapExpr(f: Expression => Expression): Expression = this
   def mapType(f: Type => Type): Expression = this.copy(tpe = f(tpe))
@@ -62,7 +51,7 @@ object WRef {
   /** Creates a WRef from an arbitrary string name */
   def apply(n: String, t: Type = UnknownType, k: Kind = ExpKind): WRef = new WRef(n, t, k, UnknownFlow)
 }
-case class WSubField(expr: Expression, name: String, tpe: Type, flow: Flow) extends Expression with GenderFromFlow {
+case class WSubField(expr: Expression, name: String, tpe: Type, flow: Flow) extends Expression {
   def serialize: String = s"${expr.serialize}.$name"
   def mapExpr(f: Expression => Expression): Expression = this.copy(expr = f(expr))
   def mapType(f: Type => Type): Expression = this.copy(tpe = f(tpe))
@@ -75,7 +64,7 @@ object WSubField {
   def apply(expr: Expression, n: String): WSubField = new WSubField(expr, n, field_type(expr.tpe, n), UnknownFlow)
   def apply(expr: Expression, name: String, tpe: Type): WSubField = new WSubField(expr, name, tpe, UnknownFlow)
 }
-case class WSubIndex(expr: Expression, value: Int, tpe: Type, flow: Flow) extends Expression with GenderFromFlow {
+case class WSubIndex(expr: Expression, value: Int, tpe: Type, flow: Flow) extends Expression {
   def serialize: String = s"${expr.serialize}[$value]"
   def mapExpr(f: Expression => Expression): Expression = this.copy(expr = f(expr))
   def mapType(f: Type => Type): Expression = this.copy(tpe = f(tpe))
@@ -84,7 +73,7 @@ case class WSubIndex(expr: Expression, value: Int, tpe: Type, flow: Flow) extend
   def foreachType(f: Type => Unit): Unit = f(tpe)
   def foreachWidth(f: Width => Unit): Unit = Unit
 }
-case class WSubAccess(expr: Expression, index: Expression, tpe: Type, flow: Flow) extends Expression with GenderFromFlow {
+case class WSubAccess(expr: Expression, index: Expression, tpe: Type, flow: Flow) extends Expression {
   def serialize: String = s"${expr.serialize}[${index.serialize}]"
   def mapExpr(f: Expression => Expression): Expression = this.copy(expr = f(expr), index = f(index))
   def mapType(f: Type => Type): Expression = this.copy(tpe = f(tpe))

--- a/src/main/scala/firrtl/package.scala
+++ b/src/main/scala/firrtl/package.scala
@@ -15,27 +15,4 @@ package object firrtl {
 
   @deprecated("Use firrtl.stage.TargetDirAnnotation", "1.2")
   val TargetDirAnnotation = firrtl.options.TargetDirAnnotation
-
-  @deprecated("Use Flow instead of Gender. This trait will be removed in 1.3", "1.2")
-  trait Gender
-
-  @deprecated("Use SourceFlow instead of MALE. This case object will be removed in 1.3", "1.2")
-  case object MALE extends Gender
-
-  @deprecated("Use SinkFlow instead of FEMALE. This case object will be removed in 1.3", "1.2")
-  case object FEMALE extends Gender
-
-  @deprecated("Use DuplexFlow instead of BIGENDER. This case object will be removed in 1.3", "1.2")
-  case object BIGENDER extends Gender
-
-  @deprecated("Use UnknownFlow instead of UNKNOWNGENDER. This case object will be removed in 1.3", "1.2")
-  case object UNKNOWNGENDER extends Gender
-
-  @deprecated("Please migrate from 'Gender' to 'Flow'. This implicit conversion will be removed in 1.3", "1.2")
-  implicit def genderToFlow(gender: Gender): Flow = gender match {
-    case MALE          => SourceFlow
-    case FEMALE        => SinkFlow
-    case BIGENDER      => DuplexFlow
-    case UNKNOWNGENDER => UnknownFlow
-  }
 }

--- a/src/main/scala/firrtl/passes/Checks.scala
+++ b/src/main/scala/firrtl/passes/Checks.scala
@@ -731,19 +731,3 @@ object CheckFlows extends Pass with PreservesAll[Transform] {
   }
 }
 
-@deprecated("Use 'CheckFlows'. This object will be removed in 1.3", "1.2")
-object CheckGenders {
-
-  implicit def toStr(g: Gender): String = g match {
-    case MALE => "source"
-    case FEMALE => "sink"
-    case UNKNOWNGENDER => "unknown"
-    case BIGENDER => "sourceOrSink"
-  }
-
-  def run(c: Circuit): Circuit = CheckFlows.run(c)
-
-  @deprecated("Use 'CheckFlows.WrongFlow'. This class will be removed in 1.3", "1.2")
-  class WrongGender(info:Info, mname: String, expr: String, wrong: Flow, right: Flow) extends PassException(
-    s"$info: [module $mname]  Expression $expr is used as a $wrong but can only be used as a $right.")
-}

--- a/src/main/scala/firrtl/passes/RemoveIntervals.scala
+++ b/src/main/scala/firrtl/passes/RemoveIntervals.scala
@@ -173,7 +173,7 @@ class RemoveIntervals extends Pass with PreservesAll[Transform] {
     case DefNode(info, name, value) => value.tpe match {
       case IntervalType(l, u, p) =>
         val newType = IntervalType(l, u, p)
-        Block(Seq(DefWire(info, name, newType), Connect(info, WRef(name, newType, WireKind, FEMALE), value)))
+        Block(Seq(DefWire(info, name, newType), Connect(info, WRef(name, newType, WireKind, SinkFlow), value)))
       case other => s
     }
     case other => other map makeWireStmt

--- a/src/main/scala/firrtl/passes/Resolves.scala
+++ b/src/main/scala/firrtl/passes/Resolves.scala
@@ -88,17 +88,6 @@ object ResolveFlows extends Pass with PreservesAll[Transform] {
     c copy (modules = c.modules map resolve_flow)
 }
 
-@deprecated("Use 'ResolveFlows'. This will be removed in 1.3", "1.2")
-object ResolveGenders extends Pass {
-
-  def run(c: Circuit): Circuit = ResolveFlows.run(c)
-
-  def resolve_e(g: Gender)(e: Expression): Expression = ResolveFlows.resolve_e(g)(e)
-
-  def resolve_s(s: Statement): Statement = ResolveFlows.resolve_s(s)
-
-}
-
 object CInferMDir extends Pass with PreservesAll[Transform] {
 
   override val prerequisites = firrtl.stage.Forms.ChirrtlForm :+ Dependency(CInferTypes)

--- a/src/main/scala/firrtl/transforms/SimplifyMems.scala
+++ b/src/main/scala/firrtl/transforms/SimplifyMems.scala
@@ -28,8 +28,7 @@ class SimplifyMems extends Transform {
     val mTarget = ModuleTarget(c.main, m.name)
 
     def onExpr(e: Expression): Expression = e.map(onExpr) match {
-      case WRef(name, tpe, MemKind, gender) if memAdapters.contains(name) =>
-        WRef(name, tpe, WireKind, gender)
+      case wr @ WRef(name, _, MemKind, _) if memAdapters.contains(name) => wr.copy(kind = WireKind)
       case e => e
     }
 

--- a/src/test/scala/firrtlTests/interval/IntervalSpec.scala
+++ b/src/test/scala/firrtlTests/interval/IntervalSpec.scala
@@ -41,7 +41,7 @@ class IntervalSpec extends FirrtlFlatSpec {
   }
 
   "Interval types" should "infer bp correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, new InferBinaryPoints())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveFlows, new InferBinaryPoints())
     val input =
       """circuit Unit :
         |  module Unit :
@@ -62,7 +62,7 @@ class IntervalSpec extends FirrtlFlatSpec {
   }
 
   "Interval types" should "trim known intervals correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, new InferBinaryPoints(), new TrimIntervals())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveFlows, new InferBinaryPoints(), new TrimIntervals())
     val input =
       """circuit Unit :
         |  module Unit :
@@ -83,7 +83,7 @@ class IntervalSpec extends FirrtlFlatSpec {
   }
 
   "Interval types" should "infer intervals correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, new InferBinaryPoints(), new TrimIntervals(), new InferWidths())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveFlows, new InferBinaryPoints(), new TrimIntervals(), new InferWidths())
     val input =
       """circuit Unit :
         |  module Unit :
@@ -104,7 +104,7 @@ class IntervalSpec extends FirrtlFlatSpec {
   }
 
   "Interval types" should "be removed correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, new InferBinaryPoints(), new TrimIntervals(), new InferWidths(), new RemoveIntervals())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveFlows, new InferBinaryPoints(), new TrimIntervals(), new InferWidths(), new RemoveIntervals())
     val input =
       """circuit Unit :
         |  module Unit :
@@ -133,7 +133,7 @@ class IntervalSpec extends FirrtlFlatSpec {
   }
 
 "Interval types" should "infer multiplication by zero correctly" in {
-  val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, new InferBinaryPoints(), new TrimIntervals(), new InferWidths())
+  val passes = Seq(ToWorkingIR, InferTypes, ResolveFlows, new InferBinaryPoints(), new TrimIntervals(), new InferWidths())
     val input =
       s"""circuit Unit :
       |  module Unit :
@@ -147,7 +147,7 @@ class IntervalSpec extends FirrtlFlatSpec {
 }
 
   "Interval types" should "infer muxes correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, new InferBinaryPoints(), new TrimIntervals(), new InferWidths())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveFlows, new InferBinaryPoints(), new TrimIntervals(), new InferWidths())
       val input =
         s"""circuit Unit :
         |  module Unit :
@@ -161,7 +161,7 @@ class IntervalSpec extends FirrtlFlatSpec {
     executeTest(input, check.split("\n") map normalized, passes)
   }
   "Interval types" should "infer dshl correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveKinds, ResolveGenders, new InferBinaryPoints(), new TrimIntervals, new InferWidths())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveKinds, ResolveFlows, new InferBinaryPoints(), new TrimIntervals, new InferWidths())
       val input =
         s"""circuit Unit :
         |  module Unit :
@@ -174,7 +174,7 @@ class IntervalSpec extends FirrtlFlatSpec {
     executeTest(input, check.split("\n") map normalized, passes)
   }
   "Interval types" should "infer asInterval correctly" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, new InferWidths())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveFlows, new InferWidths())
       val input =
         s"""circuit Unit :
         |  module Unit :
@@ -318,7 +318,7 @@ class IntervalSpec extends FirrtlFlatSpec {
     executeTest(input, check.split("\n") map normalized, passes)
   }
   "Interval types" should "remove negative binary points" in {
-    val passes = Seq(ToWorkingIR, InferTypes, ResolveGenders, new InferBinaryPoints(), new TrimIntervals(), new InferWidths(), new RemoveIntervals())
+    val passes = Seq(ToWorkingIR, InferTypes, ResolveFlows, new InferBinaryPoints(), new TrimIntervals(), new InferWidths(), new RemoveIntervals())
       val input =
         s"""circuit Unit :
         |  module Unit :


### PR DESCRIPTION
**Type of change:** API modification
**API impact:** removes already-deprecated "gender" code per warning
**Backend code-generation impact:** none

Unlike all the other deprecations, this one is actually very easy to push through, since the one-to-one adapter code was already put in for 1.2 and nearly all internal uses were switched.

We either need to do this for 1.3.0 or change all the deprecation warning messages. I think it might be worthwhile to actually go ahead with removal so we can hold to the schedule, given how straightforward this is.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you mark as `Please Merge`?
