### PR TITLE
Check width for asClock / asAsyncReset

### DIFF
--- a/src/main/scala/firrtl/passes/CheckWidths.scala
+++ b/src/main/scala/firrtl/passes/CheckWidths.scala
@@ -66,10 +66,10 @@ object CheckWidths extends Pass with PreservesAll[Transform] {
         case (IntWidth(width), _) if width >= MaxWidth =>
           errors.append(new WidthTooBig(info, target.serialize, width))
         case (w: IntWidth, f: FixedType) if (w.width < 0 && w.width == f.width) =>
-          errors append new NegWidthException(info, target.serialize)
+          errors.append(new NegWidthException(info, target.serialize))
         case (_: IntWidth, _) =>
         case _ =>
-          errors append new UninferredWidth(info, target.prettyPrint("    "))
+          errors.append(new UninferredWidth(info, target.prettyPrint("    ")))
       }
     }
 
@@ -85,21 +85,21 @@ object CheckWidths extends Pass with PreservesAll[Transform] {
         //Supports when l = u (if closed)
         case i@IntervalType(Closed(l), Closed(u), IntWidth(_)) if l <= u => i
         case i:IntervalType if i.range == Some(Nil) =>
-          errors append new InvalidRange(info, target.prettyPrint("    "), i)
+          errors.append(new InvalidRange(info, target.prettyPrint("    "), i))
           i
         case i@IntervalType(KnownBound(l), KnownBound(u), IntWidth(p)) if l >= u =>
-          errors append new InvalidRange(info, target.prettyPrint("    "), i)
+          errors.append(new InvalidRange(info, target.prettyPrint("    "), i))
           i
         case i@IntervalType(KnownBound(_), KnownBound(_), IntWidth(_)) => i
         case i@IntervalType(_: IsKnown, _, _) =>
-          errors append new UninferredBound(info, target.prettyPrint("    "), "upper")
+          errors.append(new UninferredBound(info, target.prettyPrint("    "), "upper"))
           i
         case i@IntervalType(_, _: IsKnown, _) =>
-          errors append new UninferredBound(info, target.prettyPrint("    "), "lower")
+          errors.append(new UninferredBound(info, target.prettyPrint("    "), "lower"))
           i
         case i@IntervalType(_, _, _) =>
-          errors append new UninferredBound(info, target.prettyPrint("    "), "lower")
-          errors append new UninferredBound(info, target.prettyPrint("    "), "upper")
+          errors.append(new UninferredBound(info, target.prettyPrint("    "), "lower"))
+          errors.append(new UninferredBound(info, target.prettyPrint("    "), "upper"))
           i
         case tt => tt foreach check_width_t(info, target)
       }
