### PR TITLE
Deprecate Transform via new CircuitPhase

### DIFF
--- a/src/main/scala/firrtl/AddDescriptionNodes.scala
+++ b/src/main/scala/firrtl/AddDescriptionNodes.scala
@@ -6,6 +6,7 @@ import firrtl.ir._
 import firrtl.annotations._
 import firrtl.Mappers._
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 
 case class DescriptionAnnotation(named: Named, description: String) extends Annotation {
   def update(renames: RenameMap): Seq[DescriptionAnnotation] = {
@@ -68,7 +69,7 @@ private case class DescribedMod(description: Description,
   * @note should only be used by VerilogEmitter, described nodes will
   *       break other transforms.
   */
-class AddDescriptionNodes extends Transform with PreservesAll[Transform] {
+class AddDescriptionNodes extends Transform with PreservesAll[CircuitPhase] {
   def inputForm = UnknownForm
   def outputForm = UnknownForm
 

--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -13,6 +13,7 @@ import firrtl.ir.Circuit
 import firrtl.Utils.throwInternalError
 import firrtl.annotations.transforms.{EliminateTargetPaths, ResolvePaths}
 import firrtl.options.{DependencyAPI, Dependency, PreservesAll, StageUtils, TransformLike}
+import firrtl.stage.TransformManager.TransformDependency
 import firrtl.stage.transforms.CatchCustomTransformExceptions
 
 /** Container of all annotations for a Firrtl compiler */
@@ -209,7 +210,7 @@ trait Transform extends TransformLike[CircuitState] with DependencyAPI[Transform
   import firrtl.{ChirrtlForm => C, HighForm => H, MidForm => M, LowForm => L, UnknownForm => U}
   import firrtl.stage.Forms
 
-  override def prerequisites: Seq[Dependency[Transform]] = inputForm match {
+  override def prerequisites: Seq[TransformDependency] = inputForm match {
     case C => Nil
     case H => Forms.Deduped
     case M => Forms.MidForm
@@ -217,14 +218,14 @@ trait Transform extends TransformLike[CircuitState] with DependencyAPI[Transform
     case U => Nil
   }
 
-  override def optionalPrerequisites: Seq[Dependency[Transform]] = inputForm match {
+  override def optionalPrerequisites: Seq[TransformDependency] = inputForm match {
     case L => Forms.LowFormOptimized
     case _ => Seq.empty
   }
 
-  private lazy val fullCompilerSet = new mutable.LinkedHashSet[Dependency[Transform]] ++ Forms.VerilogOptimized
+  private lazy val fullCompilerSet = new mutable.LinkedHashSet[TransformDependency] ++ Forms.VerilogOptimized
 
-  override def dependents: Seq[Dependency[Transform]] = {
+  override def dependents: Seq[TransformDependency] = {
     val lowEmitters = Dependency[LowFirrtlEmitter] :: Dependency[VerilogEmitter] :: Dependency[MinimumVerilogEmitter] ::
       Dependency[SystemVerilogEmitter] :: Nil
 

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -16,7 +16,8 @@ sealed abstract class CoreTransform extends SeqTransform
 class ChirrtlToHighFirrtl extends CoreTransform {
   def inputForm = ChirrtlForm
   def outputForm = HighForm
-  def transforms = new TransformManager(Forms.MinimalHighForm, Forms.ChirrtlForm).flattenedTransformOrder
+  def transforms = new TransformManager(Forms.MinimalHighForm, Forms.ChirrtlForm)
+    .flattenedTransformOrder.map(_.asInstanceOf[Transform])
 }
 
 /** Converts from the bare intermediate representation (ir.scala)
@@ -26,7 +27,8 @@ class ChirrtlToHighFirrtl extends CoreTransform {
 class IRToWorkingIR extends CoreTransform {
   def inputForm = HighForm
   def outputForm = HighForm
-  def transforms = new TransformManager(Forms.WorkingIR, Forms.MinimalHighForm).flattenedTransformOrder
+  def transforms = new TransformManager(Forms.WorkingIR, Forms.MinimalHighForm)
+    .flattenedTransformOrder.map(_.asInstanceOf[Transform])
 }
 
 /** Resolves types, kinds, and flows, and checks the circuit legality.
@@ -36,7 +38,8 @@ class IRToWorkingIR extends CoreTransform {
 class ResolveAndCheck extends CoreTransform {
   def inputForm = HighForm
   def outputForm = HighForm
-  def transforms = new TransformManager(Forms.Resolved, Forms.WorkingIR).flattenedTransformOrder
+  def transforms = new TransformManager(Forms.Resolved, Forms.WorkingIR)
+    .flattenedTransformOrder.map(_.asInstanceOf[Transform])
 }
 
 /** Expands aggregate connects, removes dynamic accesses, and when
@@ -48,7 +51,8 @@ class ResolveAndCheck extends CoreTransform {
 class HighFirrtlToMiddleFirrtl extends CoreTransform {
   def inputForm = HighForm
   def outputForm = MidForm
-  def transforms = new TransformManager(Forms.MidForm, Forms.Deduped).flattenedTransformOrder
+  def transforms = new TransformManager(Forms.MidForm, Forms.Deduped)
+    .flattenedTransformOrder.map(_.asInstanceOf[Transform])
 }
 
 /** Expands all aggregate types into many ground-typed components. Must
@@ -59,7 +63,8 @@ class HighFirrtlToMiddleFirrtl extends CoreTransform {
 class MiddleFirrtlToLowFirrtl extends CoreTransform {
   def inputForm = MidForm
   def outputForm = LowForm
-  def transforms = new TransformManager(Forms.LowForm, Forms.MidForm).flattenedTransformOrder
+  def transforms = new TransformManager(Forms.LowForm, Forms.MidForm)
+    .flattenedTransformOrder.map(_.asInstanceOf[Transform])
 }
 
 /** Runs a series of optimization passes on LowFirrtl
@@ -70,14 +75,16 @@ class MiddleFirrtlToLowFirrtl extends CoreTransform {
 class LowFirrtlOptimization extends CoreTransform {
   def inputForm = LowForm
   def outputForm = LowForm
-  def transforms = new TransformManager(Forms.LowFormOptimized, Forms.LowForm).flattenedTransformOrder
+  def transforms = new TransformManager(Forms.LowFormOptimized, Forms.LowForm)
+    .flattenedTransformOrder.map(_.asInstanceOf[Transform])
 }
 /** Runs runs only the optimization passes needed for Verilog emission */
 @deprecated("Use a TransformManager to handle lowering. Will be removed in 1.3.", "1.2")
 class MinimumLowFirrtlOptimization extends CoreTransform {
   def inputForm = LowForm
   def outputForm = LowForm
-  def transforms = new TransformManager(Forms.LowFormMinimumOptimized, Forms.LowForm).flattenedTransformOrder
+  def transforms = new TransformManager(Forms.LowFormMinimumOptimized, Forms.LowForm)
+    .flattenedTransformOrder.map(_.asInstanceOf[Transform])
 }
 
 

--- a/src/main/scala/firrtl/checks/CheckResets.scala
+++ b/src/main/scala/firrtl/checks/CheckResets.scala
@@ -5,6 +5,7 @@ package firrtl.checks
 import firrtl._
 import firrtl.options.{Dependency, PreservesAll}
 import firrtl.passes.{Errors, PassException}
+import firrtl.stage.CircuitPhase
 import firrtl.ir._
 import firrtl.Utils.isCast
 import firrtl.traversals.Foreachers._
@@ -28,7 +29,7 @@ object CheckResets {
 // Must run after ExpandWhens
 // Requires
 //   - static single connections of ground types
-class CheckResets extends Transform with PreservesAll[Transform] {
+class CheckResets extends Transform with PreservesAll[CircuitPhase] {
   def inputForm: CircuitForm = MidForm
   def outputForm: CircuitForm = MidForm
 

--- a/src/main/scala/firrtl/passes/CInferMDir.scala
+++ b/src/main/scala/firrtl/passes/CInferMDir.scala
@@ -6,9 +6,10 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 import Utils.throwInternalError
 
-object CInferMDir extends Pass with PreservesAll[Transform] {
+object CInferMDir extends Pass with PreservesAll[CircuitPhase] {
 
   override val prerequisites = firrtl.stage.Forms.ChirrtlForm :+ Dependency(CInferTypes)
 

--- a/src/main/scala/firrtl/passes/CheckChirrtl.scala
+++ b/src/main/scala/firrtl/passes/CheckChirrtl.scala
@@ -5,8 +5,9 @@ package firrtl.passes
 import firrtl.Transform
 import firrtl.ir._
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 
-object CheckChirrtl extends Pass with CheckHighFormLike with PreservesAll[Transform] {
+object CheckChirrtl extends Pass with CheckHighFormLike with PreservesAll[CircuitPhase] {
 
   override val dependents = firrtl.stage.Forms.ChirrtlForm ++
     Seq( Dependency(CInferTypes),

--- a/src/main/scala/firrtl/passes/CheckFlows.scala
+++ b/src/main/scala/firrtl/passes/CheckFlows.scala
@@ -7,8 +7,9 @@ import firrtl.ir._
 import firrtl.Utils._
 import firrtl.traversals.Foreachers._
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 
-object CheckFlows extends Pass with PreservesAll[Transform] {
+object CheckFlows extends Pass with PreservesAll[CircuitPhase] {
 
   override val prerequisites = Dependency(passes.ResolveFlows) +: firrtl.stage.Forms.WorkingIR
 
@@ -118,4 +119,3 @@ object CheckFlows extends Pass with PreservesAll[Transform] {
     c
   }
 }
-

--- a/src/main/scala/firrtl/passes/CheckHighForm.scala
+++ b/src/main/scala/firrtl/passes/CheckHighForm.scala
@@ -8,6 +8,7 @@ import firrtl.PrimOps._
 import firrtl.Utils._
 import firrtl.traversals.Foreachers._
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 
 trait CheckHighFormLike { this: Pass =>
   type NameSet = collection.mutable.HashSet[String]
@@ -281,7 +282,7 @@ trait CheckHighFormLike { this: Pass =>
   }
 }
 
-object CheckHighForm extends Pass with CheckHighFormLike with PreservesAll[Transform] {
+object CheckHighForm extends Pass with CheckHighFormLike with PreservesAll[CircuitPhase] {
 
   override val prerequisites = firrtl.stage.Forms.WorkingIR
 

--- a/src/main/scala/firrtl/passes/CheckInitialization.scala
+++ b/src/main/scala/firrtl/passes/CheckInitialization.scala
@@ -7,6 +7,7 @@ import firrtl.ir._
 import firrtl.Utils._
 import firrtl.traversals.Foreachers._
 import firrtl.options.PreservesAll
+import firrtl.stage.CircuitPhase
 
 import annotation.tailrec
 
@@ -15,7 +16,7 @@ import annotation.tailrec
   * @note This pass looks for [[firrtl.WVoid]]s left behind by [[ExpandWhens]]
   * @note Assumes single connection (ie. no last connect semantics)
   */
-object CheckInitialization extends Pass with PreservesAll[Transform] {
+object CheckInitialization extends Pass with PreservesAll[CircuitPhase] {
 
   override val prerequisites = firrtl.stage.Forms.Resolved
 

--- a/src/main/scala/firrtl/passes/CheckTypes.scala
+++ b/src/main/scala/firrtl/passes/CheckTypes.scala
@@ -10,8 +10,9 @@ import firrtl.traversals.Foreachers._
 import firrtl.WrappedType._
 import firrtl.constraint.{Constraint, IsKnown}
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 
-object CheckTypes extends Pass with PreservesAll[Transform] {
+object CheckTypes extends Pass with PreservesAll[CircuitPhase] {
 
   override val prerequisites = Dependency(InferTypes) +: firrtl.stage.Forms.WorkingIR
 

--- a/src/main/scala/firrtl/passes/CheckWidths.scala
+++ b/src/main/scala/firrtl/passes/CheckWidths.scala
@@ -10,8 +10,9 @@ import firrtl.Utils._
 import firrtl.constraint.IsKnown
 import firrtl.annotations.{CircuitTarget, ModuleTarget, Target, TargetToken}
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 
-object CheckWidths extends Pass with PreservesAll[Transform] {
+object CheckWidths extends Pass with PreservesAll[CircuitPhase] {
 
   override val prerequisites = Dependency[passes.InferWidths] +: firrtl.stage.Forms.WorkingIR
 

--- a/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
+++ b/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
@@ -6,8 +6,9 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 
-object CommonSubexpressionElimination extends Pass with PreservesAll[Transform] {
+object CommonSubexpressionElimination extends Pass with PreservesAll[CircuitPhase] {
 
   override val prerequisites = firrtl.stage.Forms.LowForm ++
     Seq( Dependency(firrtl.passes.RemoveValidIf),

--- a/src/main/scala/firrtl/passes/ConvertFixedToSInt.scala
+++ b/src/main/scala/firrtl/passes/ConvertFixedToSInt.scala
@@ -9,10 +9,11 @@ import firrtl._
 import firrtl.Mappers._
 import firrtl.Utils.{sub_type, module_type, field_type, max, throwInternalError}
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 
 /** Replaces FixedType with SIntType, and correctly aligns all binary points
   */
-object ConvertFixedToSInt extends Pass with PreservesAll[Transform] {
+object ConvertFixedToSInt extends Pass with PreservesAll[CircuitPhase] {
 
   override val prerequisites =
     Seq( Dependency(PullMuxes),

--- a/src/main/scala/firrtl/passes/ExpandConnects.scala
+++ b/src/main/scala/firrtl/passes/ExpandConnects.scala
@@ -3,10 +3,11 @@ package firrtl.passes
 import firrtl.Utils.{create_exps, flow, get_field, get_valid_points, times, to_flip, to_flow}
 import firrtl.ir._
 import firrtl.options.{PreservesAll, Dependency}
+import firrtl.stage.CircuitPhase
 import firrtl.{DuplexFlow, Flow, SinkFlow, SourceFlow, Transform, WDefInstance, WRef, WSubAccess, WSubField, WSubIndex}
 import firrtl.Mappers._
 
-object ExpandConnects extends Pass with PreservesAll[Transform] {
+object ExpandConnects extends Pass with PreservesAll[CircuitPhase] {
 
   override val prerequisites =
     Seq( Dependency(PullMuxes),

--- a/src/main/scala/firrtl/passes/ExpandWhens.scala
+++ b/src/main/scala/firrtl/passes/ExpandWhens.scala
@@ -9,6 +9,7 @@ import firrtl.Mappers._
 import firrtl.PrimOps._
 import firrtl.WrappedExpression._
 import firrtl.options.Dependency
+import firrtl.stage.CircuitPhase
 
 import annotation.tailrec
 import collection.mutable
@@ -33,7 +34,7 @@ object ExpandWhens extends Pass {
          Dependency(RemoveAccesses),
          Dependency(Uniquify) ) ++ firrtl.stage.Forms.Resolved
 
-  override def invalidates(a: Transform): Boolean = a match {
+  override def invalidates(a: CircuitPhase): Boolean = a match {
     case CheckInitialization | ResolveKinds | InferTypes => true
     case _ => false
   }
@@ -311,7 +312,7 @@ class ExpandWhensAndCheck extends SeqTransform {
          Dependency(RemoveAccesses),
          Dependency(Uniquify) ) ++ firrtl.stage.Forms.Deduped
 
-  override def invalidates(a: Transform): Boolean = a match {
+  override def invalidates(a: CircuitPhase): Boolean = a match {
     case ResolveKinds | InferTypes | ResolveFlows | _: InferWidths => true
     case _ => false
   }

--- a/src/main/scala/firrtl/passes/InferBinaryPoints.scala
+++ b/src/main/scala/firrtl/passes/InferBinaryPoints.scala
@@ -9,8 +9,9 @@ import firrtl.annotations.{CircuitTarget, ModuleTarget, ReferenceTarget, Target}
 import firrtl.constraint.ConstraintSolver
 import firrtl.Transform
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 
-class InferBinaryPoints extends Pass with PreservesAll[Transform] {
+class InferBinaryPoints extends Pass with PreservesAll[CircuitPhase] {
 
   override val prerequisites =
     Seq( Dependency(ResolveKinds),

--- a/src/main/scala/firrtl/passes/InferTypes.scala
+++ b/src/main/scala/firrtl/passes/InferTypes.scala
@@ -7,8 +7,9 @@ import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 
-object InferTypes extends Pass with PreservesAll[Transform] {
+object InferTypes extends Pass with PreservesAll[CircuitPhase] {
 
   override val prerequisites = Dependency(ResolveKinds) +: firrtl.stage.Forms.WorkingIR
 
@@ -88,7 +89,7 @@ object InferTypes extends Pass with PreservesAll[Transform] {
   }
 }
 
-object CInferTypes extends Pass with PreservesAll[Transform] {
+object CInferTypes extends Pass with PreservesAll[CircuitPhase] {
 
   override val prerequisites = firrtl.stage.Forms.ChirrtlForm
 

--- a/src/main/scala/firrtl/passes/InferWidths.scala
+++ b/src/main/scala/firrtl/passes/InferWidths.scala
@@ -11,6 +11,7 @@ import firrtl.annotations._
 import firrtl.constraint.{ConstraintSolver, IsMax}
 import firrtl.ir._
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 
 object InferWidths {
   def apply(): InferWidths = new InferWidths()
@@ -60,7 +61,7 @@ case class WidthGeqConstraintAnnotation(loc: ReferenceTarget, exp: ReferenceTarg
   *
   * Uses firrtl.constraint package to infer widths
   */
-class InferWidths extends Transform with ResolvedAnnotationPaths with PreservesAll[Transform] {
+class InferWidths extends Transform with ResolvedAnnotationPaths with PreservesAll[CircuitPhase] {
 
   override val prerequisites =
     Seq( Dependency(passes.ResolveKinds),

--- a/src/main/scala/firrtl/passes/Inline.scala
+++ b/src/main/scala/firrtl/passes/Inline.scala
@@ -9,7 +9,7 @@ import firrtl.annotations._
 import firrtl.annotations.TargetToken.{Instance, OfModule}
 import firrtl.analyses.{InstanceGraph}
 import firrtl.graph.{DiGraph, MutableDiGraph}
-import firrtl.stage.RunFirrtlTransformAnnotation
+import firrtl.stage.{CircuitPhase, RunFirrtlTransformAnnotation}
 import firrtl.options.{RegisteredTransform, ShellOption}
 
 // Datastructures
@@ -29,7 +29,7 @@ class InlineInstances extends Transform with RegisteredTransform {
   def outputForm = LowForm
   private [firrtl] val inlineDelim: String = "_"
 
-  override def invalidates(a: Transform): Boolean = a == ResolveKinds
+  override def invalidates(a: CircuitPhase): Boolean = a == ResolveKinds
 
   val options = Seq(
     new ShellOption[Seq[String]](

--- a/src/main/scala/firrtl/passes/Legalize.scala
+++ b/src/main/scala/firrtl/passes/Legalize.scala
@@ -4,13 +4,14 @@ import firrtl.PrimOps._
 import firrtl.Utils.{BoolType, error, zero}
 import firrtl.ir._
 import firrtl.options.{PreservesAll, Dependency}
+import firrtl.stage.CircuitPhase
 import firrtl.transforms.ConstantPropagation
-import firrtl.{Transform, bitWidth}
+import firrtl.bitWidth
 import firrtl.Mappers._
 
 // Replace shr by amount >= arg width with 0 for UInts and MSB for SInts
 // TODO replace UInt with zero-width wire instead
-object Legalize extends Pass with PreservesAll[Transform] {
+object Legalize extends Pass with PreservesAll[CircuitPhase] {
 
   override val prerequisites = firrtl.stage.Forms.MidForm :+ Dependency(LowerTypes)
 

--- a/src/main/scala/firrtl/passes/LowerTypes.scala
+++ b/src/main/scala/firrtl/passes/LowerTypes.scala
@@ -8,6 +8,7 @@ import firrtl.ir._
 import firrtl.Utils._
 import MemPortUtils.memType
 import firrtl.Mappers._
+import firrtl.stage.CircuitPhase
 
 /** Removes all aggregate types from a [[firrtl.ir.Circuit]]
   *
@@ -30,7 +31,7 @@ object LowerTypes extends Transform {
 
   override val dependents = Seq.empty
 
-  override def invalidates(a: Transform): Boolean = a match {
+  override def invalidates(a: CircuitPhase): Boolean = a match {
     case ResolveKinds | InferTypes | ResolveFlows | _: InferWidths => true
     case _ => false
   }

--- a/src/main/scala/firrtl/passes/PadWidths.scala
+++ b/src/main/scala/firrtl/passes/PadWidths.scala
@@ -7,6 +7,7 @@ import firrtl.ir._
 import firrtl.PrimOps._
 import firrtl.Mappers._
 import firrtl.options.Dependency
+import firrtl.stage.CircuitPhase
 
 import scala.collection.mutable
 
@@ -26,7 +27,7 @@ object PadWidths extends Pass {
          Dependency[SystemVerilogEmitter],
          Dependency[VerilogEmitter] )
 
-  override def invalidates(a: Transform): Boolean = a match {
+  override def invalidates(a: CircuitPhase): Boolean = a match {
     case _: firrtl.transforms.ConstantPropagation | Legalize => true
     case _ => false
   }

--- a/src/main/scala/firrtl/passes/PullMuxes.scala
+++ b/src/main/scala/firrtl/passes/PullMuxes.scala
@@ -4,8 +4,9 @@ import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.options.PreservesAll
 import firrtl.{Transform, WSubAccess, WSubField, WSubIndex}
+import firrtl.stage.CircuitPhase
 
-object PullMuxes extends Pass with PreservesAll[Transform] {
+object PullMuxes extends Pass with PreservesAll[CircuitPhase] {
 
   override val prerequisites = firrtl.stage.Forms.Deduped
 

--- a/src/main/scala/firrtl/passes/RemoveAccesses.scala
+++ b/src/main/scala/firrtl/passes/RemoveAccesses.scala
@@ -9,6 +9,7 @@ import firrtl.Mappers._
 import firrtl.Utils._
 import firrtl.WrappedExpression._
 import firrtl.options.Dependency
+import firrtl.stage.CircuitPhase
 
 import scala.collection.mutable
 
@@ -22,7 +23,7 @@ object RemoveAccesses extends Pass {
          Dependency(ReplaceAccesses),
          Dependency(ExpandConnects) ) ++ firrtl.stage.Forms.Deduped
 
-  override def invalidates(a: Transform): Boolean = a match {
+  override def invalidates(a: CircuitPhase): Boolean = a match {
     case Uniquify => true
     case _        => false
   }

--- a/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
+++ b/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
@@ -9,12 +9,13 @@ import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 
 case class MPort(name: String, clk: Expression)
 case class MPorts(readers: ArrayBuffer[MPort], writers: ArrayBuffer[MPort], readwriters: ArrayBuffer[MPort])
 case class DataRef(exp: Expression, male: String, female: String, mask: String, rdwrite: Boolean)
 
-object RemoveCHIRRTL extends Transform with PreservesAll[Transform] {
+object RemoveCHIRRTL extends Transform with PreservesAll[CircuitPhase] {
 
   override val prerequisites = firrtl.stage.Forms.ChirrtlForm ++
     Seq( Dependency(passes.CInferTypes),

--- a/src/main/scala/firrtl/passes/RemoveIntervals.scala
+++ b/src/main/scala/firrtl/passes/RemoveIntervals.scala
@@ -38,7 +38,7 @@ class WrapWithRemainder(info: Info, mname: String, wrap: DoPrim)
   */
 class RemoveIntervals extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites: Seq[Dependency[Transform]] =
+  override val prerequisites =
     Seq( Dependency(PullMuxes),
          Dependency(ReplaceAccesses),
          Dependency(ExpandConnects),

--- a/src/main/scala/firrtl/passes/RemoveIntervals.scala
+++ b/src/main/scala/firrtl/passes/RemoveIntervals.scala
@@ -9,6 +9,7 @@ import firrtl.Mappers._
 import Implicits.{bigint2WInt}
 import firrtl.constraint.IsKnown
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 
 import scala.math.BigDecimal.RoundingMode._
 
@@ -36,7 +37,7 @@ class WrapWithRemainder(info: Info, mname: String, wrap: DoPrim)
   *      c. replace with SIntType
   * 3) Run InferTypes
   */
-class RemoveIntervals extends Pass with PreservesAll[Transform] {
+class RemoveIntervals extends Pass with PreservesAll[CircuitPhase] {
 
   override val prerequisites =
     Seq( Dependency(PullMuxes),

--- a/src/main/scala/firrtl/passes/RemoveValidIf.scala
+++ b/src/main/scala/firrtl/passes/RemoveValidIf.scala
@@ -7,6 +7,7 @@ import firrtl.Mappers._
 import firrtl.ir._
 import Utils.throwInternalError
 import firrtl.options.Dependency
+import firrtl.stage.CircuitPhase
 
 /** Remove [[firrtl.ir.ValidIf ValidIf]] and replace [[firrtl.ir.IsInvalid IsInvalid]] with a connection to zero */
 object RemoveValidIf extends Pass {
@@ -35,7 +36,7 @@ object RemoveValidIf extends Pass {
     Seq( Dependency[SystemVerilogEmitter],
          Dependency[VerilogEmitter] )
 
-  override def invalidates(a: Transform): Boolean = a match {
+  override def invalidates(a: CircuitPhase): Boolean = a match {
     case Legalize | _: firrtl.transforms.ConstantPropagation => true
     case _ => false
   }

--- a/src/main/scala/firrtl/passes/ReplaceAccesses.scala
+++ b/src/main/scala/firrtl/passes/ReplaceAccesses.scala
@@ -7,11 +7,12 @@ import firrtl.ir._
 import firrtl.{WSubAccess, WSubIndex}
 import firrtl.Mappers._
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 
 /** Replaces constant [[firrtl.WSubAccess]] with [[firrtl.WSubIndex]]
   * TODO Fold in to High Firrtl Const Prop
   */
-object ReplaceAccesses extends Pass with PreservesAll[Transform] {
+object ReplaceAccesses extends Pass with PreservesAll[CircuitPhase] {
 
   override val prerequisites = firrtl.stage.Forms.Deduped :+ Dependency(PullMuxes)
 

--- a/src/main/scala/firrtl/passes/ResolveFlows.scala
+++ b/src/main/scala/firrtl/passes/ResolveFlows.scala
@@ -6,8 +6,9 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 
-object ResolveFlows extends Pass with PreservesAll[Transform] {
+object ResolveFlows extends Pass with PreservesAll[CircuitPhase] {
 
   override val prerequisites =
     Seq( Dependency(passes.ResolveKinds),

--- a/src/main/scala/firrtl/passes/ResolveKinds.scala
+++ b/src/main/scala/firrtl/passes/ResolveKinds.scala
@@ -6,8 +6,9 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.options.PreservesAll
+import firrtl.stage.CircuitPhase
 
-object ResolveKinds extends Pass with PreservesAll[Transform] {
+object ResolveKinds extends Pass with PreservesAll[CircuitPhase] {
 
   override val prerequisites = firrtl.stage.Forms.WorkingIR
 

--- a/src/main/scala/firrtl/passes/SplitExpressions.scala
+++ b/src/main/scala/firrtl/passes/SplitExpressions.scala
@@ -6,6 +6,7 @@ package passes
 import firrtl.{SystemVerilogEmitter, VerilogEmitter}
 import firrtl.ir._
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 import firrtl.Mappers._
 import firrtl.Utils.{kind, flow, get_info}
 
@@ -14,7 +15,7 @@ import scala.collection.mutable
 
 // Splits compound expressions into simple expressions
 //  and named intermediate nodes
-object SplitExpressions extends Pass with PreservesAll[Transform] {
+object SplitExpressions extends Pass with PreservesAll[CircuitPhase] {
 
   override val prerequisites = firrtl.stage.Forms.LowForm ++
     Seq( Dependency(firrtl.passes.RemoveValidIf),

--- a/src/main/scala/firrtl/passes/ToWorkingIR.scala
+++ b/src/main/scala/firrtl/passes/ToWorkingIR.scala
@@ -3,10 +3,11 @@ package firrtl.passes
 import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.options.{PreservesAll}
-import firrtl.{Transform, UnknownFlow, UnknownKind, WDefInstance, WRef, WSubAccess, WSubField, WSubIndex}
+import firrtl.{UnknownFlow, UnknownKind, WDefInstance, WRef, WSubAccess, WSubField, WSubIndex}
+import firrtl.stage.CircuitPhase
 
 // These should be distributed into separate files
-object ToWorkingIR extends Pass with PreservesAll[Transform] {
+object ToWorkingIR extends Pass with PreservesAll[CircuitPhase] {
 
   override val prerequisites = firrtl.stage.Forms.MinimalHighForm
 

--- a/src/main/scala/firrtl/passes/TrimIntervals.scala
+++ b/src/main/scala/firrtl/passes/TrimIntervals.scala
@@ -7,6 +7,7 @@ import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.constraint.{IsFloor, IsKnown, IsMul}
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 import firrtl.Transform
 
 /** Replaces IntervalType with SIntType, three AST walks:
@@ -20,7 +21,7 @@ import firrtl.Transform
   *      c. replace with SIntType
   * 3) Run InferTypes
   */
-class TrimIntervals extends Pass with PreservesAll[Transform] {
+class TrimIntervals extends Pass with PreservesAll[CircuitPhase] {
 
   override val prerequisites =
     Seq( Dependency(ResolveKinds),

--- a/src/main/scala/firrtl/passes/Uniquify.scala
+++ b/src/main/scala/firrtl/passes/Uniquify.scala
@@ -9,6 +9,7 @@ import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
 import firrtl.options.Dependency
+import firrtl.stage.CircuitPhase
 
 import MemPortUtils.memType
 
@@ -38,7 +39,7 @@ object Uniquify extends Transform {
     Seq( Dependency(ResolveKinds),
          Dependency(InferTypes) ) ++ firrtl.stage.Forms.WorkingIR
 
-  override def invalidates(a: Transform): Boolean = a match {
+  override def invalidates(a: CircuitPhase): Boolean = a match {
     case ResolveKinds | InferTypes => true
     case _ => false
   }

--- a/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
+++ b/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
@@ -8,6 +8,7 @@ import firrtl.Mappers._
 import firrtl.PrimOps.{Bits, Rem}
 import firrtl.Utils._
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 
 import scala.collection.mutable
 
@@ -24,7 +25,7 @@ import scala.collection.mutable
  *  This is technically incorrect firrtl, but allows the verilog emitter
  *  to emit correct verilog without needing to add temporary nodes
  */
-object VerilogModulusCleanup extends Pass with PreservesAll[Transform] {
+object VerilogModulusCleanup extends Pass with PreservesAll[CircuitPhase] {
 
   override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
     Seq( Dependency[firrtl.transforms.BlackBoxSourceHelper],

--- a/src/main/scala/firrtl/passes/VerilogPrep.scala
+++ b/src/main/scala/firrtl/passes/VerilogPrep.scala
@@ -5,6 +5,7 @@ import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.options.{Dependency, PreservesAll}
 import firrtl._
+import firrtl.stage.CircuitPhase
 
 import scala.collection.mutable
 
@@ -18,7 +19,7 @@ import scala.collection.mutable
   *
   * @note The result of this pass is NOT legal Firrtl
   */
-object VerilogPrep extends Pass with PreservesAll[Transform] {
+object VerilogPrep extends Pass with PreservesAll[CircuitPhase] {
 
   override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
     Seq( Dependency[firrtl.transforms.BlackBoxSourceHelper],

--- a/src/main/scala/firrtl/passes/ZeroLengthVecs.scala
+++ b/src/main/scala/firrtl/passes/ZeroLengthVecs.scala
@@ -7,6 +7,7 @@ import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.PrimOps._
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 
 /** Handles dynamic accesses to zero-length vectors.
   *
@@ -15,7 +16,7 @@ import firrtl.options.{Dependency, PreservesAll}
   * @note Removes attaches that become degenerate after zero-length-accessor removal
   * @note Replaces "source" references to elements of zero-length vectors with always-invalid validif
   */
-object ZeroLengthVecs extends Pass with PreservesAll[Transform] {
+object ZeroLengthVecs extends Pass with PreservesAll[CircuitPhase] {
   override val prerequisites =
     Seq( Dependency(PullMuxes),
          Dependency(ResolveKinds),

--- a/src/main/scala/firrtl/passes/ZeroWidth.scala
+++ b/src/main/scala/firrtl/passes/ZeroWidth.scala
@@ -7,6 +7,7 @@ import firrtl.ir._
 import firrtl._
 import firrtl.Mappers._
 import firrtl.options.Dependency
+import firrtl.stage.CircuitPhase
 
 object ZeroWidth extends Transform {
 
@@ -19,7 +20,7 @@ object ZeroWidth extends Transform {
          Dependency[ExpandWhensAndCheck],
          Dependency(ConvertFixedToSInt) ) ++ firrtl.stage.Forms.Deduped
 
-  override def invalidates(a: Transform): Boolean = a match {
+  override def invalidates(a: CircuitPhase): Boolean = a match {
     case InferTypes => true
     case _          => false
   }

--- a/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
+++ b/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
@@ -10,6 +10,7 @@ import firrtl.Mappers._
 import firrtl.traversals.Foreachers._
 import firrtl.transforms
 import firrtl.options.Dependency
+import firrtl.stage.CircuitPhase
 
 import MemPortUtils._
 import WrappedExpression._
@@ -174,7 +175,7 @@ object VerilogMemDelays extends Pass {
     Seq( Dependency[VerilogEmitter],
          Dependency[SystemVerilogEmitter] )
 
-  override def invalidates(a: Transform): Boolean = a match {
+  override def invalidates(a: CircuitPhase): Boolean = a match {
     case _: transforms.ConstantPropagation => true
     case _ => false
   }

--- a/src/main/scala/firrtl/stage/CircuitPhase.scala
+++ b/src/main/scala/firrtl/stage/CircuitPhase.scala
@@ -1,0 +1,12 @@
+// See LICENSE for license details.
+
+package firrtl.stage
+
+import firrtl.CircuitState
+import firrtl.options.{DependencyAPI, TransformLike}
+
+abstract class CircuitPhase extends TransformLike[CircuitState] with DependencyAPI[CircuitPhase] {
+
+  override def name: String = this.getClass.getName
+
+}

--- a/src/main/scala/firrtl/stage/TransformManager.scala
+++ b/src/main/scala/firrtl/stage/TransformManager.scala
@@ -4,6 +4,14 @@ package firrtl.stage
 
 import firrtl.{CircuitForm, CircuitState, Transform, UnknownForm}
 import firrtl.options.{Dependency, DependencyManager}
+import TransformManager._
+
+object TransformManager {
+
+  /** The type used to represent dependencies between [[Transform]]s */
+  type TransformDependency = Dependency[Transform]
+
+}
 
 /** A [[Transform]] that ensures some other [[Transform]]s and their prerequisites are executed.
   *
@@ -12,8 +20,8 @@ import firrtl.options.{Dependency, DependencyManager}
   * @param knownObjects existing transform objects that have already been constructed
   */
 class TransformManager(
-  val targets: Seq[TransformManager.TransformDependency],
-  val currentState: Seq[TransformManager.TransformDependency] = Seq.empty,
+  val targets: Seq[TransformDependency],
+  val currentState: Seq[TransformDependency] = Seq.empty,
   val knownObjects: Set[Transform] = Set.empty) extends Transform with DependencyManager[CircuitState, Transform] {
 
   override def inputForm: CircuitForm = UnknownForm
@@ -22,13 +30,9 @@ class TransformManager(
 
   override def execute(state: CircuitState): CircuitState = transform(state)
 
-  override protected def copy(a: Seq[Dependency[Transform]], b: Seq[Dependency[Transform]], c: Set[Transform]) = new TransformManager(a, b, c)
-
-}
-
-object TransformManager {
-
-  /** The type used to represent dependencies between [[Transform]]s */
-  type TransformDependency = Dependency[Transform]
+  override protected def copy(
+    a: Seq[TransformDependency],
+    b: Seq[TransformDependency],
+    c: Set[Transform]) = new TransformManager(a, b, c)
 
 }

--- a/src/main/scala/firrtl/stage/TransformManager.scala
+++ b/src/main/scala/firrtl/stage/TransformManager.scala
@@ -9,7 +9,7 @@ import TransformManager._
 object TransformManager {
 
   /** The type used to represent dependencies between [[Transform]]s */
-  type TransformDependency = Dependency[Transform]
+  type TransformDependency = Dependency[CircuitPhase]
 
 }
 
@@ -22,17 +22,11 @@ object TransformManager {
 class TransformManager(
   val targets: Seq[TransformDependency],
   val currentState: Seq[TransformDependency] = Seq.empty,
-  val knownObjects: Set[Transform] = Set.empty) extends Transform with DependencyManager[CircuitState, Transform] {
-
-  override def inputForm: CircuitForm = UnknownForm
-
-  override def outputForm: CircuitForm = UnknownForm
-
-  override def execute(state: CircuitState): CircuitState = transform(state)
+  val knownObjects: Set[CircuitPhase] = Set.empty) extends CircuitPhase with DependencyManager[CircuitState, CircuitPhase] {
 
   override protected def copy(
     a: Seq[TransformDependency],
     b: Seq[TransformDependency],
-    c: Set[Transform]) = new TransformManager(a, b, c)
+    c: Set[CircuitPhase]) = new TransformManager(a, b, c)
 
 }

--- a/src/main/scala/firrtl/stage/transforms/CatchCustomTransformExceptions.scala
+++ b/src/main/scala/firrtl/stage/transforms/CatchCustomTransformExceptions.scala
@@ -3,10 +3,11 @@
 package firrtl.stage.transforms
 
 import firrtl.{CircuitState, CustomTransformException, Transform}
+import firrtl.stage.CircuitPhase
 
-class CatchCustomTransformExceptions(val underlying: Transform) extends Transform with WrappedTransform {
+class CatchCustomTransformExceptions(val underlying: CircuitPhase) extends CircuitPhase with WrappedTransform {
 
-  override def execute(c: CircuitState): CircuitState = try {
+  override def transform(c: CircuitState): CircuitState = try {
     underlying.transform(c)
   } catch {
     case e: Exception if CatchCustomTransformExceptions.isCustomTransform(trueUnderlying) => throw CustomTransformException(e)
@@ -16,7 +17,7 @@ class CatchCustomTransformExceptions(val underlying: Transform) extends Transfor
 
 object CatchCustomTransformExceptions {
 
-  private[firrtl] def isCustomTransform(xform: Transform): Boolean = {
+  private[firrtl] def isCustomTransform(xform: CircuitPhase): Boolean = {
     def getTopPackage(pack: java.lang.Package): java.lang.Package =
       Package.getPackage(pack.getName.split('.').head)
     // We use the top package of the Driver to get the top firrtl package
@@ -25,6 +26,6 @@ object CatchCustomTransformExceptions {
     }.getOrElse(true)
   }
 
-  def apply(a: Transform): CatchCustomTransformExceptions = new CatchCustomTransformExceptions(a)
+  def apply(a: CircuitPhase): CatchCustomTransformExceptions = new CatchCustomTransformExceptions(a)
 
 }

--- a/src/main/scala/firrtl/stage/transforms/Compiler.scala
+++ b/src/main/scala/firrtl/stage/transforms/Compiler.scala
@@ -3,45 +3,17 @@
 package firrtl.stage.transforms
 
 import firrtl.options.DependencyManagerUtils.CharSet
-import firrtl.stage.TransformManager
+import firrtl.stage.{CircuitPhase, TransformManager}
 import firrtl.{Transform, VerilogEmitter}
 
 class Compiler(
   targets: Seq[TransformManager.TransformDependency],
   currentState: Seq[TransformManager.TransformDependency] = Seq.empty,
-  knownObjects: Set[Transform] = Set.empty) extends TransformManager(targets, currentState, knownObjects) {
+  knownObjects: Set[CircuitPhase] = Set.empty) extends TransformManager(targets, currentState, knownObjects) {
 
   override val wrappers = Seq(
-    (a: Transform) => CatchCustomTransformExceptions(a),
-    (a: Transform) => UpdateAnnotations(a)
+    (a: CircuitPhase) => CatchCustomTransformExceptions(a),
+    (a: CircuitPhase) => UpdateAnnotations(a)
   )
-
-  override def customPrintHandling(
-    tab: String,
-    charSet: CharSet,
-    size: Int): Option[PartialFunction[(Transform, Int), Seq[String]]] = {
-
-    val (l, n, c) = (charSet.lastNode, charSet.notLastNode, charSet.continuation)
-    val last = size - 1
-
-    val f: PartialFunction[(Transform, Int), Seq[String]] = {
-      {
-        case (a: VerilogEmitter, `last`) =>
-          val firstTransforms = a.transforms.dropRight(1)
-          val lastTransform = a.transforms.last
-          Seq(s"$tab$l ${a.name}") ++
-            firstTransforms.map(t => s"""$tab${" " * c.size} $n ${t.name}""") :+
-            s"""$tab${" " * c.size} $l ${lastTransform.name}"""
-        case (a: VerilogEmitter, _) =>
-          val firstTransforms = a.transforms.dropRight(1)
-          val lastTransform = a.transforms.last
-          Seq(s"$tab$n ${a.name}") ++
-            firstTransforms.map(t => s"""$tab$c $n ${t.name}""") :+
-            s"""$tab$c $l ${lastTransform.name}"""
-      }
-    }
-
-    Some(f)
-  }
 
 }

--- a/src/main/scala/firrtl/stage/transforms/WrappedTransform.scala
+++ b/src/main/scala/firrtl/stage/transforms/WrappedTransform.scala
@@ -2,32 +2,30 @@
 
 package firrtl.stage.transforms
 
-import firrtl.Transform
+import firrtl.stage.CircuitPhase
 
-/** A [[firrtl.Transform]] that "wraps" a second [[firrtl.Transform Transform]] to do some work before and after the
-  * second [[firrtl.Transform Transform]].
+/** A [[firrtl.stage.Circuitphase]] that "wraps" a second [[firrtl.Transform Transform]] to do some work before and after the
+  * second [[firrtl.stage.CircuitPhase CircuitPhase]].
   *
   * This is intended to synergize with the [[firrtl.options.DependencyManager.wrappers]] method.
   * @see [[firrtl.stage.transforms.CatchCustomTransformExceptions]]
   * @see [[firrtl.stage.transforms.TrackTransforms]]
   * @see [[firrtl.stage.transforms.UpdateAnnotations]]
   */
-trait WrappedTransform { this: Transform =>
+trait WrappedTransform { this: CircuitPhase =>
 
   /** The underlying [[firrtl.Transform]] */
-  val underlying: Transform
+  val underlying: CircuitPhase
 
   /** Return the original [[firrtl.Transform]] if this wrapper is wrapping other wrappers. */
-  lazy final val trueUnderlying: Transform = underlying match {
+  lazy final val trueUnderlying: CircuitPhase = underlying match {
     case a: WrappedTransform => a.trueUnderlying
     case _ => underlying
   }
 
-  override final val inputForm = underlying.inputForm
-  override final val outputForm = underlying.outputForm
   override final val prerequisites = underlying.prerequisites
   override final val dependents = underlying.dependents
-  override final def invalidates(b: Transform): Boolean = underlying.invalidates(b)
-  override final lazy val name = underlying.name
+  override final def invalidates(b: CircuitPhase): Boolean = underlying.invalidates(b)
+  override final lazy val name = s"${underlying.name}.wrappedWith(${this.getClass.getName})"
 
 }

--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -7,6 +7,7 @@ import java.io.{File, FileNotFoundException, FileInputStream, FileOutputStream, 
 import firrtl._
 import firrtl.annotations._
 import firrtl.options.PreservesAll
+import firrtl.stage.CircuitPhase
 
 import scala.collection.immutable.ListSet
 
@@ -55,7 +56,7 @@ class BlackBoxNotFoundException(fileName: String, message: String) extends Firrt
   * will set the directory where the Verilog will be written.  This annotation is typically be
   * set by the execution harness, or directly in the tests
   */
-class BlackBoxSourceHelper extends firrtl.Transform with PreservesAll[Transform] {
+class BlackBoxSourceHelper extends firrtl.Transform with PreservesAll[CircuitPhase] {
   import BlackBoxSourceHelper._
   private val DefaultTargetDir = new File(".")
   override def inputForm: CircuitForm = LowForm

--- a/src/main/scala/firrtl/transforms/CheckCombLoops.scala
+++ b/src/main/scala/firrtl/transforms/CheckCombLoops.scala
@@ -13,6 +13,7 @@ import firrtl.Utils.throwInternalError
 import firrtl.graph._
 import firrtl.analyses.InstanceGraph
 import firrtl.options.{Dependency, PreservesAll, RegisteredTransform, ShellOption}
+import firrtl.stage.CircuitPhase
 
 /*
  * A case class that represents a net in the circuit. This is
@@ -94,7 +95,7 @@ case class CombinationalPath(sink: ReferenceTarget, sources: Seq[ReferenceTarget
   * @note The pass relies on ExtModulePathAnnotations to find loops through ExtModules
   * @note The pass will throw exceptions on "false paths"
   */
-class CheckCombLoops extends Transform with RegisteredTransform with PreservesAll[Transform] {
+class CheckCombLoops extends Transform with RegisteredTransform with PreservesAll[CircuitPhase] {
   def inputForm = LowForm
   def outputForm = LowForm
 

--- a/src/main/scala/firrtl/transforms/CombineCats.scala
+++ b/src/main/scala/firrtl/transforms/CombineCats.scala
@@ -9,6 +9,7 @@ import firrtl.WrappedExpression._
 import firrtl.annotations.NoTargetAnnotation
 import firrtl.options.PreservesAll
 import firrtl.options.Dependency
+import firrtl.stage.CircuitPhase
 
 import scala.collection.mutable
 
@@ -53,7 +54,7 @@ object CombineCats {
   * Use [[MaxCatLenAnnotation]] to limit the number of elements that can be concatenated.
   * The default maximum number of elements is 10.
   */
-class CombineCats extends Transform with PreservesAll[Transform] {
+class CombineCats extends Transform with PreservesAll[CircuitPhase] {
   def inputForm: LowForm.type = LowForm
   def outputForm: LowForm.type = LowForm
 

--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -14,6 +14,7 @@ import firrtl.graph.DiGraph
 import firrtl.analyses.InstanceGraph
 import firrtl.annotations.TargetToken.Ref
 import firrtl.options.Dependency
+import firrtl.stage.CircuitPhase
 
 import annotation.tailrec
 import collection.mutable
@@ -117,7 +118,7 @@ class ConstantPropagation extends Transform with ResolvedAnnotationPaths {
          Dependency[SystemVerilogEmitter],
          Dependency[VerilogEmitter] )
 
-  override def invalidates(a: Transform): Boolean = a match {
+  override def invalidates(a: CircuitPhase): Boolean = a match {
     case firrtl.passes.Legalize => true
     case _ => false
   }

--- a/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
+++ b/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
@@ -11,6 +11,7 @@ import firrtl.Mappers._
 import firrtl.Utils.{throwInternalError, kind}
 import firrtl.MemoizedHash._
 import firrtl.options.{Dependency, PreservesAll, RegisteredTransform, ShellOption}
+import firrtl.stage.CircuitPhase
 
 import collection.mutable
 
@@ -30,7 +31,7 @@ import collection.mutable
   * remove such modules, use the [[NoDedupAnnotation]] to prevent deduplication.
   */
 class DeadCodeElimination extends Transform with ResolvedAnnotationPaths with RegisteredTransform
-    with PreservesAll[Transform] {
+    with PreservesAll[CircuitPhase] {
   def inputForm = UnknownForm
   def outputForm = UnknownForm
 

--- a/src/main/scala/firrtl/transforms/Dedup.scala
+++ b/src/main/scala/firrtl/transforms/Dedup.scala
@@ -10,6 +10,7 @@ import firrtl.annotations._
 import firrtl.passes.{InferTypes, MemPortUtils}
 import firrtl.Utils.throwInternalError
 import firrtl.options.{HasShellOptions, PreservesAll, ShellOption}
+import firrtl.stage.CircuitPhase
 
 // Datastructures
 import scala.collection.mutable
@@ -39,7 +40,7 @@ case object NoCircuitDedupAnnotation extends NoTargetAnnotation with HasShellOpt
   * Specifically, the restriction of instance loops must have been checked, or else this pass can
   *  infinitely recurse
   */
-class DedupModules extends Transform with PreservesAll[Transform] {
+class DedupModules extends Transform with PreservesAll[CircuitPhase] {
   def inputForm: CircuitForm = HighForm
   def outputForm: CircuitForm = HighForm
 

--- a/src/main/scala/firrtl/transforms/FixAddingNegativeLiteralsTransform.scala
+++ b/src/main/scala/firrtl/transforms/FixAddingNegativeLiteralsTransform.scala
@@ -7,7 +7,7 @@ import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.options.{Dependency, PreservesAll}
 import firrtl.PrimOps.{Add, AsSInt, Sub, Tail}
-import firrtl.stage.Forms
+import firrtl.stage.{CircuitPhase, Forms}
 
 import scala.collection.mutable
 
@@ -107,7 +107,7 @@ object FixAddingNegativeLiterals {
   * the literal and thus not all expressions in the add are the same. This is fixed here when we directly
   * subtract the literal instead.
   */
-class FixAddingNegativeLiterals extends Transform with PreservesAll[Transform] {
+class FixAddingNegativeLiterals extends Transform with PreservesAll[CircuitPhase] {
   def inputForm = UnknownForm
   def outputForm = UnknownForm
 

--- a/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
+++ b/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
@@ -7,6 +7,7 @@ import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.Utils._
 import firrtl.options.Dependency
+import firrtl.stage.CircuitPhase
 
 import scala.collection.mutable
 
@@ -121,7 +122,7 @@ class FlattenRegUpdate extends Transform {
 
   override val dependents = Seq.empty
 
-  override def invalidates(a: Transform): Boolean = a match {
+  override def invalidates(a: CircuitPhase): Boolean = a match {
     case _: DeadCodeElimination => true
     case _ => false
   }

--- a/src/main/scala/firrtl/transforms/InferResets.scala
+++ b/src/main/scala/firrtl/transforms/InferResets.scala
@@ -11,6 +11,7 @@ import firrtl.Utils.{toTarget, throwInternalError}
 import firrtl.options.Dependency
 import firrtl.passes.{Pass, PassException, InferTypes}
 import firrtl.graph.MutableDiGraph
+import firrtl.stage.CircuitPhase
 
 import scala.collection.mutable
 import scala.util.Try
@@ -122,7 +123,7 @@ class InferResets extends Transform {
          Dependency(passes.ResolveFlows),
          Dependency[passes.InferWidths] ) ++ stage.Forms.WorkingIR
 
-  override def invalidates(a: Transform): Boolean = a match {
+  override def invalidates(a: CircuitPhase): Boolean = a match {
     case _: checks.CheckResets | passes.CheckTypes => true
     case _                                         => false
   }

--- a/src/main/scala/firrtl/transforms/InlineBitExtractions.scala
+++ b/src/main/scala/firrtl/transforms/InlineBitExtractions.scala
@@ -6,6 +6,7 @@ package transforms
 import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 import firrtl.PrimOps.{Bits, Head, Tail, Shr}
 import firrtl.Utils.{isBitExtract, isTemp}
 import firrtl.WrappedExpression._
@@ -94,7 +95,7 @@ object InlineBitExtractionsTransform {
 }
 
 /** Inline nodes that are simple bits */
-class InlineBitExtractionsTransform extends Transform with PreservesAll[Transform] {
+class InlineBitExtractionsTransform extends Transform with PreservesAll[CircuitPhase] {
   def inputForm = UnknownForm
   def outputForm = UnknownForm
 

--- a/src/main/scala/firrtl/transforms/InlineCasts.scala
+++ b/src/main/scala/firrtl/transforms/InlineCasts.scala
@@ -7,6 +7,7 @@ import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.PrimOps.Pad
 import firrtl.options.Dependency
+import firrtl.stage.CircuitPhase
 
 import firrtl.Utils.{isCast, isBitExtract, NodeMap}
 
@@ -81,7 +82,7 @@ class InlineCastsTransform extends Transform {
 
   override val dependents = Seq.empty
 
-  override def invalidates(a: Transform): Boolean = a match {
+  override def invalidates(a: CircuitPhase): Boolean = a match {
     case _: LegalizeClocksTransform => true
     case _ => false
   }

--- a/src/main/scala/firrtl/transforms/LegalizeClocks.scala
+++ b/src/main/scala/firrtl/transforms/LegalizeClocks.scala
@@ -5,6 +5,7 @@ import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.options.{Dependency, PreservesAll}
 import firrtl.Utils.isCast
+import firrtl.stage.CircuitPhase
 
 // Fixup otherwise legal Verilog that lint tools and other tools don't like
 // Currently:
@@ -59,7 +60,7 @@ object LegalizeClocksTransform {
 }
 
 /** Ensure Clocks to be emitted are legal Verilog */
-class LegalizeClocksTransform extends Transform with PreservesAll[Transform] {
+class LegalizeClocksTransform extends Transform with PreservesAll[CircuitPhase] {
   def inputForm = UnknownForm
   def outputForm = UnknownForm
 

--- a/src/main/scala/firrtl/transforms/PropagatePresetAnnotations.scala
+++ b/src/main/scala/firrtl/transforms/PropagatePresetAnnotations.scala
@@ -7,6 +7,7 @@ import firrtl.PrimOps._
 import firrtl.annotations._
 import firrtl.ir.{AsyncResetType, _}
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 
 import scala.collection.mutable
 
@@ -36,7 +37,7 @@ object PropagatePresetAnnotations {
   *
   * @note This pass must run before InlineCastsTransform
   */
-class PropagatePresetAnnotations extends Transform with PreservesAll[Transform] {
+class PropagatePresetAnnotations extends Transform with PreservesAll[CircuitPhase] {
   def inputForm = UnknownForm
   def outputForm = UnknownForm
 

--- a/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
+++ b/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
@@ -11,6 +11,7 @@ import firrtl.passes.{Uniquify, PassException}
 import firrtl.Utils.v_keywords
 import firrtl.Mappers._
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 
 import scala.collection.mutable
 
@@ -233,7 +234,7 @@ class RemoveKeywordCollisions(keywords: Set[String]) extends Transform {
 }
 
 /** Transform that removes collisions with Verilog keywords */
-class VerilogRename extends RemoveKeywordCollisions(v_keywords) with PreservesAll[Transform] {
+class VerilogRename extends RemoveKeywordCollisions(v_keywords) with PreservesAll[CircuitPhase] {
 
   override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
     Seq( Dependency[BlackBoxSourceHelper],

--- a/src/main/scala/firrtl/transforms/RemoveReset.scala
+++ b/src/main/scala/firrtl/transforms/RemoveReset.scala
@@ -8,6 +8,7 @@ import firrtl.Mappers._
 import firrtl.traversals.Foreachers._
 import firrtl.WrappedExpression.we
 import firrtl.options.Dependency
+import firrtl.stage.CircuitPhase
 
 import scala.collection.{immutable, mutable}
 
@@ -27,7 +28,7 @@ object RemoveReset extends Transform {
 
   override val dependents = Seq.empty
 
-  override def invalidates(a: Transform): Boolean = a match {
+  override def invalidates(a: CircuitPhase): Boolean = a match {
     case firrtl.passes.ResolveFlows => true
     case _                          => false
   }

--- a/src/main/scala/firrtl/transforms/RemoveWires.scala
+++ b/src/main/scala/firrtl/transforms/RemoveWires.scala
@@ -10,6 +10,7 @@ import firrtl.traversals.Foreachers._
 import firrtl.WrappedExpression._
 import firrtl.graph.{MutableDiGraph, CyclicException}
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 
 import scala.collection.mutable
 import scala.util.{Try, Success, Failure}
@@ -20,7 +21,7 @@ import scala.util.{Try, Success, Failure}
   *  wires have multiple connections that may be impossible to order in a
   *  flow-foward way
   */
-class RemoveWires extends Transform with PreservesAll[Transform] {
+class RemoveWires extends Transform with PreservesAll[CircuitPhase] {
   def inputForm = LowForm
   def outputForm = LowForm
 

--- a/src/main/scala/firrtl/transforms/ReplaceTruncatingArithmetic.scala
+++ b/src/main/scala/firrtl/transforms/ReplaceTruncatingArithmetic.scala
@@ -8,6 +8,7 @@ import firrtl.Mappers._
 import firrtl.PrimOps._
 import firrtl.WrappedExpression._
 import firrtl.options.{Dependency, PreservesAll}
+import firrtl.stage.CircuitPhase
 
 import scala.collection.mutable
 
@@ -77,7 +78,7 @@ object ReplaceTruncatingArithmetic {
   * @note This replaces some FIRRTL primops with ops that are not actually legal FIRRTL. They are
   * useful for emission to languages that support non-expanding arithmetic (like Verilog)
   */
-class ReplaceTruncatingArithmetic extends Transform with PreservesAll[Transform] {
+class ReplaceTruncatingArithmetic extends Transform with PreservesAll[CircuitPhase] {
   def inputForm = UnknownForm
   def outputForm = UnknownForm
 

--- a/src/test/scala/firrtl/testutils/FirrtlSpec.scala
+++ b/src/test/scala/firrtl/testutils/FirrtlSpec.scala
@@ -14,7 +14,7 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Parser.UseInfo
 import firrtl.options.{Dependency, PreservesAll}
-import firrtl.stage.{FirrtlFileAnnotation, InfoModeAnnotation, RunFirrtlTransformAnnotation}
+import firrtl.stage.{CircuitPhase, FirrtlFileAnnotation, InfoModeAnnotation, RunFirrtlTransformAnnotation}
 import firrtl.analyses.{GetNamespace, ModuleNamespaceAnnotation}
 import firrtl.annotations._
 import firrtl.transforms.{DontTouchAnnotation, NoDedupAnnotation, RenameModules}
@@ -33,7 +33,7 @@ class CheckLowForm extends SeqTransform {
 
 case class RenameTopAnnotation(newTopName: String) extends NoTargetAnnotation
 
-object RenameTop extends Transform with PreservesAll[Transform] {
+object RenameTop extends Transform with PreservesAll[CircuitPhase] {
   def inputForm = UnknownForm
   def outputForm = UnknownForm
 

--- a/src/test/scala/firrtlTests/CustomTransformSpec.scala
+++ b/src/test/scala/firrtlTests/CustomTransformSpec.scala
@@ -7,7 +7,7 @@ import firrtl._
 import firrtl.passes.Pass
 import firrtl.ir._
 
-import firrtl.stage.{FirrtlSourceAnnotation, FirrtlStage, Forms, RunFirrtlTransformAnnotation}
+import firrtl.stage.{CircuitPhase, FirrtlSourceAnnotation, FirrtlStage, Forms, RunFirrtlTransformAnnotation}
 import firrtl.options.Dependency
 import firrtl.transforms.IdentityTransform
 
@@ -153,7 +153,7 @@ class CustomTransformSpec extends FirrtlFlatSpec {
 
     val custom = Dependency[IdentityLowForm]
 
-    def testOrder(emitter: Dependency[Emitter], preceders: Seq[Dependency[Transform]]): Unit = {
+    def testOrder(emitter: Dependency[Emitter], preceders: Seq[Dependency[CircuitPhase]]): Unit = {
       info(s"""${preceders.map(_.getSimpleName).mkString(" -> ")} -> ${custom.getSimpleName} -> ${emitter.getSimpleName} ok!""")
 
       val compiler = new firrtl.stage.transforms.Compiler(Seq(custom, emitter))

--- a/src/test/scala/firrtlTests/InlineInstancesTests.scala
+++ b/src/test/scala/firrtlTests/InlineInstancesTests.scala
@@ -559,7 +559,7 @@ class InlineInstancesTests extends LowTransformSpec {
 
     val state = CircuitState(parse(input), ChirrtlForm, Seq(inline("Inline")))
     val manager = new TransformManager(Seq(Dependency[InlineInstances], Dependency(ResolveKinds)))
-    val result = manager.execute(state)
+    val result = manager.transform(state)
 
     result shouldNot containTree { case WRef("i_a", _, PortKind, _) => true }
     result should    containTree { case WRef("i_a", _, WireKind, _) => true }

--- a/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
+++ b/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import firrtl._
 import firrtl.passes
 import firrtl.options.Dependency
-import firrtl.stage.{Forms, TransformManager}
+import firrtl.stage.{CircuitPhase, Forms, TransformManager}
 import firrtl.transforms.IdentityTransform
 
 sealed trait PatchAction { val line: Int }
@@ -108,10 +108,10 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       passes.SplitExpressions)
   }
 
-  def compare(a: Seq[Transform], b: TransformManager, patches: Seq[PatchAction] = Seq.empty): Unit = {
+  def compare(a: Seq[CircuitPhase], b: TransformManager, patches: Seq[PatchAction] = Seq.empty): Unit = {
     info(s"""Transform Order:\n${b.prettyPrint("    ")}""")
 
-    val m = new scala.collection.mutable.HashMap[Int, Seq[Dependency[Transform]]].withDefault(_ => Seq.empty)
+    val m = new scala.collection.mutable.HashMap[Int, Seq[Dependency[CircuitPhase]]].withDefault(_ => Seq.empty)
     a.map(Dependency.fromTransform).zipWithIndex.foreach{ case (t, idx) => m(idx) = Seq(t) }
 
     patches.foreach {

--- a/src/test/scala/firrtlTests/stage/phases/CompilerSpec.scala
+++ b/src/test/scala/firrtlTests/stage/phases/CompilerSpec.scala
@@ -7,7 +7,7 @@ import scala.collection.mutable
 
 import firrtl.{Compiler => _, _}
 import firrtl.options.{Phase, PreservesAll}
-import firrtl.stage.{CompilerAnnotation, FirrtlCircuitAnnotation, Forms, RunFirrtlTransformAnnotation}
+import firrtl.stage.{CircuitPhase, CompilerAnnotation, FirrtlCircuitAnnotation, Forms, RunFirrtlTransformAnnotation}
 import firrtl.stage.phases.Compiler
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -161,9 +161,10 @@ class CompilerSpec extends AnyFlatSpec with Matchers {
 
 object CompilerSpec {
 
-  private[CompilerSpec] val globalState: mutable.Queue[Class[_ <: Transform]] = mutable.Queue.empty[Class[_ <: Transform]]
+  private[CompilerSpec] val globalState: mutable.Queue[Class[_ <: CircuitPhase]] =
+    mutable.Queue.empty[Class[_ <: CircuitPhase]]
 
-  class LoggingTransform extends Transform with PreservesAll[Transform] {
+  class LoggingTransform extends Transform with PreservesAll[CircuitPhase] {
     override def inputForm = UnknownForm
     override def outputForm = UnknownForm
     override def prerequisites = Forms.HighForm


### PR DESCRIPTION
This one of two considered approaches for deprecating `CircuitForm`.

This approach creates a new parent of `Transform` called `CircuitPhase`. which removes the abstract methods `inputForm: CircuitForm` and `outputForm: CircuitForm`.

This PR has the follow benefits:

- This enables a two-step deprecation process. We deprecate `Transform` in 1.3 telling users to migrate to `CircuitPhase` and remove `Transform` in 1.4.

This PR has a number of drawbacks:

- `Transform` now mixes in `DependencyAPI[CircuitPhase]` as opposed to `DependencyAPI[Transform]`. This means that any use of an explicit `Transform` type like `PreservesAll[Transform]` or dependency specification as returning a `Transform`, e.g., `invalidates(a: Transform)` is now overly specified and will not compile. Type inference should be unaffected.
- The name `Transform` is both prolific and subjectively better than `CircuitPhase`

There are a number of extremely thorny issues here that make any kind of deprecation schedule difficult to implement:

- An `Emitter` is a `Transform` and legacy compilers depend on the existence of `Transform`-only methods (`inputForm`, etc.) to do scheduling via legacy schedulers (`getLoweringTransforms`). Making `Emitter extend CircuitPhase` is therefore extremely tricky.
- Anything using the `prepare` method (e.g., `ResolvedAnnotationPaths`) needs to be converted to use the dependency API. This should mean that a `CircuitPhase` both requires and invalidates a `CircuitPhase`.

tl;dr: This is a huge pain.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR? (**Unnecessary here**)
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
- code refactoring
- code cleanup
<!--   - backend code generation            -->
- new feature/API

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

None.

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Deprecate Transform in favor of CircuitPhase

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
