### PR TITLE
Mandatory and Optional Dependents in Dependency API

### DIFF
--- a/src/main/scala/firrtl/AddDescriptionNodes.scala
+++ b/src/main/scala/firrtl/AddDescriptionNodes.scala
@@ -87,7 +87,7 @@ class AddDescriptionNodes extends Transform with PreservesAll[Transform] {
 
   override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   def onStmt(compMap: Map[String, Seq[String]])(stmt: Statement): Statement = {
     stmt.map(onStmt(compMap)) match {

--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -185,13 +185,13 @@ trait Transform extends TransformLike[CircuitState] with DependencyAPI[Transform
   def name: String = this.getClass.getName
   /** The [[firrtl.CircuitForm]] that this transform requires to operate on */
   @deprecated(
-    "InputForm/OutputForm will be removed in 1.3. Use DependencyAPI methods (prerequisites, dependents, invalidates)",
+    "InputForm/OutputForm will be removed in 1.3. Use DependencyAPI methods (prerequisites, optionalDependents, invalidates)",
     "1.2")
   def inputForm: CircuitForm
 
   /** The [[firrtl.CircuitForm]] that this transform outputs */
   @deprecated(
-    "InputForm/OutputForm will be removed in 1.3. Use DependencyAPI methods (prerequisites, dependents, invalidates)",
+    "InputForm/OutputForm will be removed in 1.3. Use DependencyAPI methods (prerequisites, optionalDependents, invalidates)",
     "1.2")
   def outputForm: CircuitForm
 
@@ -224,7 +224,7 @@ trait Transform extends TransformLike[CircuitState] with DependencyAPI[Transform
 
   private lazy val fullCompilerSet = new mutable.LinkedHashSet[Dependency[Transform]] ++ Forms.VerilogOptimized
 
-  override def dependents: Seq[Dependency[Transform]] = {
+  override def optionalDependents: Seq[Dependency[Transform]] = {
     val lowEmitters = Dependency[LowFirrtlEmitter] :: Dependency[VerilogEmitter] :: Dependency[MinimumVerilogEmitter] ::
       Dependency[SystemVerilogEmitter] :: Nil
 

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -182,7 +182,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
 
   override val prerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   val outputSuffix = ".v"
   val tab = "  "
@@ -451,10 +451,10 @@ class VerilogEmitter extends SeqTransform with Emitter {
       case m: Module => new VerilogRender(m, moduleMap)(writer)
     }
   }
-  
-  /** 
+
+  /**
     * Store Emission option per Target
-    * Guarantee only one emission option per Target 
+    * Guarantee only one emission option per Target
     */
   private[firrtl] class EmissionOptionMap[V <: EmissionOption](val df : V) extends collection.mutable.HashMap[ReferenceTarget, V] {
     override def default(key: ReferenceTarget) = df
@@ -462,11 +462,11 @@ class VerilogEmitter extends SeqTransform with Emitter {
       if (this.contains(elem._1))
         throw EmitterException(s"Multiple EmissionOption for the target ${elem._1} (${this(elem._1)} ; ${elem._2})")
       super.+=(elem)
-    } 
+    }
   }
-  
+
   /** Provide API to retrieve EmissionOptions based on the provided [[AnnotationSeq]]
-    * 
+    *
     * @param annotations : AnnotationSeq to be searched for EmissionOptions
     *
     */
@@ -480,16 +480,16 @@ class VerilogEmitter extends SeqTransform with Emitter {
 
     def getRegisterEmissionOption(target: ReferenceTarget): RegisterEmissionOption =
       registerEmissionOption(target)
-      
+
     def getWireEmissionOption(target: ReferenceTarget): WireEmissionOption =
       wireEmissionOption(target)
-      
+
     def getPortEmissionOption(target: ReferenceTarget): PortEmissionOption =
       portEmissionOption(target)
-      
+
     def getNodeEmissionOption(target: ReferenceTarget): NodeEmissionOption =
       nodeEmissionOption(target)
-      
+
     def getConnectEmissionOption(target: ReferenceTarget): ConnectEmissionOption =
       connectEmissionOption(target)
 
@@ -582,9 +582,9 @@ class VerilogEmitter extends SeqTransform with Emitter {
     def declareVectorType(b: String, n: String, tpe: Type, size: BigInt, info: Info, preset: Expression) = {
       declares += Seq(b, " ", tpe, " ", n, " [0:", bigIntToVLit(size - 1), "] = ", preset, ";", info)
     }
-    
+
     val moduleTarget = CircuitTarget(circuitName).module(m.name)
-      
+
     // declare with initial value
     def declare(b: String, n: String, t: Type, info: Info, preset: Expression) = t match {
       case tx: VectorType =>
@@ -592,7 +592,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
       case tx =>
         declares += Seq(b, " ", tx, " ", n, " = ", preset, ";", info)
     }
-    
+
     // original declare without initial value
     def declare(b: String, n: String, t: Type, info: Info) = t match {
       case tx: VectorType =>

--- a/src/main/scala/firrtl/checks/CheckResets.scala
+++ b/src/main/scala/firrtl/checks/CheckResets.scala
@@ -39,7 +39,7 @@ class CheckResets extends Transform with PreservesAll[Transform] {
 
   override val optionalPrerequisites = Seq(Dependency[firrtl.transforms.CheckCombLoops])
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   import CheckResets._
 

--- a/src/main/scala/firrtl/options/DependencyManager.scala
+++ b/src/main/scala/firrtl/options/DependencyManager.scala
@@ -22,7 +22,7 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
 
   override lazy val prerequisites = currentState
 
-  override lazy val dependents = Seq.empty
+  override lazy val optionalDependents = Seq.empty
 
   override def invalidates(a: B): Boolean = (_currentState &~ _targets)(oToD(a))
 
@@ -119,11 +119,11 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
   }
 
   /** A directed graph consisting of prerequisites derived from only those transforms which are supposed to run. This
-    * pulls in dependents for transforms which are not in the target set.
+    * pulls in optionalDependents for transforms which are not in the target set.
     */
-  private lazy val dependentsGraph: DiGraph[B] = {
+  private lazy val optionalDependentsGraph: DiGraph[B] = {
     val v = new LinkedHashSet() ++ prerequisiteGraph.getVertices
-    DiGraph(new LinkedHashMap() ++ v.map(vv => vv -> (v & (vv.dependents.toSet).map(dToO)))).reverse
+    DiGraph(new LinkedHashMap() ++ v.map(vv => vv -> (v & (vv.optionalDependents.toSet).map(dToO)))).reverse
   }
 
   /** A directed graph of *optional* prerequisites. Each optional prerequisite is promoted to a full prerequisite if the
@@ -141,7 +141,7 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
     val edges = {
       val x = new LinkedHashMap ++ _targets
         .map(dependencyToObject)
-        .map{ a => a -> prerequisiteGraph.getVertices.filter(a._dependents(_)) }
+        .map{ a => a -> prerequisiteGraph.getVertices.filter(a._optionalDependents(_)) }
       x
         .values
         .reduce(_ ++ _)
@@ -150,8 +150,8 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
     DiGraph(edges).reverse
   }
 
-  /** A directed graph consisting of all prerequisites, including prerequisites derived from dependents */
-  lazy val dependencyGraph: DiGraph[B] = prerequisiteGraph + dependentsGraph + optionalPrerequisitesGraph
+  /** A directed graph consisting of all prerequisites, including prerequisites derived from optionalDependents */
+  lazy val dependencyGraph: DiGraph[B] = prerequisiteGraph + optionalDependentsGraph + optionalPrerequisitesGraph
 
   /** A directed graph consisting of invalidation edges */
   lazy val invalidateGraph: DiGraph[B] = {
@@ -176,7 +176,7 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
 
   /** An ordering of [[firrtl.options.TransformLike TransformLike]]s that causes the requested [[DependencyManager.targets
     * targets]] to be executed starting from the [[DependencyManager.currentState currentState]]. This ordering respects
-    * prerequisites, dependents, and invalidates of all constituent [[firrtl.options.TransformLike TransformLike]]s.
+    * prerequisites, optionalDependents, and invalidates of all constituent [[firrtl.options.TransformLike TransformLike]]s.
     * This uses an algorithm that attempts to reduce the number of re-lowerings due to invalidations. Re-lowerings are
     * implemented as new [[DependencyManager]]s.
     * @throws DependencyManagerException if a cycle exists in either the [[DependencyManager.dependencyGraph
@@ -197,7 +197,7 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
           v.map(vv => vv -> (new LinkedHashSet() ++ (dependencyGraph.getEdges(vv).toSeq.sortWith(cmp))))
       }
 
-      cyclePossible("prerequisites/dependents", dependencyGraph) {
+      cyclePossible("prerequisites/optionalDependents", dependencyGraph) {
         DiGraph(edges)
           .linearize
           .reverse
@@ -207,7 +207,7 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
 
     /* [todo] Seq is inefficient here, but Array has ClassTag problems. Use something else? */
     val (s, l) = sorted.foldLeft((_currentState, Seq[B]())){ case ((state, out), in) =>
-      /* The prerequisites are both prerequisites AND dependents. */
+      /* The prerequisites are both prerequisites AND optionalDependents. */
       val prereqs = new LinkedHashSet() ++ in.prerequisites ++
         dependencyGraph.getEdges(in).toSeq.map(oToD) ++
         otherDependents.getEdges(in).toSeq.map(oToD)
@@ -265,7 +265,7 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
   /** Get a name of some [[firrtl.options.TransformLike TransformLike]] */
   private def transformName(transform: B, suffix: String = ""): String = s""""${transform.name}$suffix""""
 
-  /** Convert all prerequisites, dependents, and invalidates to a Graphviz representation.
+  /** Convert all prerequisites, optionalDependents, and invalidates to a Graphviz representation.
     * @param file the name of the output file
     */
   def dependenciesToGraphviz: String = {
@@ -289,14 +289,14 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
 
     val connections =
       Seq( (prerequisiteGraph, "edge []"),
-           (dependentsGraph,   """edge [style=bold color="#4292c6"]"""),
+           (optionalDependentsGraph,   """edge [style=bold color="#4292c6"]"""),
            (invalidateGraph,   """edge [minlen=2 style=dashed constraint=false color="#fb6a4a"]"""),
            (optionalPrerequisitesGraph, """edge [style=dotted color="#a1d99b"]""") )
         .flatMap{ case (a, b) => toGraphviz(a, b) }
         .mkString("\n")
 
     val nodes =
-      (prerequisiteGraph + dependentsGraph + invalidateGraph + otherDependents)
+      (prerequisiteGraph + optionalDependentsGraph + invalidateGraph + otherDependents)
         .getVertices
         .map(v => s"""${transformName(v)} [label="${v.name}"]""")
 

--- a/src/main/scala/firrtl/options/Phase.scala
+++ b/src/main/scala/firrtl/options/Phase.scala
@@ -110,6 +110,10 @@ trait DependencyAPI[A <: DependencyAPI[A]] { this: TransformLike[_] =>
   private[options] lazy val _optionalPrerquisites: LinkedHashSet[Dependency[A]] =
     new LinkedHashSet() ++ optionalPrerequisites.toSet
 
+  def dependents: Seq[Dependency[A]] = Seq.empty
+  private[options] lazy val _dependents: LinkedHashSet[Dependency[A]] =
+    new LinkedHashSet() ++ dependents.toSet
+
   /** All transforms that must run ''after'' this transform, but only if a prerequisite of another transform.
     *
     * ''This is a means of prerequisite injection into some other transform.'' Normally a transform will define its own

--- a/src/main/scala/firrtl/options/Phase.scala
+++ b/src/main/scala/firrtl/options/Phase.scala
@@ -83,7 +83,7 @@ trait TransformLike[A] extends LazyLogging {
   * "transforms")
   *
   * This trait forms the basis of the Dependency API of the Chisel/FIRRTL Hardware Compiler Framework. Dependencies are
-  * defined in terms of prerequisistes, dependents, and invalidates. A prerequisite is a transform that must run before
+  * defined in terms of prerequisistes, optionalDependents, and invalidates. A prerequisite is a transform that must run before
   * this transform. A dependent is a transform that must run ''after'' this transform. (This can be viewed as a means of
   * injecting a prerequisite into some other transform.) Finally, invalidates define the set of transforms whose effects
   * this transform undos/invalidates. (Invalidation then implies that a transform that is invalidated by this transform
@@ -110,7 +110,7 @@ trait DependencyAPI[A <: DependencyAPI[A]] { this: TransformLike[_] =>
   private[options] lazy val _optionalPrerquisites: LinkedHashSet[Dependency[A]] =
     new LinkedHashSet() ++ optionalPrerequisites.toSet
 
-  /** All transforms that must run ''after'' this transform
+  /** All transforms that must run ''after'' this transform, but only if a prerequisite of another transform.
     *
     * ''This is a means of prerequisite injection into some other transform.'' Normally a transform will define its own
     * prerequisites. Dependents exist for two main situations:
@@ -129,8 +129,8 @@ trait DependencyAPI[A <: DependencyAPI[A]] { this: TransformLike[_] =>
     * @see [[firrtl.passes.CheckTypes]] for an example of an optional checking [[firrtl.Transform]]
     * $seqNote
     */
-  def dependents: Seq[Dependency[A]] = Seq.empty
-  private[options] lazy val _dependents: LinkedHashSet[Dependency[A]] = new LinkedHashSet() ++ dependents.toSet
+  def optionalDependents: Seq[Dependency[A]] = Seq.empty
+  private[options] lazy val _optionalDependents: LinkedHashSet[Dependency[A]] = new LinkedHashSet() ++ optionalDependents.toSet
 
   /** A function that, given *another* transform (parameter `a`) will return true if this transform invalidates/undos the
     * effects of the *other* transform (parameter `a`).

--- a/src/main/scala/firrtl/options/phases/AddDefaults.scala
+++ b/src/main/scala/firrtl/options/phases/AddDefaults.scala
@@ -14,7 +14,7 @@ class AddDefaults extends Phase with PreservesAll[Phase] {
 
   override val prerequisites = Seq(Dependency[GetIncludes], Dependency[ConvertLegacyAnnotations])
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = {
     val td = annotations.collectFirst{ case a: TargetDirAnnotation => a}.isEmpty

--- a/src/main/scala/firrtl/options/phases/Checks.scala
+++ b/src/main/scala/firrtl/options/phases/Checks.scala
@@ -14,7 +14,7 @@ class Checks extends Phase with PreservesAll[Phase] {
 
   override val prerequisites = Seq(Dependency[GetIncludes], Dependency[ConvertLegacyAnnotations], Dependency[AddDefaults])
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   /** Validate an [[AnnotationSeq]] for [[StageOptions]]
     * @throws OptionsException if annotations are invalid

--- a/src/main/scala/firrtl/options/phases/ConvertLegacyAnnotations.scala
+++ b/src/main/scala/firrtl/options/phases/ConvertLegacyAnnotations.scala
@@ -11,7 +11,7 @@ class ConvertLegacyAnnotations extends Phase with PreservesAll[Phase] {
 
   override val prerequisites = Seq(Dependency[GetIncludes])
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = LegacyAnnotation.convertLegacyAnnos(annotations)
 

--- a/src/main/scala/firrtl/options/phases/DeletedWrapper.scala
+++ b/src/main/scala/firrtl/options/phases/DeletedWrapper.scala
@@ -17,7 +17,7 @@ class DeletedWrapper(p: Phase) extends Phase with Translator[AnnotationSeq, (Ann
 
   override val prerequisites = Seq.empty
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   override lazy val name: String = p.name
 

--- a/src/main/scala/firrtl/options/phases/GetIncludes.scala
+++ b/src/main/scala/firrtl/options/phases/GetIncludes.scala
@@ -20,7 +20,7 @@ class GetIncludes extends Phase with PreservesAll[Phase] {
 
   override val prerequisites = Seq.empty
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   /** Read all [[annotations.Annotation]] from a file in JSON or YAML format
     * @param filename a JSON or YAML file of [[annotations.Annotation]]

--- a/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
+++ b/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
@@ -20,7 +20,7 @@ class WriteOutputAnnotations extends Phase with PreservesAll[Phase] {
          Dependency[AddDefaults],
          Dependency[Checks] )
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   /** Write the input [[AnnotationSeq]] to a fie. */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/passes/CheckChirrtl.scala
+++ b/src/main/scala/firrtl/passes/CheckChirrtl.scala
@@ -8,7 +8,7 @@ import firrtl.options.{Dependency, PreservesAll}
 
 object CheckChirrtl extends Pass with CheckHighFormLike with PreservesAll[Transform] {
 
-  override val dependents = firrtl.stage.Forms.ChirrtlForm ++
+  override val optionalDependents = firrtl.stage.Forms.ChirrtlForm ++
     Seq( Dependency(CInferTypes),
          Dependency(CInferMDir),
          Dependency(RemoveCHIRRTL) )

--- a/src/main/scala/firrtl/passes/CheckFlows.scala
+++ b/src/main/scala/firrtl/passes/CheckFlows.scala
@@ -12,7 +12,7 @@ object CheckFlows extends Pass with PreservesAll[Transform] {
 
   override val prerequisites = Dependency(passes.ResolveFlows) +: firrtl.stage.Forms.WorkingIR
 
-  override val dependents =
+  override val optionalDependents =
     Seq( Dependency[passes.InferBinaryPoints],
          Dependency[passes.TrimIntervals],
          Dependency[passes.InferWidths],
@@ -118,4 +118,3 @@ object CheckFlows extends Pass with PreservesAll[Transform] {
     c
   }
 }
-

--- a/src/main/scala/firrtl/passes/CheckHighForm.scala
+++ b/src/main/scala/firrtl/passes/CheckHighForm.scala
@@ -285,7 +285,7 @@ object CheckHighForm extends Pass with CheckHighFormLike with PreservesAll[Trans
 
   override val prerequisites = firrtl.stage.Forms.WorkingIR
 
-  override val dependents =
+  override val optionalDependents =
     Seq( Dependency(passes.ResolveKinds),
          Dependency(passes.InferTypes),
          Dependency(passes.Uniquify),

--- a/src/main/scala/firrtl/passes/CheckTypes.scala
+++ b/src/main/scala/firrtl/passes/CheckTypes.scala
@@ -15,7 +15,7 @@ object CheckTypes extends Pass with PreservesAll[Transform] {
 
   override val prerequisites = Dependency(InferTypes) +: firrtl.stage.Forms.WorkingIR
 
-  override val dependents =
+  override val optionalDependents =
     Seq( Dependency(passes.Uniquify),
          Dependency(passes.ResolveFlows),
          Dependency(passes.CheckFlows),

--- a/src/main/scala/firrtl/passes/CheckWidths.scala
+++ b/src/main/scala/firrtl/passes/CheckWidths.scala
@@ -15,7 +15,7 @@ object CheckWidths extends Pass with PreservesAll[Transform] {
 
   override val prerequisites = Dependency[passes.InferWidths] +: firrtl.stage.Forms.WorkingIR
 
-  override val dependents = Seq(Dependency[transforms.InferResets])
+  override val optionalDependents = Seq(Dependency[transforms.InferResets])
 
   /** The maximum allowed width for any circuit element */
   val MaxWidth = 1000000

--- a/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
+++ b/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
@@ -16,7 +16,7 @@ object CommonSubexpressionElimination extends Pass with PreservesAll[Transform] 
          Dependency(firrtl.passes.SplitExpressions),
          Dependency[firrtl.transforms.CombineCats] )
 
-  override val dependents =
+  override val optionalDependents =
     Seq( Dependency[SystemVerilogEmitter],
          Dependency[VerilogEmitter] )
 

--- a/src/main/scala/firrtl/passes/InferBinaryPoints.scala
+++ b/src/main/scala/firrtl/passes/InferBinaryPoints.scala
@@ -18,7 +18,7 @@ class InferBinaryPoints extends Pass with PreservesAll[Transform] {
          Dependency(Uniquify),
          Dependency(ResolveFlows) )
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   private val constraintSolver = new ConstraintSolver()
 

--- a/src/main/scala/firrtl/passes/Legalize.scala
+++ b/src/main/scala/firrtl/passes/Legalize.scala
@@ -16,7 +16,7 @@ object Legalize extends Pass with PreservesAll[Transform] {
 
   override val optionalPrerequisites = Seq.empty
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   private def legalizeShiftRight(e: DoPrim): Expression = {
     require(e.op == Shr)

--- a/src/main/scala/firrtl/passes/LowerTypes.scala
+++ b/src/main/scala/firrtl/passes/LowerTypes.scala
@@ -28,7 +28,7 @@ object LowerTypes extends Transform {
 
   override val prerequisites = firrtl.stage.Forms.MidForm
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   override def invalidates(a: Transform): Boolean = a match {
     case ResolveKinds | InferTypes | ResolveFlows | _: InferWidths => true

--- a/src/main/scala/firrtl/passes/PadWidths.scala
+++ b/src/main/scala/firrtl/passes/PadWidths.scala
@@ -21,7 +21,7 @@ object PadWidths extends Pass {
 
   override val optionalPrerequisites = Seq(Dependency[firrtl.transforms.ConstantPropagation])
 
-  override val dependents =
+  override val optionalDependents =
     Seq( Dependency(firrtl.passes.memlib.VerilogMemDelays),
          Dependency[SystemVerilogEmitter],
          Dependency[VerilogEmitter] )

--- a/src/main/scala/firrtl/passes/RemoveValidIf.scala
+++ b/src/main/scala/firrtl/passes/RemoveValidIf.scala
@@ -31,7 +31,7 @@ object RemoveValidIf extends Pass {
 
   override val prerequisites = firrtl.stage.Forms.LowForm
 
-  override val dependents =
+  override val optionalDependents =
     Seq( Dependency[SystemVerilogEmitter],
          Dependency[VerilogEmitter] )
 

--- a/src/main/scala/firrtl/passes/SplitExpressions.scala
+++ b/src/main/scala/firrtl/passes/SplitExpressions.scala
@@ -20,7 +20,7 @@ object SplitExpressions extends Pass with PreservesAll[Transform] {
     Seq( Dependency(firrtl.passes.RemoveValidIf),
          Dependency(firrtl.passes.memlib.VerilogMemDelays) )
 
-  override val dependents =
+  override val optionalDependents =
     Seq( Dependency[SystemVerilogEmitter],
          Dependency[VerilogEmitter] )
 

--- a/src/main/scala/firrtl/passes/TrimIntervals.scala
+++ b/src/main/scala/firrtl/passes/TrimIntervals.scala
@@ -29,7 +29,7 @@ class TrimIntervals extends Pass with PreservesAll[Transform] {
          Dependency(ResolveFlows),
          Dependency[InferBinaryPoints] )
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   def run(c: Circuit): Circuit = {
     // Open -> closed

--- a/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
+++ b/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
@@ -37,7 +37,7 @@ object VerilogModulusCleanup extends Pass with PreservesAll[Transform] {
 
   override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   private def onModule(m: Module): Module = {
     val namespace = Namespace(m)

--- a/src/main/scala/firrtl/passes/VerilogPrep.scala
+++ b/src/main/scala/firrtl/passes/VerilogPrep.scala
@@ -33,7 +33,7 @@ object VerilogPrep extends Pass with PreservesAll[Transform] {
 
   override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   type AttachSourceMap = Map[WrappedExpression, Expression]
 

--- a/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
+++ b/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
@@ -170,7 +170,7 @@ object VerilogMemDelays extends Pass {
 
   override val prerequisites = firrtl.stage.Forms.LowForm :+ Dependency(firrtl.passes.RemoveValidIf)
 
-  override val dependents =
+  override val optionalDependents =
     Seq( Dependency[VerilogEmitter],
          Dependency[SystemVerilogEmitter] )
 

--- a/src/main/scala/firrtl/stage/FirrtlStage.scala
+++ b/src/main/scala/firrtl/stage/FirrtlStage.scala
@@ -21,7 +21,7 @@ class FirrtlStage extends Stage {
 
   override lazy val prerequisites = phase.prerequisites
 
-  override lazy val dependents = phase.dependents
+  override lazy val optionalDependents = phase.optionalDependents
 
   override def invalidates(a: Phase): Boolean = phase.invalidates(a)
 

--- a/src/main/scala/firrtl/stage/phases/AddCircuit.scala
+++ b/src/main/scala/firrtl/stage/phases/AddCircuit.scala
@@ -29,7 +29,7 @@ class AddCircuit extends Phase with PreservesAll[Phase] {
 
   override val prerequisites = Seq(Dependency[AddDefaults], Dependency[Checks])
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   /** Extract the info mode from an [[AnnotationSeq]] or use the default info mode if no annotation exists
     * @param annotations some annotations

--- a/src/main/scala/firrtl/stage/phases/AddDefaults.scala
+++ b/src/main/scala/firrtl/stage/phases/AddDefaults.scala
@@ -14,7 +14,7 @@ class AddDefaults extends Phase with PreservesAll[Phase] {
 
   override val prerequisites = Seq.empty
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   /** Append any missing default annotations to an annotation sequence */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/stage/phases/AddImplicitEmitter.scala
+++ b/src/main/scala/firrtl/stage/phases/AddImplicitEmitter.scala
@@ -13,7 +13,7 @@ class AddImplicitEmitter extends Phase with PreservesAll[Phase] {
 
   override val prerequisites = Seq(Dependency[AddDefaults])
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   def transform(annos: AnnotationSeq): AnnotationSeq = {
     val emitter = annos.collectFirst{ case a: EmitAnnotation => a }

--- a/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
+++ b/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
@@ -24,7 +24,7 @@ class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
 
   override val prerequisites = Seq(Dependency[AddCircuit])
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   /** Add an [[OutputFileAnnotation]] to an [[AnnotationSeq]] */
   def transform(annotations: AnnotationSeq): AnnotationSeq =

--- a/src/main/scala/firrtl/stage/phases/CatchExceptions.scala
+++ b/src/main/scala/firrtl/stage/phases/CatchExceptions.scala
@@ -13,7 +13,7 @@ import scala.util.control.ControlThrowable
 class CatchExceptions(val underlying: Phase) extends Phase {
 
   override final val prerequisites = underlying.prerequisites
-  override final val dependents = underlying.dependents
+  override final val optionalDependents = underlying.optionalDependents
   override final def invalidates(a: Phase): Boolean = underlying.invalidates(a)
   override final lazy val name = underlying.name
 

--- a/src/main/scala/firrtl/stage/phases/Checks.scala
+++ b/src/main/scala/firrtl/stage/phases/Checks.scala
@@ -20,7 +20,7 @@ class Checks extends Phase with PreservesAll[Phase] {
 
   override val prerequisites = Seq(Dependency[AddDefaults], Dependency[AddImplicitEmitter])
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   /** Determine if annotations are sane
     *

--- a/src/main/scala/firrtl/stage/phases/Compiler.scala
+++ b/src/main/scala/firrtl/stage/phases/Compiler.scala
@@ -51,7 +51,7 @@ class Compiler extends Phase with Translator[AnnotationSeq, Seq[CompilerRun]] wi
         Dependency[AddCircuit],
         Dependency[AddImplicitOutputFile])
 
-  override val dependents = Seq(Dependency[WriteEmitted])
+  override val optionalDependents = Seq(Dependency[WriteEmitted])
 
   /** Convert an [[AnnotationSeq]] into a sequence of compiler runs. */
   protected def aToB(a: AnnotationSeq): Seq[CompilerRun] = {

--- a/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
+++ b/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
@@ -126,7 +126,7 @@ object DriverCompatibility {
 
     override val prerequisites = Seq(Dependency[AddImplicitFirrtlFile])
 
-    override val dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
+    override val optionalDependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
 
     /** Try to add an [[firrtl.options.InputAnnotationFileAnnotation InputAnnotationFileAnnotation]] implicitly specified by
       * an [[AnnotationSeq]]. */
@@ -165,7 +165,7 @@ object DriverCompatibility {
 
     override val prerequisites = Seq.empty
 
-    override val dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
+    override val optionalDependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
 
     /** Try to add a [[FirrtlFileAnnotation]] implicitly specified by an [[AnnotationSeq]]. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {
@@ -196,7 +196,7 @@ object DriverCompatibility {
 
     override val prerequisites = Seq.empty
 
-    override val dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
+    override val optionalDependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
 
     /** Add one [[EmitAnnotation]] foreach [[CompilerAnnotation]]. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {
@@ -222,7 +222,7 @@ object DriverCompatibility {
 
     override val prerequisites = Seq(Dependency[AddImplicitFirrtlFile])
 
-    override val dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
+    override val optionalDependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
 
     /** Add an [[OutputFileAnnotation]] derived from a [[TopNameAnnotation]] if needed. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
+++ b/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
@@ -28,7 +28,7 @@ class WriteEmitted extends Phase with PreservesAll[Phase] {
 
   override val prerequisites = Seq.empty
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   /** Write any [[EmittedAnnotation]]s in an [[AnnotationSeq]] to files. Written [[EmittedAnnotation]]s are deleted. */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/stage/transforms/WrappedTransform.scala
+++ b/src/main/scala/firrtl/stage/transforms/WrappedTransform.scala
@@ -26,7 +26,7 @@ trait WrappedTransform { this: Transform =>
   override final val inputForm = underlying.inputForm
   override final val outputForm = underlying.outputForm
   override final val prerequisites = underlying.prerequisites
-  override final val dependents = underlying.dependents
+  override final val optionalDependents = underlying.optionalDependents
   override final def invalidates(b: Transform): Boolean = underlying.invalidates(b)
   override final lazy val name = underlying.name
 

--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -65,7 +65,7 @@ class BlackBoxSourceHelper extends firrtl.Transform with PreservesAll[Transform]
 
   override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   /** Collect BlackBoxHelperAnnos and and find the target dir if specified
     * @param annos a list of generic annotations for this transform

--- a/src/main/scala/firrtl/transforms/CheckCombLoops.scala
+++ b/src/main/scala/firrtl/transforms/CheckCombLoops.scala
@@ -105,7 +105,7 @@ class CheckCombLoops extends Transform with RegisteredTransform with PreservesAl
 
   override val optionalPrerequisites = Seq.empty
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   import CheckCombLoops._
 

--- a/src/main/scala/firrtl/transforms/CombineCats.scala
+++ b/src/main/scala/firrtl/transforms/CombineCats.scala
@@ -65,7 +65,7 @@ class CombineCats extends Transform with PreservesAll[Transform] {
 
   override val optionalPrerequisites = Seq.empty
 
-  override val dependents = Seq(
+  override val optionalDependents = Seq(
     Dependency[SystemVerilogEmitter],
     Dependency[VerilogEmitter] )
 

--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -111,7 +111,7 @@ class ConstantPropagation extends Transform with ResolvedAnnotationPaths {
 
   override val optionalPrerequisites = Seq.empty
 
-  override val dependents =
+  override val optionalDependents =
     Seq( Dependency(firrtl.passes.memlib.VerilogMemDelays),
          Dependency(firrtl.passes.SplitExpressions),
          Dependency[SystemVerilogEmitter],

--- a/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
+++ b/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
@@ -44,7 +44,7 @@ class DeadCodeElimination extends Transform with ResolvedAnnotationPaths with Re
 
   override val optionalPrerequisites = Seq.empty
 
-  override val dependents =
+  override val optionalDependents =
     Seq( Dependency[firrtl.transforms.BlackBoxSourceHelper],
          Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
          Dependency[firrtl.transforms.FlattenRegUpdate],

--- a/src/main/scala/firrtl/transforms/Dedup.scala
+++ b/src/main/scala/firrtl/transforms/Dedup.scala
@@ -45,7 +45,7 @@ class DedupModules extends Transform with PreservesAll[Transform] {
 
   override val prerequisites = firrtl.stage.Forms.Resolved
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   /** Deduplicate a Circuit
     * @param state Input Firrtl AST

--- a/src/main/scala/firrtl/transforms/FixAddingNegativeLiteralsTransform.scala
+++ b/src/main/scala/firrtl/transforms/FixAddingNegativeLiteralsTransform.scala
@@ -115,7 +115,7 @@ class FixAddingNegativeLiterals extends Transform with PreservesAll[Transform] {
 
   override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   def execute(state: CircuitState): CircuitState = {
     val modulesx = state.circuit.modules.map(FixAddingNegativeLiterals.fixupModule)

--- a/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
+++ b/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
@@ -119,7 +119,7 @@ class FlattenRegUpdate extends Transform {
 
   override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: DeadCodeElimination => true

--- a/src/main/scala/firrtl/transforms/InlineBitExtractions.scala
+++ b/src/main/scala/firrtl/transforms/InlineBitExtractions.scala
@@ -105,7 +105,7 @@ class InlineBitExtractionsTransform extends Transform with PreservesAll[Transfor
 
   override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   def execute(state: CircuitState): CircuitState = {
     val modulesx = state.circuit.modules.map(InlineBitExtractionsTransform.onMod(_))

--- a/src/main/scala/firrtl/transforms/InlineCasts.scala
+++ b/src/main/scala/firrtl/transforms/InlineCasts.scala
@@ -79,7 +79,7 @@ class InlineCastsTransform extends Transform {
 
   override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: LegalizeClocksTransform => true

--- a/src/main/scala/firrtl/transforms/LegalizeClocks.scala
+++ b/src/main/scala/firrtl/transforms/LegalizeClocks.scala
@@ -72,7 +72,7 @@ class LegalizeClocksTransform extends Transform with PreservesAll[Transform] {
 
   override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   def execute(state: CircuitState): CircuitState = {
     val modulesx = state.circuit.modules.map(LegalizeClocksTransform.onMod(_))

--- a/src/main/scala/firrtl/transforms/PropagatePresetAnnotations.scala
+++ b/src/main/scala/firrtl/transforms/PropagatePresetAnnotations.scala
@@ -47,7 +47,7 @@ class PropagatePresetAnnotations extends Transform with PreservesAll[Transform] 
 
   override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
 
   import PropagatePresetAnnotations._

--- a/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
+++ b/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
@@ -247,6 +247,6 @@ class VerilogRename extends RemoveKeywordCollisions(v_keywords) with PreservesAl
 
   override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
 }

--- a/src/main/scala/firrtl/transforms/RemoveReset.scala
+++ b/src/main/scala/firrtl/transforms/RemoveReset.scala
@@ -25,7 +25,7 @@ object RemoveReset extends Transform {
 
   override val optionalPrerequisites = Seq.empty
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   override def invalidates(a: Transform): Boolean = a match {
     case firrtl.passes.ResolveFlows => true

--- a/src/main/scala/firrtl/transforms/RemoveWires.scala
+++ b/src/main/scala/firrtl/transforms/RemoveWires.scala
@@ -32,7 +32,7 @@ class RemoveWires extends Transform with PreservesAll[Transform] {
 
   override val optionalPrerequisites = Seq(Dependency[checks.CheckResets])
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   // Extract all expressions that are references to a Node, Wire, or Reg
   // Since we are operating on LowForm, they can only be WRefs

--- a/src/main/scala/firrtl/transforms/ReplaceTruncatingArithmetic.scala
+++ b/src/main/scala/firrtl/transforms/ReplaceTruncatingArithmetic.scala
@@ -87,7 +87,7 @@ class ReplaceTruncatingArithmetic extends Transform with PreservesAll[Transform]
 
   override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   def execute(state: CircuitState): CircuitState = {
     val modulesx = state.circuit.modules.map(ReplaceTruncatingArithmetic.onMod(_))

--- a/src/main/scala/logger/phases/AddDefaults.scala
+++ b/src/main/scala/logger/phases/AddDefaults.scala
@@ -11,7 +11,7 @@ import logger.{LoggerOption, LogLevelAnnotation}
 private [logger] class AddDefaults extends Phase with PreservesAll[Phase] {
 
   override val prerequisites = Seq.empty
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   /** Add missing default [[Logger]] [[Annotation]]s to an [[AnnotationSeq]]
     * @param annotations input annotations

--- a/src/main/scala/logger/phases/Checks.scala
+++ b/src/main/scala/logger/phases/Checks.scala
@@ -15,7 +15,7 @@ import scala.collection.mutable
 object Checks extends Phase with PreservesAll[Phase] {
 
   override val prerequisites = Seq(Dependency[AddDefaults])
-  override val dependents = Seq.empty
+  override val optionalDependents = Seq.empty
 
   /** Ensure that an [[firrtl.AnnotationSeq AnnotationSeq]] has necessary [[Logger]] [[firrtl.annotations.Annotation
     * Annotation]]s

--- a/src/test/scala/firrtl/testutils/FirrtlSpec.scala
+++ b/src/test/scala/firrtl/testutils/FirrtlSpec.scala
@@ -39,7 +39,7 @@ object RenameTop extends Transform with PreservesAll[Transform] {
 
   override val optionalPrerequisites = Seq(Dependency[RenameModules])
 
-  override val dependents = Seq(Dependency[VerilogEmitter], Dependency[MinimumVerilogEmitter])
+  override val optionalDependents = Seq(Dependency[VerilogEmitter], Dependency[MinimumVerilogEmitter])
 
   def execute(state: CircuitState): CircuitState = {
     val c = state.circuit

--- a/src/test/scala/firrtlTests/options/PhaseManagerSpec.scala
+++ b/src/test/scala/firrtlTests/options/PhaseManagerSpec.scala
@@ -190,7 +190,7 @@ object DependentsFixture {
    */
   class Custom extends IdentityPhase {
     override val prerequisites = Seq(Dependency[First])
-    override val dependents = Seq(Dependency[Second])
+    override val optionalDependents = Seq(Dependency[Second])
     override def invalidates(phase: Phase): Boolean = false
   }
 
@@ -255,7 +255,7 @@ object UnrelatedFixture {
 
   class B6Sub extends B6 {
     override val prerequisites = Seq(Dependency[B6])
-    override val dependents = Seq(Dependency[B7])
+    override val optionalDependents = Seq(Dependency[B7])
   }
 
   class B6_0 extends B6Sub
@@ -276,7 +276,7 @@ object UnrelatedFixture {
   class B6_15 extends B6Sub
 
   class B8Dep extends B8 {
-    override val dependents = Seq(Dependency[B8])
+    override val optionalDependents = Seq(Dependency[B8])
   }
 
   class B8_0 extends B8Dep
@@ -304,12 +304,12 @@ object CustomAfterOptimizationFixture {
 
   class OptMinimum extends IdentityPhase with PreservesAll[Phase] {
     override val prerequisites = Seq(Dependency[Root])
-    override val dependents = Seq(Dependency[AfterOpt])
+    override val optionalDependents = Seq(Dependency[AfterOpt])
   }
 
   class OptFull extends IdentityPhase with PreservesAll[Phase] {
     override val prerequisites = Seq(Dependency[Root], Dependency[OptMinimum])
-    override val dependents = Seq(Dependency[AfterOpt])
+    override val optionalDependents = Seq(Dependency[AfterOpt])
   }
 
   class AfterOpt extends IdentityPhase with PreservesAll[Phase]
@@ -324,7 +324,7 @@ object CustomAfterOptimizationFixture {
 
   class Custom extends IdentityPhase with PreservesAll[Phase] {
     override val prerequisites = Seq(Dependency[Root], Dependency[AfterOpt])
-    override val dependents = Seq(Dependency[DoneMinimum], Dependency[DoneFull])
+    override val optionalDependents = Seq(Dependency[DoneMinimum], Dependency[DoneFull])
   }
 
 }
@@ -352,7 +352,7 @@ object OptionalPrerequisitesFixture {
   class Custom extends IdentityPhase with PreservesAll[Phase] {
     override val prerequisites = Seq(Dependency[Root])
     override val optionalPrerequisites = Seq(Dependency[OptMinimum], Dependency[OptFull])
-    override val dependents = Seq(Dependency[DoneMinimum], Dependency[DoneFull])
+    override val optionalDependents = Seq(Dependency[DoneMinimum], Dependency[DoneFull])
   }
 
 }
@@ -524,7 +524,7 @@ class PhaseManagerSpec extends AnyFlatSpec with Matchers {
     pm.flattenedTransformOrder.map(_.getClass) should be (order)
   }
 
-  /** This test shows how the dependents member can be used to run one transform before another. */
+  /** This test shows how the optionalDependents member can be used to run one transform before another. */
   it should "handle a custom Phase with a dependent" in {
     val f = DependentsFixture
 
@@ -578,7 +578,7 @@ class PhaseManagerSpec extends AnyFlatSpec with Matchers {
            Dependency[f.B14],
            Dependency[f.B15] )
     /** A sequence of custom transforms that should all run after B6 and before B7. This exercises correct ordering of the
-      * prerequisiteGraph and dependentsGraph.
+      * prerequisiteGraph and optionalDependentsGraph.
       */
     val prerequisiteTargets =
       Seq( Dependency[f.B6_0],
@@ -597,7 +597,7 @@ class PhaseManagerSpec extends AnyFlatSpec with Matchers {
            Dependency[f.B6_13],
            Dependency[f.B6_14],
            Dependency[f.B6_15] )
-    /** A sequence of transforms that are invalidated by B0 and only define dependents on B8. This exercises the ordering
+    /** A sequence of transforms that are invalidated by B0 and only define optionalDependents on B8. This exercises the ordering
       * defined by "otherDependents".
       */
     val current =


### PR DESCRIPTION
This modifies and extends the Dependency API in the following way:

1. `dependents` are renamed to `optionalDependents` to better express what they are. These are prerequisites injected into other phases. However, these only matter if the other phases are requested to be run because they are (1) targets or (2) prerequisites of other transforms
2. A new `dependents` portion of the Dependency API is added that allows phases to add downstream nodes to the `DependencyAPI` graph that are guaranteed to run.

I'm vacillating between two poles on this:

1. **This is wrong**: The new notion of mandatory `dependents` is wrong. If a user wants to add a downstream dependency, then they should list optional `dependents` or `invalidates` and then list the downstream phase as a target.
2. **This fills an API hole**: The dependency API provides no way for a user to, with a dependency specified inside a phase, to add both a vertex and an edge to the downstream dependency graph. The fact that this API is missing indicates that the API is deficient and should be corrected.

This PR requires more motivating use cases. It would be great if @azidar and @sequencer could help provide some.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- ~[ ] Did you update the FIRRTL spec to include every new feature/behavior?~
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
- new feature/API                    

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

This breaks the existing dependency API by renaming `dependents` -> `optionalDependents` while simultaneously changing the meaning of dependents. Current users of `dependents` will result in different transform/phase orderings.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