@@ -113,28 +113,28 @@ object CheckWidths extends Pass with PreservesAll[Transform] {
       e match {
         case e: UIntLiteral => e.width match {
           case w: IntWidth if math.max(1, e.value.bitLength) > w.width =>
-            errors append new WidthTooSmall(info, target.serialize, e.value)
+            errors.append(new WidthTooSmall(info, target.serialize, e.value))
           case _ =>
         }
         case e: SIntLiteral => e.width match {
           case w: IntWidth if e.value.bitLength + 1 > w.width =>
-            errors append new WidthTooSmall(info, target.serialize, e.value)
+            errors.append(new WidthTooSmall(info, target.serialize, e.value))
           case _ =>
         }
         case sqz@DoPrim(Squeeze, Seq(a, b), _, IntervalType(Closed(min), Closed(max), _)) =>
           (a.tpe, b.tpe) match {
             case (IntervalType(Closed(la), Closed(ua), _), IntervalType(Closed(lb), Closed(ub), _)) if (ua < lb) || (ub < la) =>
-              errors append new DisjointSqueeze(info, target.serialize, sqz)
+              errors.append(new DisjointSqueeze(info, target.serialize, sqz))
             case other =>
           }
         case DoPrim(Bits, Seq(a), Seq(hi, lo), _) if (hasWidth(a.tpe) && bitWidth(a.tpe) <= hi) =>
-          errors append new BitsWidthException(info, target.serialize, hi, bitWidth(a.tpe), e.serialize)
+          errors.append(new BitsWidthException(info, target.serialize, hi, bitWidth(a.tpe), e.serialize))
         case DoPrim(Head, Seq(a), Seq(n), _) if (hasWidth(a.tpe) && bitWidth(a.tpe) < n) =>
-          errors append new HeadWidthException(info, target.serialize, n, bitWidth(a.tpe))
+          errors.append(new HeadWidthException(info, target.serialize, n, bitWidth(a.tpe)))
         case DoPrim(Tail, Seq(a), Seq(n), _) if (hasWidth(a.tpe) && bitWidth(a.tpe) < n) =>
-          errors append new TailWidthException(info, target.serialize, n, bitWidth(a.tpe))
+          errors.append(new TailWidthException(info, target.serialize, n, bitWidth(a.tpe)))
         case DoPrim(Dshl, Seq(a, b), _, _) if (hasWidth(a.tpe) && bitWidth(b.tpe) >= DshlMaxWidth) =>
-          errors append new DshlTooBig(info, target.serialize)
+          errors.append(new DshlTooBig(info, target.serialize))
         case DoPrim(AsClock, Seq(a), _, _) if (bitWidth(a.tpe) != 1) =>
           errors.append(new MultiBitAsClock(info, target.serialize))
         case DoPrim(AsAsyncReset, Seq(a), _, _) if (bitWidth(a.tpe) != 1) =>

--- a/src/test/scala/firrtlTests/AsyncResetSpec.scala
+++ b/src/test/scala/firrtlTests/AsyncResetSpec.scala
@@ -80,7 +80,7 @@ class AsyncResetSpec extends FirrtlFlatSpec {
       |input c : Clock
       |input d : Fixed<1><<0>>
       |input e : AsyncReset
-      |input f : Interval[0, 1].0
+      |input f : Interval[0, 0].0
       |output u : AsyncReset
       |output v : AsyncReset
       |output w : AsyncReset

--- a/src/test/scala/firrtlTests/WidthSpec.scala
+++ b/src/test/scala/firrtlTests/WidthSpec.scala
@@ -18,6 +18,17 @@ class WidthSpec extends FirrtlFlatSpec {
     }
   }
 
+  private val inferPasses = Seq(
+    ToWorkingIR,
+    CheckHighForm,
+    ResolveKinds,
+    InferTypes,
+    CheckTypes,
+    ResolveFlows,
+    new InferWidths)
+
+  private val inferAndCheckPasses = inferPasses :+ CheckWidths
+
   case class LiteralWidthCheck(lit: BigInt, uIntWidth: Option[BigInt], sIntWidth: BigInt)
   val litChecks = Seq(
     LiteralWidthCheck(-4, None, 3),
@@ -43,15 +54,6 @@ class WidthSpec extends FirrtlFlatSpec {
   }
 
   "Dshl by 20 bits" should "result in an error" in {
-    val passes = Seq(
-      ToWorkingIR,
-      CheckHighForm,
-      ResolveKinds,
-      InferTypes,
-      CheckTypes,
-      ResolveFlows,
-      new InferWidths,
-      CheckWidths)
     val input =
       """circuit Unit :
         |  module Unit :
@@ -62,38 +64,21 @@ class WidthSpec extends FirrtlFlatSpec {
     // Throws both DshlTooBig and WidthTooBig
     // TODO check message
     intercept[PassExceptions] {
-      executeTest(input, Nil, passes)
+      executeTest(input, Nil, inferAndCheckPasses)
     }
   }
+
   "Width >= MaxWidth" should "result in an error" in {
-    val passes = Seq(
-      ToWorkingIR,
-      CheckHighForm,
-      ResolveKinds,
-      InferTypes,
-      CheckTypes,
-      ResolveFlows,
-      new InferWidths,
-      CheckWidths)
     val input =
      s"""circuit Unit :
         |  module Unit :
         |    input x: UInt<${CheckWidths.MaxWidth}>
       """.stripMargin
     intercept[CheckWidths.WidthTooBig] {
-      executeTest(input, Nil, passes)
+      executeTest(input, Nil, inferAndCheckPasses)
     }
   }
   "Circular reg depending on reg + 1" should "error" in {
-    val passes = Seq(
-      ToWorkingIR,
-      CheckHighForm,
-      ResolveKinds,
-      InferTypes,
-      CheckTypes,
-      ResolveFlows,
-      new InferWidths,
-      CheckWidths)
     val input =
       """circuit Unit :
         |  module Unit :
@@ -105,19 +90,11 @@ class WidthSpec extends FirrtlFlatSpec {
         |    r <= T_7
         |""".stripMargin
     intercept[CheckWidths.UninferredWidth] {
-      executeTest(input, Nil, passes)
+      executeTest(input, Nil, inferAndCheckPasses)
     }
   }
 
   "Add of UInt<2> and SInt<2>" should "error" in {
-    val passes = Seq(
-      ToWorkingIR,
-      CheckHighForm,
-      ResolveKinds,
-      InferTypes,
-      CheckTypes,
-      ResolveFlows,
-      new InferWidths)
     val input =
       """circuit Unit :
         |  module Unit :
@@ -127,19 +104,11 @@ class WidthSpec extends FirrtlFlatSpec {
         |    z <= add(x, y)""".stripMargin
     val check = Seq( "output z : SInt<4>")
     intercept[PassExceptions] {
-      executeTest(input, check, passes)
+      executeTest(input, check, inferPasses)
     }
   }
 
   "SInt<2> - UInt<3>" should "error" in {
-    val passes = Seq(
-      ToWorkingIR,
-      CheckHighForm,
-      ResolveKinds,
-      InferTypes,
-      CheckTypes,
-      ResolveFlows,
-      new InferWidths)
     val input =
       """circuit Unit :
         |  module Unit :
@@ -149,21 +118,13 @@ class WidthSpec extends FirrtlFlatSpec {
         |    z <= sub(y, x)""".stripMargin
     val check = Seq( "output z : SInt<5>")
     intercept[PassExceptions] {
-      executeTest(input, check, passes)
+      executeTest(input, check, inferPasses)
     }
   }
 
   behavior of "CheckWidths.UniferredWidth"
 
   it should "provide a good error message with a full target if a user forgets an assign" in {
-    val passes = Seq(
-      ToWorkingIR,
-      ResolveKinds,
-      InferTypes,
-      CheckTypes,
-      ResolveFlows,
-      new InferWidths,
-      CheckWidths)
     val input =
       """|circuit Foo :
          |  module Foo :
@@ -172,7 +133,7 @@ class WidthSpec extends FirrtlFlatSpec {
          |  module Bar :
          |    wire a: { b : UInt<1>, c : { d : UInt<1>, e : UInt } }
          |""".stripMargin
-    val msg = intercept[CheckWidths.UninferredWidth] { executeTest(input, Nil, passes) }
+    val msg = intercept[CheckWidths.UninferredWidth] { executeTest(input, Nil, inferAndCheckPasses) }
       .getMessage should include ("""|    circuit Foo:
                                      |    └── module Bar:
                                      |        └── a.c.e""".stripMargin)

--- a/src/test/scala/firrtlTests/WidthSpec.scala
+++ b/src/test/scala/firrtlTests/WidthSpec.scala
@@ -68,6 +68,28 @@ class WidthSpec extends FirrtlFlatSpec {
     }
   }
 
+  "Casting a multi-bit signal to Clock" should "result in error" in {
+    val input =
+      s"""circuit Unit :
+         |  module Unit :
+         |    input i: UInt<2>
+         |    node x = asClock(i)""".stripMargin
+    intercept[CheckWidths.MultiBitAsClock] {
+        executeTest(input, Nil, inferAndCheckPasses)
+    }
+  }
+
+  "Casting a multi-bit signal to AsyncReset" should "result in error" in {
+    val input =
+      s"""circuit Unit :
+         |  module Unit :
+         |    input i: UInt<2>
+         |    node x = asAsyncReset(i)""".stripMargin
+    intercept[CheckWidths.MultiBitAsAsyncReset] {
+        executeTest(input, Nil, inferAndCheckPasses)
+    }
+  }
+
   "Width >= MaxWidth" should "result in an error" in {
     val input =
      s"""circuit Unit :


### PR DESCRIPTION
**Type of change:** bug fix
**API impact:** none
**Backend code-generation impact:** none
**Release notes:**
Any cast to AsyncReset and Clock now checks that its argument is of single-bit width.

Currently, casting a multi-bit signal to a clock or async reset is allowed; it effectively results in grabbing bit 0 through some very lint-unclean Verilog.

```
circuit weird:
  module weird:
    input i: UInt<2>
    output o: Clock
    o <= asClock(i)
```
Currently generates:
```
module weird(
  input  [1:0] i,
  output       o
);
  assign o = i;
endmodule
```

I added a couple test cases. I also did some Scala style guide code cleanup.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
