### PR TITLE
Verilog Emitter: move asyncInitials inside initial block RANDOMIZE ifdef

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -563,10 +563,13 @@ class VerilogEmitter extends SeqTransform with Emitter {
     //   if (reset) ...
     // There is a fundamental mismatch between this representation which treats async reset
     // registers as edge-triggered when in reality they are level-triggered.
-    // This can result in silicon-simulation mismatch in the case where async reset is held high
+    // When not randomized, there is no mismatch because the async reset transition at the start
+    // of simulation from X to 1 triggers the posedge block for async reset.
+    // When randomized, this can result in silicon-simulation mismatch when async reset is held high
     // upon power on with no clock, then async reset is dropped before the clock starts. In this
     // circumstance, the async reset register will be randomized in simulation instead of being
-    // reset. To fix this, we need extra initial block logic for async reset registers
+    // reset. To fix this, we need extra initial block logic to reset async reset registers again
+    // post-randomize.
     val asyncInitials = ArrayBuffer[Seq[Any]]()
     val simulates = ArrayBuffer[Seq[Any]]()
 
@@ -993,8 +996,8 @@ class VerilogEmitter extends SeqTransform with Emitter {
         emit(Seq("      `endif"))
         emit(Seq("    `endif"))
         for (x <- initials) emit(Seq(tab, x))
-        emit(Seq("  `endif // RANDOMIZE"))
         for (x <- asyncInitials) emit(Seq(tab, x))
+        emit(Seq("  `endif // RANDOMIZE"))
         emit(Seq("end // initial"))
         emit(Seq("`endif // SYNTHESIS"))
       }


### PR DESCRIPTION
### Contributor Checklist
- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [X] Did you delete any extraneous printlns/debugging code?
- [X] Did you specify the type of improvement?
- [X] Did you state the API impact?
- [X] Did you specify the code generation impact?
- [X] Did you request a desired merge strategy?
- [X] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- bug fix
- backend code generation

#### API Impact
bug fix to Verilog emitter

#### Backend Code Generation Impact
There is an excellent comment at https://github.com/freechipsproject/firrtl/blob/2272044c6ab46b5148c39c124e66e1a8e9073a24/src/main/scala/firrtl/Emitter.scala#L423-L432

Re-iterating: this scenario is when the async reset register will be randomized in simulation **_and then_** async reset is dropped before the clock starts.

Some emulation platforms (a hybrid of simulation and fpga synthesis) which define RANDOMIZE=**false** and SYNTHESIS=false throw a compiler error on this: "Illegal construct in initial block which is not a clock generator, reset generator or a clocked process."

The fix is to only post-randomize force asyncInitials in the initial block **_if_** the async reset register was randomized in simulation.

old:
```
  `endif // RANDOMIZE_REG_INIT
  `endif // RANDOMIZE
  if (_T_20) begin
    _T_22 = 1'h1;
  end
end // initial
`endif // SYNTHESIS
```
new:
```
  `endif // RANDOMIZE_REG_INIT
  if (_T_20) begin
    _T_22 = 1'h1;
  end
  `endif // RANDOMIZE
end // initial
`endif // SYNTHESIS
```

#### Desired Merge Strategy
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
Fix emulator compile error "Illegal construct in initial block which is not a clock generator, reset generator or a clocked process." for asynchronous reset registers when `ifdef RANDOMIZE` is not defined set.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
