### PR TITLE
Create new scopes for child statements of Conditionally

### DIFF
--- a/src/main/scala/firrtl/passes/CheckHighForm.scala
+++ b/src/main/scala/firrtl/passes/CheckHighForm.scala
@@ -12,6 +12,21 @@ import firrtl.options.Dependency
 trait CheckHighFormLike { this: Pass =>
   type NameSet = collection.mutable.HashSet[String]
 
+  private object ScopeView {
+    def apply(): ScopeView = new ScopeView(new NameSet, List(new NameSet))
+  }
+
+  private class ScopeView private (moduleNS: NameSet, scopes: List[NameSet]) {
+    require(scopes.nonEmpty)
+    def declare(name: String): Unit = {
+      moduleNS += name
+      scopes.head += name
+    }
+    def legalDecl(name: String): Boolean = !moduleNS.contains(name)
+    def legalRef(name: String): Boolean = scopes.exists(_.contains(name))
+    def childScope(): ScopeView = new ScopeView(moduleNS, new NameSet +: scopes)
+  }
+
   // Custom Exceptions
   class NotUniqueException(info: Info, mname: String, name: String) extends PassException(
     s"$info: [module $mname] Reference $name does not have a unique name.")
@@ -176,11 +191,11 @@ trait CheckHighFormLike { this: Pass =>
       }
     }
 
