### PR TITLE
Always run PadWidths when generating Verilog

### DIFF
--- a/src/main/scala/firrtl/passes/PadWidths.scala
+++ b/src/main/scala/firrtl/passes/PadWidths.scala
@@ -17,8 +17,9 @@ object PadWidths extends Pass {
     ((new mutable.LinkedHashSet())
        ++ firrtl.stage.Forms.LowForm
        - Dependency(firrtl.passes.Legalize)
-       + Dependency(firrtl.passes.RemoveValidIf)
-       + Dependency[firrtl.transforms.ConstantPropagation]).toSeq
+       + Dependency(firrtl.passes.RemoveValidIf)).toSeq
+
+  override val optionalPrerequisites = Seq(Dependency[firrtl.transforms.ConstantPropagation])
 
   override val dependents =
     Seq( Dependency(firrtl.passes.memlib.VerilogMemDelays),

--- a/src/main/scala/firrtl/stage/Forms.scala
+++ b/src/main/scala/firrtl/stage/Forms.scala
@@ -67,12 +67,12 @@ object Forms {
 
   val LowFormMinimumOptimized: Seq[TransformDependency] = LowForm ++
     Seq( Dependency(passes.RemoveValidIf),
+         Dependency(passes.PadWidths),
          Dependency(passes.memlib.VerilogMemDelays),
          Dependency(passes.SplitExpressions) )
 
   val LowFormOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
     Seq( Dependency[firrtl.transforms.ConstantPropagation],
-         Dependency(passes.PadWidths),
          Dependency[firrtl.transforms.CombineCats],
          Dependency(passes.CommonSubexpressionElimination),
          Dependency[firrtl.transforms.DeadCodeElimination] )

--- a/src/test/scala/firrtlTests/CompilerTests.scala
+++ b/src/test/scala/firrtlTests/CompilerTests.scala
@@ -158,16 +158,21 @@ class MinimumVerilogCompilerSpec extends CompilerSpec with Matchers {
   val input = """|circuit Top:
                  |  module Top:
                  |    output b: UInt<1>[3]
+                 |    input i: SInt<3>
+                 |    output o: SInt<5>
                  |    node c = bits(UInt<3>("h7"), 2, 2)
                  |    node d = shr(UInt<3>("h7"), 2)
                  |    b[0] is invalid
                  |    b[1] <= c
                  |    b[2] <= d
+                 |    o <= i
                  |""".stripMargin
   val check = """|module Top(
-                 |  output  b_0,
-                 |  output  b_1,
-                 |  output  b_2
+                 |  output       b_0,
+                 |  output       b_1,
+                 |  output       b_2,
+                 |  input  [2:0] i,
+                 |  output [4:0] o
                  |);
                  |  wire  c;
                  |  wire  d;
@@ -176,11 +181,12 @@ class MinimumVerilogCompilerSpec extends CompilerSpec with Matchers {
                  |  assign b_0 = 1'h0;
                  |  assign b_1 = c;
                  |  assign b_2 = d;
+                 |  assign o = {{2{i[2]}},i};
                  |endmodule
                  |""".stripMargin
   def compiler = new MinimumVerilogCompiler()
 
-  "A circuit's minimum Verilog output" should "not have constants propagated or dead code eliminated" in {
+  "A circuit's minimum Verilog output" should "pad signed RHSes but not reflect any const-prop or DCE" in {
     getOutput should be (check)
   }
 }

--- a/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
+++ b/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
@@ -102,6 +102,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       new firrtl.transforms.DeadCodeElimination)
     case _: MinimumLowFirrtlOptimization => Seq(
       passes.RemoveValidIf,
+      passes.PadWidths,
       passes.Legalize,
       passes.memlib.VerilogMemDelays, // TODO move to Verilog emitter
       passes.SplitExpressions)


### PR DESCRIPTION
**Type of change:** bugfix
**API impact:** none
**Backend code-generation impact:** avoids generating legal but incorrect Verilog under `mverilog`
**Desired merge strategy:** rebase
**Release notes:**
The PadWidths transform is now included in the mverilog compiler, reflecting the fact that it is a mandatory component of the current Verilog emission strategy.

Currently (in both 1.2 and master), `PadWidths` is not run under `mverilog`, which results in the following FIRRTL input:
```
circuit sign_ext:
  module sign_ext:
    input i: SInt<3>
    output o: SInt<5>
    o <= i
```
producing the following (incorrect) Verilog that lacks sign-extension.
```
module sign_ext(
  input  [2:0] i,
  output [4:0] o
);
  assign o = i;
endmodule
```

This PR adds `PadWidths` to `LowFormMinimumOptimized`, which fixes the test case while leaving `PadWidths` as close as possible to its standard position in the standard Verilog compiler. It also adds the above pattern as part of the test case for `mverilog`.

The presence of this problem is why #853 is failing CI -- not only does it update how Yosys equivalence tests are run, it also adds new equivalence `scalatest`s that rely on `mverilog`, which causes a true-positive LEC failure.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
