### PR TITLE
Fix mixed -E and -e emission

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -143,10 +143,10 @@ sealed abstract class FirrtlEmitter(form: CircuitForm) extends Transform with Em
 
   override def execute(state: CircuitState): CircuitState = {
     val newAnnos = state.annotations.flatMap {
-      case EmitCircuitAnnotation(_) =>
+      case EmitCircuitAnnotation(a) if this.getClass == a =>
         Seq(EmittedFirrtlCircuitAnnotation(
               EmittedFirrtlCircuit(state.circuit.main, state.circuit.serialize, outputSuffix)))
-      case EmitAllModulesAnnotation(_) =>
+      case EmitAllModulesAnnotation(a) if this.getClass == a =>
         emitAllModules(state.circuit) map (EmittedFirrtlModuleAnnotation(_))
       case _ => Seq()
     }
@@ -1077,12 +1077,12 @@ class VerilogEmitter extends SeqTransform with Emitter {
 
   override def execute(state: CircuitState): CircuitState = {
     val newAnnos = state.annotations.flatMap {
-      case EmitCircuitAnnotation(_) =>
+      case EmitCircuitAnnotation(a) if this.getClass == a =>
         val writer = new java.io.StringWriter
         emit(state, writer)
         Seq(EmittedVerilogCircuitAnnotation(EmittedVerilogCircuit(state.circuit.main, writer.toString, outputSuffix)))
 
-      case EmitAllModulesAnnotation(_) =>
+      case EmitAllModulesAnnotation(a) if this.getClass == a =>
         val cs = runTransforms(state)
         val emissionOptions = new EmissionOptions(cs.annotations)
         val moduleMap = cs.circuit.modules.map(m => m.name -> m).toMap

--- a/src/test/scala/firrtlTests/stage/FirrtlMainSpec.scala
+++ b/src/test/scala/firrtlTests/stage/FirrtlMainSpec.scala
@@ -22,11 +22,12 @@ class FirrtlMainSpec extends AnyFeatureSpec with GivenWhenThen with Matchers wit
     with BackendCompilationUtilities {
 
   /** Parameterizes one test of [[FirrtlMain]]. Running the [[FirrtlMain]] `main` with certain args should produce
-    * certain files.
+    * certain files and not produce others.
     * @param args arguments to pass
     * @param circuit a [[FirrtlCircuitFixture]] to use. This will generate an appropriate '-i $targetDir/$main.fi'
     * argument.
     * @param files expected files that will be created
+    * @param files files that should NOT be created
     * @param stdout expected stdout string, None if no output expected
     * @param stderr expected stderr string, None if no output expected
     * @param result expected exit code
@@ -35,6 +36,7 @@ class FirrtlMainSpec extends AnyFeatureSpec with GivenWhenThen with Matchers wit
     args: Array[String],
     circuit: Option[FirrtlCircuitFixture] = Some(new SimpleFirrtlCircuitFixture),
     files: Seq[String] = Seq.empty,
+    notFiles: Seq[String] = Seq.empty,
     stdout: Option[String] = None,
     stderr: Option[String] = None,
     result: Int = 0) {
@@ -66,6 +68,7 @@ class FirrtlMainSpec extends AnyFeatureSpec with GivenWhenThen with Matchers wit
       }
 
       p.files.foreach( f => new File(td.buildDir + s"/$f").delete() )
+      p.notFiles.foreach( f => new File(td.buildDir + s"/$f").delete() )
 
       When(s"""the user tries to compile with '${p.argsString}'""")
       val (stdout, stderr, result) =
@@ -102,6 +105,12 @@ class FirrtlMainSpec extends AnyFeatureSpec with GivenWhenThen with Matchers wit
         And(s"file '$f' should be emitted in the target directory")
         val out = new File(td.buildDir + s"/$f")
         out should (exist)
+      }
+
+      p.notFiles.foreach { f =>
+        And(s"file '$f' should NOT be emitted in the target directory")
+        val out = new File(td.buildDir + s"/$f")
+        out should not (exist)
       }
     }
   }
@@ -206,6 +215,11 @@ class FirrtlMainSpec extends AnyFeatureSpec with GivenWhenThen with Matchers wit
       FirrtlMainTest(args   = Array("-X", "sverilog", "-e", "sverilog"),
                       files  = Seq("Top.sv", "Child.sv"),
                       stdout = Some("SystemVerilog Compiler behaves the same as the Verilog Compiler!")),
+
+      /* Test mixing of -E with -e */
+      FirrtlMainTest(args     = Array("-X", "middle", "-E", "high", "-e", "middle"),
+                     files    = Seq("Top.hi.fir", "Top.mid.fir", "Child.mid.fir"),
+                     notFiles = Seq("Child.hi.fir")),
 
       /* Test changes to output file name */
       FirrtlMainTest(args   = Array("-X", "none", "-E", "chirrtl", "-o", "foo"),


### PR DESCRIPTION
This corrects the behavior when you do something like `./firrtl -E high -e middle`. Previously (see #1511), this would cause both emitters to use the same style (one-file-per-module or one-file). This PR adds a check that the emitter class actually matches the class stored in the annotation before doing emission.

To test this, the PR adds the ability to check that certain files are not emitted.

Fixes #1511.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix                            
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

No impact.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->


None.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Fix bug in mixed -e/-E emission

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- ~[ ] Did you mark as `Please Merge`?~