-    def checkHighFormE(info: Info, mname: String, names: NameSet)(e: Expression): Unit = {
+    def checkHighFormE(info: Info, mname: String, names: ScopeView)(e: Expression): Unit = {
       e match {
-        case ex: Reference if !names(ex.name) =>
+        case ex: Reference if !names.legalRef(ex.name) =>
           errors.append(new UndeclaredReferenceException(info, mname, ex.name))
-        case ex: WRef if !names(ex.name) =>
+        case ex: WRef if !names.legalRef(ex.name) =>
           errors.append(new UndeclaredReferenceException(info, mname, ex.name))
         case ex: UIntLiteral if ex.value < 0 =>
           errors.append(new NegUIntException(info, mname))
@@ -194,10 +209,10 @@ trait CheckHighFormLike { this: Pass =>
       e foreach checkHighFormE(info, mname, names)
     }
 
-    def checkName(info: Info, mname: String, names: NameSet)(name: String): Unit = {
-      if (names(name))
+    def checkName(info: Info, mname: String, names: ScopeView)(name: String): Unit = {
+      if (!names.legalDecl(name))
         errors.append(new NotUniqueException(info, mname, name))
-      names += name
+      names.declare(name)
     }
 
     def checkInstance(info: Info, child: String, parent: String): Unit = {
@@ -209,7 +224,7 @@ trait CheckHighFormLike { this: Pass =>
         errors.append(new InstanceLoop(info, parent, childToParent mkString "->"))
     }
 
-    def checkHighFormS(minfo: Info, mname: String, names: NameSet)(s: Statement): Unit = {
+    def checkHighFormS(minfo: Info, mname: String, names: ScopeView)(s: Statement): Unit = {
       val info = get_info(s) match {case NoInfo => minfo case x => x}
       s foreach checkName(info, mname, names)
       s match {
@@ -233,13 +248,18 @@ trait CheckHighFormLike { this: Pass =>
       }
       s foreach checkHighFormT(info, mname)
       s foreach checkHighFormE(info, mname, names)
-      s foreach checkHighFormS(minfo, mname, names)
+      s match {
+        case Conditionally(_,_, conseq, alt) =>
+          checkHighFormS(minfo, mname, names.childScope())(conseq)
+          checkHighFormS(minfo, mname, names.childScope())(alt)
+        case _ => s foreach checkHighFormS(minfo, mname, names)
+      }
     }
 
-    def checkHighFormP(mname: String, names: NameSet)(p: Port): Unit = {
-      if (names(p.name))
+    def checkHighFormP(mname: String, names: ScopeView)(p: Port): Unit = {
+      if (!names.legalDecl(p.name))
         errors.append(new NotUniqueException(NoInfo, mname, p.name))
-      names += p.name
+      names.declare(p.name)
       checkHighFormT(p.info, mname)(p.tpe)
     }
 
@@ -255,7 +275,7 @@ trait CheckHighFormLike { this: Pass =>
     }
 
     def checkHighFormM(m: DefModule): Unit = {
-      val names = new NameSet
+      val names = ScopeView()
       m foreach checkHighFormP(m.name, names)
       m foreach checkHighFormS(m.info, m.name, names)
       m match {

--- a/src/test/resources/features/ChirrtlMems.fir
+++ b/src/test/resources/features/ChirrtlMems.fir
@@ -14,13 +14,13 @@ circuit ChirrtlMems :
     raddr <= add(raddr, UInt(1))
     infer mport r = ram[raddr], newClock
 
+    reg waddr : UInt<4>, clock with : (reset => (reset, UInt(0)))
+    waddr <= add(waddr, UInt(1))
+
     when wen :
       node newerClock = clock
-      reg waddr : UInt<4>, clock with : (reset => (reset, UInt(0)))
-      waddr <= add(waddr, UInt(1))
       infer mport w = ram[waddr], newerClock
       w <= waddr
-
       when eq(waddr, UInt(0)) :
         raddr <= UInt(0)
 

--- a/src/test/scala/firrtlTests/CheckSpec.scala
+++ b/src/test/scala/firrtlTests/CheckSpec.scala
@@ -352,6 +352,53 @@ class CheckSpec extends AnyFlatSpec with Matchers {
     }
   }
 
+  "Conditionally statements" should "create a new scope" in {
+    val input =
+      s"""|circuit scopes:
+          |  module scopes:
+          |    input i: UInt<1>
+          |    output o: UInt<1>
+          |    when i:
+          |      node x = not(i)
+          |    o <= and(x, i)
+          |""".stripMargin
+    assertThrows[CheckHighForm.UndeclaredReferenceException] {
+      checkHighInput(input)
+    }
+  }
+
+  "Attempting to shadow a component name" should "throw an error" in {
+    val input =
+      s"""|circuit scopes:
+          |  module scopes:
+          |    input i: UInt<1>
+          |    output o: UInt<1>
+          |    wire x: UInt<1>
+          |    when i:
+          |      node x = not(i)
+          |    o <= and(x, i)
+          |""".stripMargin
+    assertThrows[CheckHighForm.NotUniqueException] {
+      checkHighInput(input)
+    }
+  }
+
+  "Conditionally statements" should "create separate consequent and alternate scopes" in {
+    val input =
+      s"""|circuit scopes:
+          |  module scopes:
+          |    input i: UInt<1>
+          |    output o: UInt<1>
+          |    o <= i
+          |    when i:
+          |      node x = not(i)
+          |    else:
+          |      o <= and(x, i)
+          |""".stripMargin
+    assertThrows[CheckHighForm.UndeclaredReferenceException] {
+      checkHighInput(input)
+    }
+  }
 }
 
 object CheckSpec {

--- a/test/integration/RightShiftTester.fir
+++ b/test/integration/RightShiftTester.fir
@@ -37,8 +37,8 @@ circuit RightShiftTester :
     dut.clock <= clock
     dut.reset <= reset
     reg T_6 : UInt<2>, clock with : (reset => (reset, UInt<2>("h00")))
+    node T_8 = eq(T_6, UInt<2>("h03"))
     when UInt<1>("h01") :
-      node T_8 = eq(T_6, UInt<2>("h03"))
       node T_10 = and(UInt<1>("h00"), T_8)
       node T_13 = add(T_6, UInt<1>("h01"))
       node T_14 = tail(T_13, 1)


### PR DESCRIPTION
**Type of change:** bug fix
**API impact:** changes what FIRRTL is accepted by the compiler
**Backend code-generation impact:** none for circuits that are still accepted
**Desired merge strategy:** merge
**Release notes:**
Unlike prior versions of FIRRTL, which did not implement new block scopes for the consequent and alternate child statements of a Conditionally (when) statement, declarations inside a child scope are not visible in the parent scope. This aligns the implementation with the specification.

* Fixes #1505 
* UPDATE: I added a behavior to support current CHIRRTL mem emission while being otherwise as strict as possible. It does rely on the Counter fix in freechipsproject/chisel3#1408, so it should still be on a major version.
* We can drop the adapter for 1.4.0 with the inferred mport re-implementation

~~I left in the failing tests as they illustrate the fact that CHIRRTL memory emission relies on the same buggy pattern as the Counter previously did. When an `mport` is declared inside a when, it is referenced outside the enclosing scope in several tests, which reflects a (now-illegal) idiom for unconditionally viewing the result of a read. However, I did manually fixup the `RightShiftExecutionTest` to reflect the fix for `Counter` in freechipsproject/chisel3#1408.~~

~~Since this would cause huge backwards incompatibilities at the CHIRRTL level, it probably makes sense to combine this with the upcoming CHIRRTL `mport` refactor and define a new pattern that doesn't rely on out-of-scope references.~~

I blended a little immutable management of the scope levels into the code to try to encapsulate things without having to refactor too much of `CheckHighForm`. It can benchmark this against the alternate approach of a flat mutable set with explicit deletion on scope exit, but I don't suspect either will be a bottleneck.

### Contributor Checklist
- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
