### PR TITLE
Prevent infinite recursion in CheckResets

### DIFF
--- a/src/test/scala/firrtlTests/AsyncResetSpec.scala
+++ b/src/test/scala/firrtlTests/AsyncResetSpec.scala
@@ -117,6 +117,20 @@ class AsyncResetSpec extends FirrtlFlatSpec {
     }
   }
 
+  "Self-inits" should "NOT cause infinite loops in CheckResets" in {
+    val result = compileBody(s"""
+        |input clock : Clock
+        |input reset : AsyncReset
+        |input in : UInt<12>
+        |output out : UInt<10>
+        |
+        |reg a : UInt<10>, clock with :
+        |  reset => (reset, a)
+        |out <= UInt<5>("h15")""".stripMargin
+      )
+    result should containLine("assign out = 10'h15;")
+  }
+
   "Late non-literals connections" should "NOT be allowed as reset values for AsyncReset" in {
     an [checks.CheckResets.NonLiteralAsyncResetValueException] shouldBe thrownBy {
       compileBody(s"""


### PR DESCRIPTION
**Type of improvement:** bug fix
**API impact:** none
**Backend code-generation impact:** none
**Desired merge strategy:** rebase

A self-init async reset register can lead to a non-combinational dependency loop that is (necessarily) not flagged by `CheckCombLoops`. This leads to infinite recursion in `CheckResets`, as found in #1516 by @grebe.

Funnily enough, the `@tailrec` seems to make it just hang rather than overflowing the stack :)

This PR:
- Cleans up the logic to avoid infinite loops
- Explicitly handles the self-init case
- Adds the circuit from #1516 as a testcase

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
