### PR TITLE
Trait-base Dependency API Migration

### DIFF
--- a/src/main/scala/firrtl/AddDescriptionNodes.scala
+++ b/src/main/scala/firrtl/AddDescriptionNodes.scala
@@ -68,11 +68,9 @@ private case class DescribedMod(description: Description,
   * @note should only be used by VerilogEmitter, described nodes will
   *       break other transforms.
   */
-class AddDescriptionNodes extends Transform with PreservesAll[Transform] {
-  def inputForm = UnknownForm
-  def outputForm = UnknownForm
+class AddDescriptionNodes extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
+  override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
     Seq( Dependency[firrtl.transforms.BlackBoxSourceHelper],
          Dependency[firrtl.transforms.FixAddingNegativeLiterals],
          Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
@@ -85,9 +83,9 @@ class AddDescriptionNodes extends Transform with PreservesAll[Transform] {
          Dependency[firrtl.transforms.VerilogRename],
          Dependency(firrtl.passes.VerilogPrep) )
 
-  override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
+  override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   def onStmt(compMap: Map[String, Seq[String]])(stmt: Statement): Statement = {
     stmt.map(onStmt(compMap)) match {

--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -13,6 +13,7 @@ import firrtl.ir.Circuit
 import firrtl.Utils.throwInternalError
 import firrtl.annotations.transforms.{EliminateTargetPaths, ResolvePaths}
 import firrtl.options.{DependencyAPI, Dependency, PreservesAll, StageUtils, TransformLike}
+import firrtl.stage.Forms
 import firrtl.stage.transforms.CatchCustomTransformExceptions
 
 /** Container of all annotations for a Firrtl compiler */
@@ -100,7 +101,9 @@ object CircuitState {
   * strictly supersets of the "lower" forms. Thus, that any transform that
   * operates on [[HighForm]] can also operate on [[MidForm]] or [[LowForm]]
   */
-@deprecated("CircuitForm will be removed in 1.3. Switch to Seq[TransformDependency] to specify dependencies.", "1.2")
+@deprecated(
+  "Mix-in the DependencyAPIMigration trait into your Transform and specify its Dependency API dependencies. See: https://bit.ly/2Voppre",
+  "FIRRTL 1.3")
 sealed abstract class CircuitForm(private val value: Int) extends Ordered[CircuitForm] {
   // Note that value is used only to allow comparisons
   def compare(that: CircuitForm): Int = this.value - that.value
@@ -119,7 +122,9 @@ sealed abstract class CircuitForm(private val value: Int) extends Ordered[Circui
   *
   * See [[CDefMemory]] and [[CDefMPort]]
   */
-@deprecated("Form-based dependencies will be removed in 1.3. Please migrate to the new Dependency API.", "1.2")
+@deprecated(
+  "Mix-in the DependencyAPIMigration trait into your Transform and specify its Dependency API dependencies. See: https://bit.ly/2Voppre",
+  "FIRRTL 1.3")
 final case object ChirrtlForm extends CircuitForm(value = 3) {
   val outputSuffix: String = ".fir"
 }
@@ -131,7 +136,9 @@ final case object ChirrtlForm extends CircuitForm(value = 3) {
   *
   * Also see [[firrtl.ir]]
   */
-@deprecated("Form-based dependencies will be removed in 1.3. Please migrate to the new Dependency API.", "1.2")
+@deprecated(
+  "Mix-in the DependencyAPIMigration trait into your Transform and specify its Dependency API dependencies. See: https://bit.ly/2Voppre",
+  "FIRRTL 1.3")
 final case object HighForm extends CircuitForm(2) {
   val outputSuffix: String = ".hi.fir"
 }
@@ -143,7 +150,9 @@ final case object HighForm extends CircuitForm(2) {
   *  - All whens must be removed
   *  - There can only be a single connection to any element
   */
-@deprecated("Form-based dependencies will be removed in 1.3. Please migrate to the new Dependency API.", "1.2")
+@deprecated(
+  "Mix-in the DependencyAPIMigration trait into your Transform and specify its Dependency API dependencies. See: https://bit.ly/2Voppre",
+  "FIRRTL 1.3")
 final case object MidForm extends CircuitForm(1) {
   val outputSuffix: String = ".mid.fir"
 }
@@ -154,7 +163,9 @@ final case object MidForm extends CircuitForm(1) {
   *  - All aggregate types (vector/bundle) must have been removed
   *  - All implicit truncations must be made explicit
   */
-@deprecated("Form-based dependencies will be removed in 1.3. Please migrate to the new Dependency API.", "1.2")
+@deprecated(
+  "Mix-in the DependencyAPIMigration trait into your Transform and specify its Dependency API dependencies. See: https://bit.ly/2Voppre",
+  "FIRRTL 1.3")
 final case object LowForm extends CircuitForm(0) {
   val outputSuffix: String = ".lo.fir"
 }
@@ -170,7 +181,9 @@ final case object LowForm extends CircuitForm(0) {
   * TODO(azidar): Replace with PreviousForm, which more explicitly encodes
   * this requirement.
   */
-@deprecated("Form-based dependencies will be removed in 1.3. Please migrate to the new Dependency API.", "1.2")
+@deprecated(
+  "Mix-in the DependencyAPIMigration trait into your Transform and specify its Dependency API dependencies. See: https://bit.ly/2Voppre",
+  "FIRRTL 1.3")
 final case object UnknownForm extends CircuitForm(-1) {
   override def compare(that: CircuitForm): Int = { sys.error("Illegal to compare UnknownForm"); 0 }
 
@@ -183,16 +196,17 @@ trait Transform extends TransformLike[CircuitState] with DependencyAPI[Transform
 
   /** A convenience function useful for debugging and error messages */
   def name: String = this.getClass.getName
+
   /** The [[firrtl.CircuitForm]] that this transform requires to operate on */
   @deprecated(
-    "InputForm/OutputForm will be removed in 1.3. Use DependencyAPI methods (prerequisites, dependents, invalidates)",
-    "1.2")
+    "Use Dependency API methods for equivalent functionality. See: https://bit.ly/2Voppre",
+    "FIRRTL 1.3")
   def inputForm: CircuitForm
 
   /** The [[firrtl.CircuitForm]] that this transform outputs */
   @deprecated(
-    "InputForm/OutputForm will be removed in 1.3. Use DependencyAPI methods (prerequisites, dependents, invalidates)",
-    "1.2")
+    "Use Dependency API methods for equivalent functionality. See: https://bit.ly/2Voppre",
+    "FIRRTL 1.3")
   def outputForm: CircuitForm
 
   /** Perform the transform, encode renaming with RenameMap, and can
@@ -206,8 +220,11 @@ trait Transform extends TransformLike[CircuitState] with DependencyAPI[Transform
 
   def transform(state: CircuitState): CircuitState = execute(state)
 
-  import firrtl.{ChirrtlForm => C, HighForm => H, MidForm => M, LowForm => L, UnknownForm => U}
-  import firrtl.stage.Forms
+  private val C = ChirrtlForm
+  private val H = HighForm
+  private val M = MidForm
+  private val L = LowForm
+  private val U = UnknownForm
 
   override def prerequisites: Seq[Dependency[Transform]] = inputForm match {
     case C => Nil

--- a/src/main/scala/firrtl/DependencyAPIMigration.scala
+++ b/src/main/scala/firrtl/DependencyAPIMigration.scala
@@ -1,0 +1,38 @@
+// See LICENSE for license details.
+
+package firrtl
+
+import firrtl.stage.TransformManager.TransformDependency
+
+/** This trait helps ease migration from old [[firrtl.CircuitForm CircuitForm]] specification of dependencies to
+  * Dependency API specification of dependencies. This trait implements deprecated, abstract [[Transform]] methods
+  * (`inputForm` and `outputForm`) for you and sets default values for dependencies:
+  *
+  *    - `prerequisites` are empty
+  *    - `optionalPrerequisites` are empty
+  *    - `dependents` are empty
+  *    - all transforms are invalidated
+  *
+  * For more information, see: https://bit.ly/2Voppre
+  */
+trait DependencyAPIMigration { this: Transform =>
+
+  @deprecated(
+    "Use Dependency API methods for equivalent functionality. See: https://bit.ly/2Voppre",
+    "FIRRTL 1.3")
+  final override def inputForm: CircuitForm = UnknownForm
+
+  @deprecated(
+    "Use Dependency API methods for equivalent functionality. See: https://bit.ly/2Voppre",
+    "FIRRTL 1.3")
+  final override def outputForm: CircuitForm = UnknownForm
+
+  override def prerequisites: Seq[TransformDependency] = Seq.empty
+
+  override def optionalPrerequisites: Seq[TransformDependency] = Seq.empty
+
+  override def dependents: Seq[TransformDependency] = Seq.empty
+
+  override def invalidates(a: Transform): Boolean = true
+
+}

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -180,9 +180,9 @@ class VerilogEmitter extends SeqTransform with Emitter {
   def inputForm = LowForm
   def outputForm = LowForm
 
-  override val prerequisites = firrtl.stage.Forms.LowFormOptimized
+  override def prerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   val outputSuffix = ".v"
   val tab = "  "
@@ -1108,7 +1108,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
 
 class MinimumVerilogEmitter extends VerilogEmitter with Emitter {
 
-  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized
+  override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized
 
   override def transforms = new TransformManager(firrtl.stage.Forms.VerilogMinimumOptimized, prerequisites)
     .flattenedTransformOrder

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -12,7 +12,10 @@ sealed abstract class CoreTransform extends SeqTransform
 /** This transforms "CHIRRTL", the chisel3 IR, to "Firrtl". Note the resulting
   * circuit has only IR nodes, not WIR.
   */
-@deprecated("Use a TransformManager to handle lowering. Will be removed in 1.3.", "1.2")
+@deprecated(
+  "Use 'new TransformManager(Forms.MinimalHighForm, Forms.ChirrtlForm)'. This will be removed in 1.4.",
+  "FIRRTL 1.3"
+)
 class ChirrtlToHighFirrtl extends CoreTransform {
   def inputForm = ChirrtlForm
   def outputForm = HighForm
@@ -22,7 +25,10 @@ class ChirrtlToHighFirrtl extends CoreTransform {
 /** Converts from the bare intermediate representation (ir.scala)
   * to a working representation (WIR.scala)
   */
-@deprecated("Use a TransformManager to handle lowering. Will be removed in 1.3.", "1.2")
+@deprecated(
+  "Use 'new TransformManager(Forms.WorkingIR, Forms.MinimalHighForm)'. This will be removed in 1.4.",
+  "FIRRTL 1.3"
+)
 class IRToWorkingIR extends CoreTransform {
   def inputForm = HighForm
   def outputForm = HighForm
@@ -32,7 +38,10 @@ class IRToWorkingIR extends CoreTransform {
 /** Resolves types, kinds, and flows, and checks the circuit legality.
   * Operates on working IR nodes and high Firrtl.
   */
-@deprecated("Use a TransformManager to handle lowering. Will be removed in 1.3.", "1.2")
+@deprecated(
+  "Use 'new TransformManager(Forms.Resolved, Forms.WorkingIR)'. This will be removed in 1.4.",
+  "FIRRTL 1.3"
+)
 class ResolveAndCheck extends CoreTransform {
   def inputForm = HighForm
   def outputForm = HighForm
@@ -44,7 +53,10 @@ class ResolveAndCheck extends CoreTransform {
   * well-formed graph.
   * Operates on working IR nodes.
   */
-@deprecated("Use a TransformManager to handle lowering. Will be removed in 1.3.", "1.2")
+@deprecated(
+  "Use 'new TransformManager(Forms.MidForm, Forms.Deduped)'. This will be removed in 1.4.",
+  "FIRRTL 1.3"
+)
 class HighFirrtlToMiddleFirrtl extends CoreTransform {
   def inputForm = HighForm
   def outputForm = MidForm
@@ -55,7 +67,10 @@ class HighFirrtlToMiddleFirrtl extends CoreTransform {
   * accept a well-formed graph of only middle Firrtl features.
   * Operates on working IR nodes.
   */
-@deprecated("Use a TransformManager to handle lowering. Will be removed in 1.3.", "1.2")
+@deprecated(
+  "Use 'new TransformManager(Forms.LowForm, Forms.MidForm)'. This will be removed in 1.4.",
+  "FIRRTL 1.3"
+)
 class MiddleFirrtlToLowFirrtl extends CoreTransform {
   def inputForm = MidForm
   def outputForm = LowForm
@@ -66,27 +81,35 @@ class MiddleFirrtlToLowFirrtl extends CoreTransform {
   * @note This is currently required for correct Verilog emission
   * TODO Fix the above note
   */
-@deprecated("Use a TransformManager to handle lowering. Will be removed in 1.3.", "1.2")
+@deprecated(
+  "Use 'new TransformManager(Forms.LowFormOptimized, Forms.LowForm)'. This will be removed in 1.4.",
+  "FIRRTL 1.3"
+)
 class LowFirrtlOptimization extends CoreTransform {
   def inputForm = LowForm
   def outputForm = LowForm
   def transforms = new TransformManager(Forms.LowFormOptimized, Forms.LowForm).flattenedTransformOrder
 }
+
 /** Runs runs only the optimization passes needed for Verilog emission */
-@deprecated("Use a TransformManager to handle lowering. Will be removed in 1.3.", "1.2")
+  @deprecated(
+    "Use 'new TransformManager(Forms.LowFormMinimumOptimized, Forms.LowForm)'. This will be removed in 1.4.",
+    "FIRRTL 1.3"
+  )
 class MinimumLowFirrtlOptimization extends CoreTransform {
   def inputForm = LowForm
   def outputForm = LowForm
   def transforms = new TransformManager(Forms.LowFormMinimumOptimized, Forms.LowForm).flattenedTransformOrder
 }
 
-
-import CompilerUtils.getLoweringTransforms
-
 /** Emits input circuit with no changes
   *
   * Primarily useful for changing between .fir and .pb serialized formats
   */
+@deprecated(
+  "Use stage.{FirrtlStage, FirrtlMain} or stage.transforms.Compiler(Seq(Dependency[ChirrtlEmitter]))",
+  "FIRRTL 1.3"
+)
 class NoneCompiler extends Compiler {
   val emitter = new ChirrtlEmitter
   def transforms: Seq[Transform] = Seq(new IdentityTransform(ChirrtlForm))
@@ -95,38 +118,60 @@ class NoneCompiler extends Compiler {
 /** Emits input circuit
   * Will replace Chirrtl constructs with Firrtl
   */
+@deprecated(
+  "Use stage.{FirrtlStage, FirrtlMain} stage.transforms.Compiler(Seq(Dependency[HighFirrtlEmitter]))",
+  "FIRRTL 1.3"
+)
 class HighFirrtlCompiler extends Compiler {
   val emitter = new HighFirrtlEmitter
-  def transforms: Seq[Transform] = getLoweringTransforms(ChirrtlForm, HighForm)
+  def transforms: Seq[Transform] = Forms.HighForm.map(_.getObject)
 }
 
 /** Emits middle Firrtl input circuit */
+@deprecated(
+  "Use stage.{FirrtlStage, FirrtlMain} stage.transforms.Compiler(Dependency[MiddleFirrtlEmitter])",
+  "FIRRTL 1.3"
+)
 class MiddleFirrtlCompiler extends Compiler {
   val emitter = new MiddleFirrtlEmitter
-  def transforms: Seq[Transform] = getLoweringTransforms(ChirrtlForm, MidForm)
+  def transforms: Seq[Transform] = Forms.MidForm.map(_.getObject)
 }
 
 /** Emits lowered input circuit */
+@deprecated(
+  "Use stage.{FirrtlStage, FirrtlMain} stage.transforms.Compiler(Dependency[LowFirrtlEmitter])",
+  "FIRRTL 1.3"
+)
 class LowFirrtlCompiler extends Compiler {
   val emitter = new LowFirrtlEmitter
-  def transforms: Seq[Transform] = getLoweringTransforms(ChirrtlForm, LowForm)
+  def transforms: Seq[Transform] = Forms.LowForm.map(_.getObject)
 }
 
 /** Emits Verilog */
+@deprecated(
+  "Use stage.{FirrtlStage, FirrtlMain} stage.transforms.Compiler(Dependency[VerilogEmitter])",
+  "FIRRTL 1.3"
+)
 class VerilogCompiler extends Compiler {
   val emitter = new VerilogEmitter
-  def transforms: Seq[Transform] = getLoweringTransforms(ChirrtlForm, LowForm) ++
-    Seq(new LowFirrtlOptimization)
+  def transforms: Seq[Transform] = Forms.LowFormOptimized.map(_.getObject)
 }
 
 /** Emits Verilog without optimizations */
+@deprecated(
+  "Use stage.{FirrtlStage, FirrtlMain} stage.transforms.Compiler(Dependency[MinimumVerilogEmitter])",
+  "FIRRTL 1.3"
+)
 class MinimumVerilogCompiler extends Compiler {
   val emitter = new MinimumVerilogEmitter
-  def transforms: Seq[Transform] = getLoweringTransforms(ChirrtlForm, LowForm) ++
-    Seq(new MinimumLowFirrtlOptimization)
+  def transforms: Seq[Transform] = Forms.LowFormMinimumOptimized.map(_.getObject)
 }
 
 /** Currently just an alias for the [[VerilogCompiler]] */
+@deprecated(
+  "Use stage.{FirrtlStage, FirrtlMain} stage.transforms.Compiler(Dependency[SystemVerilogEmitter])",
+  "FIRRTL 1.3"
+)
 class SystemVerilogCompiler extends VerilogCompiler {
   override val emitter = new SystemVerilogEmitter
   StageUtils.dramaticWarning("SystemVerilog Compiler behaves the same as the Verilog Compiler!")

--- a/src/main/scala/firrtl/analyses/GetNamespace.scala
+++ b/src/main/scala/firrtl/analyses/GetNamespace.scala
@@ -3,7 +3,9 @@
 package firrtl.analyses
 
 import firrtl.annotations.NoTargetAnnotation
-import firrtl.{CircuitState, LowForm, Namespace, Transform}
+import firrtl.{CircuitState, DependencyAPIMigration, Namespace, Transform}
+import firrtl.options.PreservesAll
+import firrtl.stage.Forms
 
 case class ModuleNamespaceAnnotation(namespace: Namespace) extends NoTargetAnnotation
 
@@ -11,9 +13,10 @@ case class ModuleNamespaceAnnotation(namespace: Namespace) extends NoTargetAnnot
   *
   * namespace is used by RenameModules to get unique names
   */
-class GetNamespace extends Transform {
-  def inputForm: LowForm.type = LowForm
-  def outputForm: LowForm.type = LowForm
+class GetNamespace extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+  override def prerequisites = Forms.LowForm
+  override def optionalPrerequisites = Seq.empty
+  override def dependents = Forms.LowEmitters
 
   def execute(state: CircuitState): CircuitState = {
     val namespace = Namespace(state.circuit)

--- a/src/main/scala/firrtl/annotations/transforms/EliminateTargetPaths.scala
+++ b/src/main/scala/firrtl/annotations/transforms/EliminateTargetPaths.scala
@@ -9,7 +9,9 @@ import firrtl.annotations.TargetToken.{Instance, OfModule, fromDefModuleToTarget
 import firrtl.annotations.analysis.DuplicationHelper
 import firrtl.annotations._
 import firrtl.ir._
-import firrtl.{CircuitForm, CircuitState, FirrtlInternalException, HighForm, RenameMap, Transform, WDefInstance}
+import firrtl.{CircuitState, DependencyAPIMigration, FirrtlInternalException, RenameMap, Transform, WDefInstance}
+import firrtl.options.PreservesAll
+import firrtl.stage.Forms
 
 import scala.collection.mutable
 
@@ -41,11 +43,11 @@ case class NoSuchTargetException(message: String) extends FirrtlInternalExceptio
   * B/x -> (B/x, B_/x) // where x is any reference in B
   * C/x -> (C/x, C_/x) // where x is any reference in C
   */
-class EliminateTargetPaths extends Transform {
+class EliminateTargetPaths extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
 
-  def inputForm: CircuitForm = HighForm
-
-  def outputForm: CircuitForm = HighForm
+  override def prerequisites = Forms.MinimalHighForm
+  override def optionalPrerequisites = Seq.empty
+  override def dependents = Seq.empty
 
   /** Replaces old ofModules with new ofModules by calling dupMap methods
     * Updates oldUsedOfModules, newUsedOfModules

--- a/src/main/scala/firrtl/checks/CheckResets.scala
+++ b/src/main/scala/firrtl/checks/CheckResets.scala
@@ -28,18 +28,16 @@ object CheckResets {
 // Must run after ExpandWhens
 // Requires
 //   - static single connections of ground types
-class CheckResets extends Transform with PreservesAll[Transform] {
-  def inputForm: CircuitForm = MidForm
-  def outputForm: CircuitForm = MidForm
+class CheckResets extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
 
-  override val prerequisites =
+  override def prerequisites =
     Seq( Dependency(passes.LowerTypes),
          Dependency(passes.Legalize),
          Dependency(firrtl.transforms.RemoveReset) ) ++ firrtl.stage.Forms.MidForm
 
-  override val optionalPrerequisites = Seq(Dependency[firrtl.transforms.CheckCombLoops])
+  override def optionalPrerequisites = Seq(Dependency[firrtl.transforms.CheckCombLoops])
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   import CheckResets._
 

--- a/src/main/scala/firrtl/options/DependencyManager.scala
+++ b/src/main/scala/firrtl/options/DependencyManager.scala
@@ -20,9 +20,11 @@ case class DependencyManagerException(message: String, cause: Throwable = null) 
 trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends TransformLike[A] with DependencyAPI[B] {
   import DependencyManagerUtils.CharSet
 
-  override lazy val prerequisites = currentState
+  override def prerequisites = currentState
 
-  override lazy val dependents = Seq.empty
+  override def dependents = Seq.empty
+
+  override def optionalPrerequisites = Seq.empty
 
   override def invalidates(a: B): Boolean = (_currentState &~ _targets)(oToD(a))
 

--- a/src/main/scala/firrtl/options/DependencyManager.scala
+++ b/src/main/scala/firrtl/options/DependencyManager.scala
@@ -114,7 +114,7 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
     val edges = bfs(
       start = _targets &~ _currentState,
       blacklist = _currentState,
-      extractor = (p: B) => new LinkedHashSet[Dependency[B]]() ++ p.prerequisites &~ _currentState)
+      extractor = (p: B) => p._prerequisites &~ _currentState)
     DiGraph(edges)
   }
 
@@ -123,7 +123,7 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
     */
   private lazy val dependentsGraph: DiGraph[B] = {
     val v = new LinkedHashSet() ++ prerequisiteGraph.getVertices
-    DiGraph(new LinkedHashMap() ++ v.map(vv => vv -> (v & (vv.dependents.toSet).map(dToO)))).reverse
+    DiGraph(new LinkedHashMap() ++ v.map(vv => vv -> (v & (vv._dependents).map(dToO)))).reverse
   }
 
   /** A directed graph of *optional* prerequisites. Each optional prerequisite is promoted to a full prerequisite if the
@@ -131,7 +131,7 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
     */
   private lazy val optionalPrerequisitesGraph: DiGraph[B] = {
     val v = new LinkedHashSet() ++ prerequisiteGraph.getVertices
-    DiGraph(new LinkedHashMap() ++ v.map(vv => vv -> (v & (vv.optionalPrerequisites.toSet).map(dToO))))
+    DiGraph(new LinkedHashMap() ++ v.map(vv => vv -> (v & (vv._optionalPrerequisites).map(dToO))))
   }
 
   /** A directed graph consisting of prerequisites derived from ALL targets. This is necessary for defining targets for
@@ -208,7 +208,7 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
     /* [todo] Seq is inefficient here, but Array has ClassTag problems. Use something else? */
     val (s, l) = sorted.foldLeft((_currentState, Seq[B]())){ case ((state, out), in) =>
       /* The prerequisites are both prerequisites AND dependents. */
-      val prereqs = new LinkedHashSet() ++ in.prerequisites ++
+      val prereqs = in._prerequisites ++
         dependencyGraph.getEdges(in).toSeq.map(oToD) ++
         otherDependents.getEdges(in).toSeq.map(oToD)
       val preprocessing: Option[B] = {

--- a/src/main/scala/firrtl/options/Phase.scala
+++ b/src/main/scala/firrtl/options/Phase.scala
@@ -107,7 +107,7 @@ trait DependencyAPI[A <: DependencyAPI[A]] { this: TransformLike[_] =>
     * $seqNote
     */
   def optionalPrerequisites: Seq[Dependency[A]] = Seq.empty
-  private[options] lazy val _optionalPrerquisites: LinkedHashSet[Dependency[A]] =
+  private[options] lazy val _optionalPrerequisites: LinkedHashSet[Dependency[A]] =
     new LinkedHashSet() ++ optionalPrerequisites.toSet
 
   /** All transforms that must run ''after'' this transform

--- a/src/main/scala/firrtl/options/Phase.scala
+++ b/src/main/scala/firrtl/options/Phase.scala
@@ -79,6 +79,29 @@ trait TransformLike[A] extends LazyLogging {
 
 }
 
+/** Mix-in that makes a [[firrtl.options.TransformLike TransformLike]] guaranteed to be an identity function on some
+  * type.
+  * @tparam A the transformed type
+  */
+trait IdentityLike[A] { this: TransformLike[A] =>
+
+  /** The internal operation of this transform which, in order for this to be an identity function, must return nothing.
+    * @param a an input object
+    * @return nothing
+    */
+  protected def internalTransform(a: A): Unit = Unit
+
+  /** This method will execute `internalTransform` and then return the original input object
+    * @param a an input object
+    * @return the input object
+    */
+  final override def transform(a: A): A = {
+    internalTransform(a)
+    a
+  }
+
+}
+
 /** Mixin that defines dependencies between [[firrtl.options.TransformLike TransformLike]]s (hereafter referred to as
   * "transforms")
   *

--- a/src/main/scala/firrtl/options/phases/AddDefaults.scala
+++ b/src/main/scala/firrtl/options/phases/AddDefaults.scala
@@ -12,9 +12,9 @@ import firrtl.options.{Dependency, Phase, PreservesAll, TargetDirAnnotation}
   */
 class AddDefaults extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(Dependency[GetIncludes], Dependency[ConvertLegacyAnnotations])
+  override def prerequisites = Seq(Dependency[GetIncludes], Dependency[ConvertLegacyAnnotations])
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = {
     val td = annotations.collectFirst{ case a: TargetDirAnnotation => a}.isEmpty

--- a/src/main/scala/firrtl/options/phases/Checks.scala
+++ b/src/main/scala/firrtl/options/phases/Checks.scala
@@ -12,9 +12,9 @@ import firrtl.options.Dependency
   */
 class Checks extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(Dependency[GetIncludes], Dependency[ConvertLegacyAnnotations], Dependency[AddDefaults])
+  override def prerequisites = Seq(Dependency[GetIncludes], Dependency[ConvertLegacyAnnotations], Dependency[AddDefaults])
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   /** Validate an [[AnnotationSeq]] for [[StageOptions]]
     * @throws OptionsException if annotations are invalid

--- a/src/main/scala/firrtl/options/phases/ConvertLegacyAnnotations.scala
+++ b/src/main/scala/firrtl/options/phases/ConvertLegacyAnnotations.scala
@@ -9,9 +9,9 @@ import firrtl.options.{Dependency, Phase, PreservesAll}
 /** Convert any [[firrtl.annotations.LegacyAnnotation LegacyAnnotation]]s to non-legacy variants */
 class ConvertLegacyAnnotations extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(Dependency[GetIncludes])
+  override def prerequisites = Seq(Dependency[GetIncludes])
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = LegacyAnnotation.convertLegacyAnnos(annotations)
 

--- a/src/main/scala/firrtl/options/phases/DeletedWrapper.scala
+++ b/src/main/scala/firrtl/options/phases/DeletedWrapper.scala
@@ -15,9 +15,9 @@ import scala.collection.mutable
 class DeletedWrapper(p: Phase) extends Phase with Translator[AnnotationSeq, (AnnotationSeq, AnnotationSeq)]
     with PreservesAll[Phase] {
 
-  override val prerequisites = Seq.empty
+  override def prerequisites = Seq.empty
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   override lazy val name: String = p.name
 

--- a/src/main/scala/firrtl/options/phases/GetIncludes.scala
+++ b/src/main/scala/firrtl/options/phases/GetIncludes.scala
@@ -18,9 +18,9 @@ import scala.util.{Try, Failure}
 /** Recursively expand all [[InputAnnotationFileAnnotation]]s in an [[AnnotationSeq]] */
 class GetIncludes extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq.empty
+  override def prerequisites = Seq.empty
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   /** Read all [[annotations.Annotation]] from a file in JSON or YAML format
     * @param filename a JSON or YAML file of [[annotations.Annotation]]

--- a/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
+++ b/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
@@ -14,13 +14,13 @@ import java.io.PrintWriter
   */
 class WriteOutputAnnotations extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites =
+  override def prerequisites =
     Seq( Dependency[GetIncludes],
          Dependency[ConvertLegacyAnnotations],
          Dependency[AddDefaults],
          Dependency[Checks] )
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   /** Write the input [[AnnotationSeq]] to a fie. */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/passes/CInferMDir.scala
+++ b/src/main/scala/firrtl/passes/CInferMDir.scala
@@ -10,7 +10,7 @@ import Utils.throwInternalError
 
 object CInferMDir extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.ChirrtlForm :+ Dependency(CInferTypes)
+  override def prerequisites = firrtl.stage.Forms.ChirrtlForm :+ Dependency(CInferTypes)
 
   type MPortDirMap = collection.mutable.LinkedHashMap[String, MPortDir]
 

--- a/src/main/scala/firrtl/passes/CheckFlows.scala
+++ b/src/main/scala/firrtl/passes/CheckFlows.scala
@@ -10,9 +10,9 @@ import firrtl.options.{Dependency, PreservesAll}
 
 object CheckFlows extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = Dependency(passes.ResolveFlows) +: firrtl.stage.Forms.WorkingIR
+  override def prerequisites = Dependency(passes.ResolveFlows) +: firrtl.stage.Forms.WorkingIR
 
-  override val dependents =
+  override def dependents =
     Seq( Dependency[passes.InferBinaryPoints],
          Dependency[passes.TrimIntervals],
          Dependency[passes.InferWidths],
@@ -118,4 +118,3 @@ object CheckFlows extends Pass with PreservesAll[Transform] {
     c
   }
 }
-

--- a/src/main/scala/firrtl/passes/CheckHighForm.scala
+++ b/src/main/scala/firrtl/passes/CheckHighForm.scala
@@ -283,9 +283,9 @@ trait CheckHighFormLike { this: Pass =>
 
 object CheckHighForm extends Pass with CheckHighFormLike with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.WorkingIR
+  override def prerequisites = firrtl.stage.Forms.WorkingIR
 
-  override val dependents =
+  override def dependents =
     Seq( Dependency(passes.ResolveKinds),
          Dependency(passes.InferTypes),
          Dependency(passes.Uniquify),

--- a/src/main/scala/firrtl/passes/CheckInitialization.scala
+++ b/src/main/scala/firrtl/passes/CheckInitialization.scala
@@ -17,7 +17,7 @@ import annotation.tailrec
   */
 object CheckInitialization extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.Resolved
+  override def prerequisites = firrtl.stage.Forms.Resolved
 
   private case class VoidExpr(stmt: Statement, voidDeps: Seq[Expression])
 

--- a/src/main/scala/firrtl/passes/CheckTypes.scala
+++ b/src/main/scala/firrtl/passes/CheckTypes.scala
@@ -13,9 +13,9 @@ import firrtl.options.{Dependency, PreservesAll}
 
 object CheckTypes extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = Dependency(InferTypes) +: firrtl.stage.Forms.WorkingIR
+  override def prerequisites = Dependency(InferTypes) +: firrtl.stage.Forms.WorkingIR
 
-  override val dependents =
+  override def dependents =
     Seq( Dependency(passes.Uniquify),
          Dependency(passes.ResolveFlows),
          Dependency(passes.CheckFlows),

--- a/src/main/scala/firrtl/passes/CheckWidths.scala
+++ b/src/main/scala/firrtl/passes/CheckWidths.scala
@@ -13,9 +13,9 @@ import firrtl.options.{Dependency, PreservesAll}
 
 object CheckWidths extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = Dependency[passes.InferWidths] +: firrtl.stage.Forms.WorkingIR
+  override def prerequisites = Dependency[passes.InferWidths] +: firrtl.stage.Forms.WorkingIR
 
-  override val dependents = Seq(Dependency[transforms.InferResets])
+  override def dependents = Seq(Dependency[transforms.InferResets])
 
   /** The maximum allowed width for any circuit element */
   val MaxWidth = 1000000

--- a/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
+++ b/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
@@ -9,14 +9,14 @@ import firrtl.options.{Dependency, PreservesAll}
 
 object CommonSubexpressionElimination extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.LowForm ++
+  override def prerequisites = firrtl.stage.Forms.LowForm ++
     Seq( Dependency(firrtl.passes.RemoveValidIf),
          Dependency[firrtl.transforms.ConstantPropagation],
          Dependency(firrtl.passes.memlib.VerilogMemDelays),
          Dependency(firrtl.passes.SplitExpressions),
          Dependency[firrtl.transforms.CombineCats] )
 
-  override val dependents =
+  override def dependents =
     Seq( Dependency[SystemVerilogEmitter],
          Dependency[VerilogEmitter] )
 

--- a/src/main/scala/firrtl/passes/ConvertFixedToSInt.scala
+++ b/src/main/scala/firrtl/passes/ConvertFixedToSInt.scala
@@ -14,7 +14,7 @@ import firrtl.options.{Dependency, PreservesAll}
   */
 object ConvertFixedToSInt extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites =
+  override def prerequisites =
     Seq( Dependency(PullMuxes),
          Dependency(ReplaceAccesses),
          Dependency(ExpandConnects),

--- a/src/main/scala/firrtl/passes/ExpandConnects.scala
+++ b/src/main/scala/firrtl/passes/ExpandConnects.scala
@@ -8,7 +8,7 @@ import firrtl.Mappers._
 
 object ExpandConnects extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites =
+  override def prerequisites =
     Seq( Dependency(PullMuxes),
          Dependency(ReplaceAccesses) ) ++ firrtl.stage.Forms.Deduped
 

--- a/src/main/scala/firrtl/passes/ExpandWhens.scala
+++ b/src/main/scala/firrtl/passes/ExpandWhens.scala
@@ -26,7 +26,7 @@ import collection.mutable
   */
 object ExpandWhens extends Pass {
 
-  override val prerequisites =
+  override def prerequisites =
     Seq( Dependency(PullMuxes),
          Dependency(ReplaceAccesses),
          Dependency(ExpandConnects),
@@ -302,9 +302,9 @@ object ExpandWhens extends Pass {
     DoPrim(Eq, Seq(e, zero), Nil, BoolType)
 }
 
-class ExpandWhensAndCheck extends SeqTransform {
+class ExpandWhensAndCheck extends Transform with DependencyAPIMigration {
 
-  override val prerequisites =
+  override def prerequisites =
     Seq( Dependency(PullMuxes),
          Dependency(ReplaceAccesses),
          Dependency(ExpandConnects),
@@ -316,9 +316,7 @@ class ExpandWhensAndCheck extends SeqTransform {
     case _ => false
   }
 
-  override def inputForm = UnknownForm
-  override def outputForm = UnknownForm
-
-  override val transforms = Seq(ExpandWhens, CheckInitialization)
+  override def execute(a: CircuitState): CircuitState =
+    Seq(ExpandWhens, CheckInitialization).foldLeft(a){ case (acc, tx) => tx.transform(acc) }
 
 }

--- a/src/main/scala/firrtl/passes/InferBinaryPoints.scala
+++ b/src/main/scala/firrtl/passes/InferBinaryPoints.scala
@@ -12,13 +12,13 @@ import firrtl.options.{Dependency, PreservesAll}
 
 class InferBinaryPoints extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites =
+  override def prerequisites =
     Seq( Dependency(ResolveKinds),
          Dependency(InferTypes),
          Dependency(Uniquify),
          Dependency(ResolveFlows) )
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   private val constraintSolver = new ConstraintSolver()
 

--- a/src/main/scala/firrtl/passes/InferTypes.scala
+++ b/src/main/scala/firrtl/passes/InferTypes.scala
@@ -10,7 +10,7 @@ import firrtl.options.{Dependency, PreservesAll}
 
 object InferTypes extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = Dependency(ResolveKinds) +: firrtl.stage.Forms.WorkingIR
+  override def prerequisites = Dependency(ResolveKinds) +: firrtl.stage.Forms.WorkingIR
 
   type TypeMap = collection.mutable.LinkedHashMap[String, Type]
 
@@ -90,7 +90,7 @@ object InferTypes extends Pass with PreservesAll[Transform] {
 
 object CInferTypes extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.ChirrtlForm
+  override def prerequisites = firrtl.stage.Forms.ChirrtlForm
 
   type TypeMap = collection.mutable.LinkedHashMap[String, Type]
 

--- a/src/main/scala/firrtl/passes/InferWidths.scala
+++ b/src/main/scala/firrtl/passes/InferWidths.scala
@@ -60,18 +60,18 @@ case class WidthGeqConstraintAnnotation(loc: ReferenceTarget, exp: ReferenceTarg
   *
   * Uses firrtl.constraint package to infer widths
   */
-class InferWidths extends Transform with ResolvedAnnotationPaths with PreservesAll[Transform] {
+class InferWidths extends Transform
+    with ResolvedAnnotationPaths
+    with DependencyAPIMigration
+    with PreservesAll[Transform] {
 
-  override val prerequisites =
+  override def prerequisites =
     Seq( Dependency(passes.ResolveKinds),
          Dependency(passes.InferTypes),
          Dependency(passes.Uniquify),
          Dependency(passes.ResolveFlows),
          Dependency[passes.InferBinaryPoints],
          Dependency[passes.TrimIntervals] ) ++ firrtl.stage.Forms.WorkingIR
-
-  def inputForm: CircuitForm = UnknownForm
-  def outputForm: CircuitForm = UnknownForm
 
   private val constraintSolver = new ConstraintSolver()
 

--- a/src/main/scala/firrtl/passes/Inline.scala
+++ b/src/main/scala/firrtl/passes/Inline.scala
@@ -9,7 +9,7 @@ import firrtl.annotations._
 import firrtl.annotations.TargetToken.{Instance, OfModule}
 import firrtl.analyses.{InstanceGraph}
 import firrtl.graph.{DiGraph, MutableDiGraph}
-import firrtl.stage.RunFirrtlTransformAnnotation
+import firrtl.stage.{Forms, RunFirrtlTransformAnnotation}
 import firrtl.options.{RegisteredTransform, ShellOption}
 
 // Datastructures
@@ -24,12 +24,15 @@ case class InlineAnnotation(target: Named) extends SingleTargetAnnotation[Named]
   * @note Only use on legal Firrtl. Specifically, the restriction of instance loops must have been checked, or else this
   * pass can infinitely recurse.
   */
-class InlineInstances extends Transform with RegisteredTransform {
-  def inputForm = LowForm
-  def outputForm = LowForm
-  private [firrtl] val inlineDelim: String = "_"
+class InlineInstances extends Transform with DependencyAPIMigration with RegisteredTransform {
+
+  override def prerequisites = Forms.LowForm
+  override def optionalPrerequisites = Seq.empty
+  override def dependents = Forms.LowEmitters
 
   override def invalidates(a: Transform): Boolean = a == ResolveKinds
+
+  private [firrtl] val inlineDelim: String = "_"
 
   val options = Seq(
     new ShellOption[Seq[String]](

--- a/src/main/scala/firrtl/passes/Legalize.scala
+++ b/src/main/scala/firrtl/passes/Legalize.scala
@@ -12,11 +12,11 @@ import firrtl.Mappers._
 // TODO replace UInt with zero-width wire instead
 object Legalize extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.MidForm :+ Dependency(LowerTypes)
+  override def prerequisites = firrtl.stage.Forms.MidForm :+ Dependency(LowerTypes)
 
-  override val optionalPrerequisites = Seq.empty
+  override def optionalPrerequisites = Seq.empty
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   private def legalizeShiftRight(e: DoPrim): Expression = {
     require(e.op == Shr)

--- a/src/main/scala/firrtl/passes/LowerTypes.scala
+++ b/src/main/scala/firrtl/passes/LowerTypes.scala
@@ -22,13 +22,11 @@ import firrtl.Mappers._
   *   wire foo_b : UInt<16>
   * }}}
   */
-object LowerTypes extends Transform {
-  def inputForm = UnknownForm
-  def outputForm = UnknownForm
+object LowerTypes extends Transform with DependencyAPIMigration {
 
-  override val prerequisites = firrtl.stage.Forms.MidForm
+  override def prerequisites = firrtl.stage.Forms.MidForm
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   override def invalidates(a: Transform): Boolean = a match {
     case ResolveKinds | InferTypes | ResolveFlows | _: InferWidths => true

--- a/src/main/scala/firrtl/passes/PadWidths.scala
+++ b/src/main/scala/firrtl/passes/PadWidths.scala
@@ -13,15 +13,15 @@ import scala.collection.mutable
 // Makes all implicit width extensions and truncations explicit
 object PadWidths extends Pass {
 
-  override val prerequisites =
+  override def prerequisites =
     ((new mutable.LinkedHashSet())
        ++ firrtl.stage.Forms.LowForm
        - Dependency(firrtl.passes.Legalize)
        + Dependency(firrtl.passes.RemoveValidIf)).toSeq
 
-  override val optionalPrerequisites = Seq(Dependency[firrtl.transforms.ConstantPropagation])
+  override def optionalPrerequisites = Seq(Dependency[firrtl.transforms.ConstantPropagation])
 
-  override val dependents =
+  override def dependents =
     Seq( Dependency(firrtl.passes.memlib.VerilogMemDelays),
          Dependency[SystemVerilogEmitter],
          Dependency[VerilogEmitter] )

--- a/src/main/scala/firrtl/passes/Pass.scala
+++ b/src/main/scala/firrtl/passes/Pass.scala
@@ -1,26 +1,15 @@
 package firrtl.passes
 
-import firrtl.Utils.error
+import firrtl.DependencyAPIMigration
 import firrtl.ir.Circuit
-import firrtl.{CircuitForm, CircuitState, FirrtlUserException, Transform, UnknownForm}
+import firrtl.{CircuitState, FirrtlUserException, Transform}
 
 /** [[Pass]] is simple transform that is generally part of a larger [[Transform]]
   * Has an [[UnknownForm]], because larger [[Transform]] should specify form
   */
-trait Pass extends Transform {
-  def inputForm: CircuitForm = UnknownForm
-  def outputForm: CircuitForm = UnknownForm
+trait Pass extends Transform with DependencyAPIMigration {
   def run(c: Circuit): Circuit
-  def execute(state: CircuitState): CircuitState = {
-    val result = (state.form, inputForm) match {
-      case (_, UnknownForm) => run(state.circuit)
-      case (UnknownForm, _) => run(state.circuit)
-      case (x, y) if x > y =>
-        error(s"[$name]: Input form must be lower or equal to $inputForm. Got ${state.form}")
-      case _ => run(state.circuit)
-    }
-    CircuitState(result, outputForm, state.annotations, state.renames)
-  }
+  def execute(state: CircuitState): CircuitState = state.copy(circuit = run(state.circuit))
 }
 
 // Error handling

--- a/src/main/scala/firrtl/passes/PullMuxes.scala
+++ b/src/main/scala/firrtl/passes/PullMuxes.scala
@@ -7,7 +7,7 @@ import firrtl.{Transform, WSubAccess, WSubField, WSubIndex}
 
 object PullMuxes extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.Deduped
+  override def prerequisites = firrtl.stage.Forms.Deduped
 
   def run(c: Circuit): Circuit = {
      def pull_muxes_e(e: Expression): Expression = e map pull_muxes_e match {

--- a/src/main/scala/firrtl/passes/RemoveAccesses.scala
+++ b/src/main/scala/firrtl/passes/RemoveAccesses.scala
@@ -16,7 +16,7 @@ import scala.collection.mutable
   */
 object RemoveAccesses extends Pass {
 
-  override val prerequisites =
+  override def prerequisites =
     Seq( Dependency(PullMuxes),
          Dependency(ZeroLengthVecs),
          Dependency(ReplaceAccesses),

--- a/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
+++ b/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
@@ -14,14 +14,12 @@ case class MPort(name: String, clk: Expression)
 case class MPorts(readers: ArrayBuffer[MPort], writers: ArrayBuffer[MPort], readwriters: ArrayBuffer[MPort])
 case class DataRef(exp: Expression, male: String, female: String, mask: String, rdwrite: Boolean)
 
-object RemoveCHIRRTL extends Transform with PreservesAll[Transform] {
+object RemoveCHIRRTL extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.ChirrtlForm ++
+  override def prerequisites = firrtl.stage.Forms.ChirrtlForm ++
     Seq( Dependency(passes.CInferTypes),
          Dependency(passes.CInferMDir) )
 
-  def inputForm: CircuitForm = UnknownForm
-  def outputForm: CircuitForm = UnknownForm
   val ut = UnknownType
   type MPortMap = collection.mutable.LinkedHashMap[String, MPorts]
   type SeqMemSet = collection.mutable.HashSet[String]
@@ -274,6 +272,6 @@ object RemoveCHIRRTL extends Transform with PreservesAll[Transform] {
     val renames = RenameMap()
     renames.setCircuit(c.main)
     val result = c copy (modules = c.modules map remove_chirrtl_m(renames))
-    CircuitState(result, outputForm, state.annotations, Some(renames))
+    state.copy(circuit = result, renames = Some(renames))
   }
 }

--- a/src/main/scala/firrtl/passes/RemoveEmpty.scala
+++ b/src/main/scala/firrtl/passes/RemoveEmpty.scala
@@ -4,8 +4,15 @@ package firrtl
 package passes
 
 import firrtl.ir._
+import firrtl.options.PreservesAll
+import firrtl.stage.Forms
 
-object RemoveEmpty extends Pass {
+object RemoveEmpty extends Pass with DependencyAPIMigration with PreservesAll[Transform] {
+
+  override def prerequisites = Seq.empty
+  override def optionalPrerequisites = Forms.LowFormOptimized
+  override def dependents = Forms.ChirrtlEmitters
+
   private def onModule(m: DefModule): DefModule = {
     m match {
       case m: Module => Module(m.info, m.name, m.ports, Utils.squashEmpty(m.body))

--- a/src/main/scala/firrtl/passes/RemoveIntervals.scala
+++ b/src/main/scala/firrtl/passes/RemoveIntervals.scala
@@ -38,7 +38,7 @@ class WrapWithRemainder(info: Info, mname: String, wrap: DoPrim)
   */
 class RemoveIntervals extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites: Seq[Dependency[Transform]] =
+  override def prerequisites: Seq[Dependency[Transform]] =
     Seq( Dependency(PullMuxes),
          Dependency(ReplaceAccesses),
          Dependency(ExpandConnects),

--- a/src/main/scala/firrtl/passes/RemoveValidIf.scala
+++ b/src/main/scala/firrtl/passes/RemoveValidIf.scala
@@ -29,9 +29,9 @@ object RemoveValidIf extends Pass {
     case other => throwInternalError(s"Unexpected type $other")
   }
 
-  override val prerequisites = firrtl.stage.Forms.LowForm
+  override def prerequisites = firrtl.stage.Forms.LowForm
 
-  override val dependents =
+  override def dependents =
     Seq( Dependency[SystemVerilogEmitter],
          Dependency[VerilogEmitter] )
 

--- a/src/main/scala/firrtl/passes/ReplaceAccesses.scala
+++ b/src/main/scala/firrtl/passes/ReplaceAccesses.scala
@@ -13,7 +13,7 @@ import firrtl.options.{Dependency, PreservesAll}
   */
 object ReplaceAccesses extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.Deduped :+ Dependency(PullMuxes)
+  override def prerequisites = firrtl.stage.Forms.Deduped :+ Dependency(PullMuxes)
 
   def run(c: Circuit): Circuit = {
     def onStmt(s: Statement): Statement = s map onStmt map onExp

--- a/src/main/scala/firrtl/passes/ResolveFlows.scala
+++ b/src/main/scala/firrtl/passes/ResolveFlows.scala
@@ -9,7 +9,7 @@ import firrtl.options.{Dependency, PreservesAll}
 
 object ResolveFlows extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites =
+  override def prerequisites =
     Seq( Dependency(passes.ResolveKinds),
          Dependency(passes.InferTypes),
          Dependency(passes.Uniquify) ) ++ firrtl.stage.Forms.WorkingIR

--- a/src/main/scala/firrtl/passes/ResolveKinds.scala
+++ b/src/main/scala/firrtl/passes/ResolveKinds.scala
@@ -9,7 +9,7 @@ import firrtl.options.PreservesAll
 
 object ResolveKinds extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.WorkingIR
+  override def prerequisites = firrtl.stage.Forms.WorkingIR
 
   type KindMap = collection.mutable.LinkedHashMap[String, Kind]
 

--- a/src/main/scala/firrtl/passes/SplitExpressions.scala
+++ b/src/main/scala/firrtl/passes/SplitExpressions.scala
@@ -16,11 +16,11 @@ import scala.collection.mutable
 //  and named intermediate nodes
 object SplitExpressions extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.LowForm ++
+  override def prerequisites = firrtl.stage.Forms.LowForm ++
     Seq( Dependency(firrtl.passes.RemoveValidIf),
          Dependency(firrtl.passes.memlib.VerilogMemDelays) )
 
-  override val dependents =
+  override def dependents =
     Seq( Dependency[SystemVerilogEmitter],
          Dependency[VerilogEmitter] )
 

--- a/src/main/scala/firrtl/passes/ToWorkingIR.scala
+++ b/src/main/scala/firrtl/passes/ToWorkingIR.scala
@@ -8,7 +8,7 @@ import firrtl.{Transform, UnknownFlow, UnknownKind, WDefInstance, WRef, WSubAcce
 // These should be distributed into separate files
 object ToWorkingIR extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.MinimalHighForm
+  override def prerequisites = firrtl.stage.Forms.MinimalHighForm
 
   def toExp(e: Expression): Expression = e map toExp match {
     case ex: Reference => WRef(ex.name, ex.tpe, UnknownKind, UnknownFlow)

--- a/src/main/scala/firrtl/passes/TrimIntervals.scala
+++ b/src/main/scala/firrtl/passes/TrimIntervals.scala
@@ -22,14 +22,14 @@ import firrtl.Transform
   */
 class TrimIntervals extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites =
+  override def prerequisites =
     Seq( Dependency(ResolveKinds),
          Dependency(InferTypes),
          Dependency(Uniquify),
          Dependency(ResolveFlows),
          Dependency[InferBinaryPoints] )
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   def run(c: Circuit): Circuit = {
     // Open -> closed

--- a/src/main/scala/firrtl/passes/Uniquify.scala
+++ b/src/main/scala/firrtl/passes/Uniquify.scala
@@ -32,9 +32,9 @@ import MemPortUtils.memType
   *      there WOULD be collisions in references a[0] and a_0 so we still have
   *      to rename a
   */
-object Uniquify extends Transform {
+object Uniquify extends Transform with DependencyAPIMigration {
 
-  override val prerequisites =
+  override def prerequisites =
     Seq( Dependency(ResolveKinds),
          Dependency(InferTypes) ) ++ firrtl.stage.Forms.WorkingIR
 
@@ -43,8 +43,6 @@ object Uniquify extends Transform {
     case _ => false
   }
 
-  def inputForm = UnknownForm
-  def outputForm = UnknownForm
   private case class UniquifyException(msg: String) extends FirrtlInternalException(msg)
   private def error(msg: String)(implicit sinfo: Info, mname: String) =
     throw new UniquifyException(s"$sinfo: [moduleOpt $mname] $msg")
@@ -392,6 +390,6 @@ object Uniquify extends Transform {
 
     sinfo = c.info
     val result = Circuit(c.info, c.modules map uniquifyPorts(renames) map uniquifyModule(renames), c.main)
-    CircuitState(result, outputForm, state.annotations, Some(renames))
+    state.copy(circuit = result, renames = Some(renames))
   }
 }

--- a/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
+++ b/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
@@ -26,7 +26,7 @@ import scala.collection.mutable
  */
 object VerilogModulusCleanup extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
+  override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
     Seq( Dependency[firrtl.transforms.BlackBoxSourceHelper],
          Dependency[firrtl.transforms.FixAddingNegativeLiterals],
          Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
@@ -35,9 +35,9 @@ object VerilogModulusCleanup extends Pass with PreservesAll[Transform] {
          Dependency[firrtl.transforms.LegalizeClocksTransform],
          Dependency[firrtl.transforms.FlattenRegUpdate] )
 
-  override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
+  override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   private def onModule(m: Module): Module = {
     val namespace = Namespace(m)

--- a/src/main/scala/firrtl/passes/VerilogPrep.scala
+++ b/src/main/scala/firrtl/passes/VerilogPrep.scala
@@ -20,7 +20,7 @@ import scala.collection.mutable
   */
 object VerilogPrep extends Pass with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
+  override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
     Seq( Dependency[firrtl.transforms.BlackBoxSourceHelper],
          Dependency[firrtl.transforms.FixAddingNegativeLiterals],
          Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
@@ -31,9 +31,9 @@ object VerilogPrep extends Pass with PreservesAll[Transform] {
          Dependency(passes.VerilogModulusCleanup),
          Dependency[firrtl.transforms.VerilogRename] )
 
-  override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
+  override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   type AttachSourceMap = Map[WrappedExpression, Expression]
 

--- a/src/main/scala/firrtl/passes/ZeroLengthVecs.scala
+++ b/src/main/scala/firrtl/passes/ZeroLengthVecs.scala
@@ -16,7 +16,7 @@ import firrtl.options.{Dependency, PreservesAll}
   * @note Replaces "source" references to elements of zero-length vectors with always-invalid validif
   */
 object ZeroLengthVecs extends Pass with PreservesAll[Transform] {
-  override val prerequisites =
+  override def prerequisites =
     Seq( Dependency(PullMuxes),
          Dependency(ResolveKinds),
          Dependency(InferTypes),

--- a/src/main/scala/firrtl/passes/ZeroWidth.scala
+++ b/src/main/scala/firrtl/passes/ZeroWidth.scala
@@ -8,9 +8,9 @@ import firrtl._
 import firrtl.Mappers._
 import firrtl.options.Dependency
 
-object ZeroWidth extends Transform {
+object ZeroWidth extends Transform with DependencyAPIMigration {
 
-  override val prerequisites =
+  override def prerequisites =
     Seq( Dependency(PullMuxes),
          Dependency(ReplaceAccesses),
          Dependency(ExpandConnects),
@@ -23,9 +23,6 @@ object ZeroWidth extends Transform {
     case InferTypes => true
     case _          => false
   }
-
-  def inputForm: CircuitForm = UnknownForm
-  def outputForm: CircuitForm = UnknownForm
 
   private def makeEmptyMemBundle(name: String): Field =
     Field(name, Flip, BundleType(Seq(

--- a/src/main/scala/firrtl/passes/clocklist/ClockListTransform.scala
+++ b/src/main/scala/firrtl/passes/clocklist/ClockListTransform.scala
@@ -10,7 +10,7 @@ import java.io.{PrintWriter, Writer}
 import Utils._
 import memlib._
 import firrtl.options.{RegisteredTransform, ShellOption}
-import firrtl.stage.RunFirrtlTransformAnnotation
+import firrtl.stage.{Forms, RunFirrtlTransformAnnotation}
 
 case class ClockListAnnotation(target: ModuleName, outputConfig: String) extends
     SingleTargetAnnotation[ModuleName] {
@@ -51,9 +51,11 @@ Usage:
   }
 }
 
-class ClockListTransform extends Transform with RegisteredTransform {
-  def inputForm = LowForm
-  def outputForm = LowForm
+class ClockListTransform extends Transform with DependencyAPIMigration with RegisteredTransform {
+
+   override def prerequisites = Forms.LowForm
+   override def optionalPrerequisites = Seq.empty
+   override def dependents = Forms.LowEmitters
 
   val options = Seq(
     new ShellOption[String](

--- a/src/main/scala/firrtl/passes/memlib/DecorateMems.scala
+++ b/src/main/scala/firrtl/passes/memlib/DecorateMems.scala
@@ -4,9 +4,17 @@ package firrtl
 package passes
 package memlib
 
-class CreateMemoryAnnotations(reader: Option[YamlFileReader]) extends Transform {
-  def inputForm = MidForm
-  def outputForm = MidForm
+import firrtl.options.PreservesAll
+import firrtl.stage.Forms
+
+class CreateMemoryAnnotations(reader: Option[YamlFileReader]) extends Transform
+    with DependencyAPIMigration
+    with PreservesAll[Transform] {
+
+  override def prerequisites = Forms.MidForm
+  override def optionalPrerequisites = Seq.empty
+  override def dependents = Forms.MidEmitters
+
   def execute(state: CircuitState): CircuitState = reader match {
     case None => state
     case Some(r) =>

--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemMacros.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemMacros.scala
@@ -10,6 +10,8 @@ import firrtl.Mappers._
 import MemPortUtils.{MemPortMap, Modules}
 import MemTransformUtils._
 import firrtl.annotations._
+import firrtl.options.PreservesAll
+import firrtl.stage.Forms
 import wiring._
 
 
@@ -24,9 +26,11 @@ object ReplaceMemMacros {
   * This will not generate wmask ports if not needed.
   * Creates the minimum # of black boxes needed by the design.
   */
-class ReplaceMemMacros(writer: ConfWriter) extends Transform {
-  def inputForm = MidForm
-  def outputForm = MidForm
+class ReplaceMemMacros(writer: ConfWriter) extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+
+  override def prerequisites = Forms.MidForm
+  override def optionalPrerequisites = Seq.empty
+  override def dependents = Forms.MidEmitters
 
   /** Return true if mask granularity is per bit, false if per byte or unspecified
     */
@@ -263,6 +267,6 @@ class ReplaceMemMacros(writer: ConfWriter) extends Transform {
         case m: ExtModule => SinkAnnotation(ModuleName(m.name, CircuitName(c.main)), pin)
       }
     } ++ state.annotations
-    CircuitState(c.copy(modules = modules ++ memMods), inputForm, annos)
+    state.copy(circuit = c.copy(modules = modules ++ memMods), annotations = annos)
   }
 }

--- a/src/main/scala/firrtl/passes/memlib/ResolveMemoryReference.scala
+++ b/src/main/scala/firrtl/passes/memlib/ResolveMemoryReference.scala
@@ -6,6 +6,8 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.annotations._
+import firrtl.options.PreservesAll
+import firrtl.stage.Forms
 
 /** A component, e.g. register etc. Must be declared only once under the TopAnnotation */
 case class NoDedupMemAnnotation(target: ComponentName) extends SingleTargetAnnotation[ComponentName] {
@@ -14,9 +16,11 @@ case class NoDedupMemAnnotation(target: ComponentName) extends SingleTargetAnnot
 
 /** Resolves annotation ref to memories that exactly match (except name) another memory
  */
-class ResolveMemoryReference extends Transform {
-  def inputForm = MidForm
-  def outputForm = MidForm
+class ResolveMemoryReference extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+
+  override def prerequisites = Forms.MidForm
+  override def optionalPrerequisites = Seq.empty
+  override def dependents = Forms.MidEmitters
 
   /** Helper class for determining when two memories are equivalent while igoring
     * irrelevant details like name and info

--- a/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
+++ b/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
@@ -168,7 +168,7 @@ class MemDelayAndReadwriteTransformer(m: DefModule) {
 
 object VerilogMemDelays extends Pass {
 
-  override val prerequisites = firrtl.stage.Forms.LowForm :+ Dependency(firrtl.passes.RemoveValidIf)
+  override def prerequisites = firrtl.stage.Forms.LowForm :+ Dependency(firrtl.passes.RemoveValidIf)
 
   override val dependents =
     Seq( Dependency[VerilogEmitter],

--- a/src/main/scala/firrtl/passes/wiring/WiringTransform.scala
+++ b/src/main/scala/firrtl/passes/wiring/WiringTransform.scala
@@ -7,6 +7,7 @@ import firrtl._
 import firrtl.Utils._
 import scala.collection.mutable
 import firrtl.annotations._
+import firrtl.stage.Forms
 
 /** A class for all exceptions originating from firrtl.passes.wiring */
 case class WiringException(msg: String) extends PassException(msg)
@@ -36,9 +37,16 @@ case class SinkAnnotation(target: Named, pin: String) extends
   *
   * @throws WiringException if a sink is equidistant to two sources
   */
-class WiringTransform extends Transform {
-  def inputForm: CircuitForm = MidForm
-  def outputForm: CircuitForm = HighForm
+class WiringTransform extends Transform with DependencyAPIMigration {
+
+  override def prerequisites = Forms.MidForm
+  override def optionalPrerequisites = Seq.empty
+  override def dependents = Forms.MidEmitters
+
+  override def invalidates(a: Transform): Boolean = {
+    val everything = new mutable.LinkedHashSet[Dependency[Transform]] ++ Forms.VerilogOptimized
+    (everything -- Forms.MinimalHighForm)(Dependency.fromTransform(a))
+  }
 
   /** Defines the sequence of Transform that should be applied */
   private def transforms(w: Seq[WiringInfo]): Seq[Transform] = Seq(

--- a/src/main/scala/firrtl/passes/wiring/WiringTransform.scala
+++ b/src/main/scala/firrtl/passes/wiring/WiringTransform.scala
@@ -7,6 +7,7 @@ import firrtl._
 import firrtl.Utils._
 import scala.collection.mutable
 import firrtl.annotations._
+import firrtl.options.Dependency
 import firrtl.stage.Forms
 
 /** A class for all exceptions originating from firrtl.passes.wiring */
@@ -43,10 +44,8 @@ class WiringTransform extends Transform with DependencyAPIMigration {
   override def optionalPrerequisites = Seq.empty
   override def dependents = Forms.MidEmitters
 
-  override def invalidates(a: Transform): Boolean = {
-    val everything = new mutable.LinkedHashSet[Dependency[Transform]] ++ Forms.VerilogOptimized
-    (everything -- Forms.MinimalHighForm)(Dependency.fromTransform(a))
-  }
+  private val invalidates = Forms.VerilogOptimized.toSet -- Forms.MinimalHighForm
+  override def invalidates(a: Transform): Boolean = invalidates(Dependency.fromTransform(a))
 
   /** Defines the sequence of Transform that should be applied */
   private def transforms(w: Seq[WiringInfo]): Seq[Transform] = Seq(

--- a/src/main/scala/firrtl/stage/FirrtlStage.scala
+++ b/src/main/scala/firrtl/stage/FirrtlStage.scala
@@ -19,9 +19,11 @@ class FirrtlStage extends Stage {
 
   lazy val phase = new FirrtlPhase
 
-  override lazy val prerequisites = phase.prerequisites
+  override def prerequisites = phase.prerequisites
 
-  override lazy val dependents = phase.dependents
+  override def dependents = phase.dependents
+
+  override def optionalPrerequisites = phase.optionalPrerequisites
 
   override def invalidates(a: Phase): Boolean = phase.invalidates(a)
 

--- a/src/main/scala/firrtl/stage/Forms.scala
+++ b/src/main/scala/firrtl/stage/Forms.scala
@@ -24,18 +24,20 @@ object Forms {
 
   val WorkingIR: Seq[TransformDependency] = MinimalHighForm :+ Dependency(passes.ToWorkingIR)
 
-  val Resolved: Seq[TransformDependency] = WorkingIR ++
+  val Checks: Seq[TransformDependency] =
     Seq( Dependency(passes.CheckHighForm),
-         Dependency(passes.ResolveKinds),
-         Dependency(passes.InferTypes),
          Dependency(passes.CheckTypes),
+         Dependency(passes.CheckFlows),
+         Dependency(passes.CheckWidths) )
+
+  val Resolved: Seq[TransformDependency] = WorkingIR ++ Checks ++
+    Seq( Dependency(passes.ResolveKinds),
+         Dependency(passes.InferTypes),
          Dependency(passes.Uniquify),
          Dependency(passes.ResolveFlows),
-         Dependency(passes.CheckFlows),
          Dependency[passes.InferBinaryPoints],
          Dependency[passes.TrimIntervals],
          Dependency[passes.InferWidths],
-         Dependency(passes.CheckWidths),
          Dependency[firrtl.transforms.InferResets] )
 
   val Deduped: Seq[TransformDependency] = Resolved :+ Dependency[firrtl.transforms.DedupModules]
@@ -91,5 +93,18 @@ object Forms {
          Dependency[firrtl.AddDescriptionNodes] )
 
   val VerilogOptimized: Seq[TransformDependency] = LowFormOptimized ++ VerilogMinimumOptimized
+
+  val BackendEmitters =
+    Seq( Dependency[VerilogEmitter],
+         Dependency[MinimumVerilogEmitter],
+         Dependency[SystemVerilogEmitter] )
+
+  val LowEmitters = Dependency[LowFirrtlEmitter] +: BackendEmitters
+
+  val MidEmitters = Dependency[MiddleFirrtlEmitter] +: LowEmitters
+
+  val HighEmitters = Dependency[HighFirrtlEmitter] +: MidEmitters
+
+  val ChirrtlEmitters = Dependency[ChirrtlEmitter] +: HighEmitters
 
 }

--- a/src/main/scala/firrtl/stage/TransformManager.scala
+++ b/src/main/scala/firrtl/stage/TransformManager.scala
@@ -2,7 +2,7 @@
 
 package firrtl.stage
 
-import firrtl.{CircuitForm, CircuitState, Transform, UnknownForm}
+import firrtl.{CircuitState, DependencyAPIMigration, Transform}
 import firrtl.options.{Dependency, DependencyManager}
 
 /** A [[Transform]] that ensures some other [[Transform]]s and their prerequisites are executed.
@@ -14,11 +14,9 @@ import firrtl.options.{Dependency, DependencyManager}
 class TransformManager(
   val targets: Seq[TransformManager.TransformDependency],
   val currentState: Seq[TransformManager.TransformDependency] = Seq.empty,
-  val knownObjects: Set[Transform] = Set.empty) extends Transform with DependencyManager[CircuitState, Transform] {
-
-  override def inputForm: CircuitForm = UnknownForm
-
-  override def outputForm: CircuitForm = UnknownForm
+  val knownObjects: Set[Transform] = Set.empty) extends Transform
+    with DependencyAPIMigration
+    with DependencyManager[CircuitState, Transform] {
 
   override def execute(state: CircuitState): CircuitState = transform(state)
 

--- a/src/main/scala/firrtl/stage/phases/AddDefaults.scala
+++ b/src/main/scala/firrtl/stage/phases/AddDefaults.scala
@@ -12,9 +12,9 @@ import firrtl.stage.{CompilerAnnotation, InfoModeAnnotation, FirrtlOptions}
   */
 class AddDefaults extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq.empty
+  override def prerequisites = Seq.empty
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   /** Append any missing default annotations to an annotation sequence */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/stage/phases/AddImplicitEmitter.scala
+++ b/src/main/scala/firrtl/stage/phases/AddImplicitEmitter.scala
@@ -11,9 +11,9 @@ import firrtl.options.{Dependency, Phase, PreservesAll}
   */
 class AddImplicitEmitter extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(Dependency[AddDefaults])
+  override def prerequisites = Seq(Dependency[AddDefaults])
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   def transform(annos: AnnotationSeq): AnnotationSeq = {
     val emitter = annos.collectFirst{ case a: EmitAnnotation => a }

--- a/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
+++ b/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
@@ -22,9 +22,9 @@ import firrtl.stage.{FirrtlOptions, OutputFileAnnotation}
   */
 class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(Dependency[AddCircuit])
+  override def prerequisites = Seq(Dependency[AddCircuit])
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   /** Add an [[OutputFileAnnotation]] to an [[AnnotationSeq]] */
   def transform(annotations: AnnotationSeq): AnnotationSeq =

--- a/src/main/scala/firrtl/stage/phases/CatchExceptions.scala
+++ b/src/main/scala/firrtl/stage/phases/CatchExceptions.scala
@@ -12,8 +12,9 @@ import scala.util.control.ControlThrowable
 
 class CatchExceptions(val underlying: Phase) extends Phase {
 
-  override final val prerequisites = underlying.prerequisites
-  override final val dependents = underlying.dependents
+  override final def prerequisites = underlying.prerequisites
+  override final def optionalPrerequisites = underlying.optionalPrerequisites
+  override final def dependents = underlying.dependents
   override final def invalidates(a: Phase): Boolean = underlying.invalidates(a)
   override final lazy val name = underlying.name
 

--- a/src/main/scala/firrtl/stage/phases/Compiler.scala
+++ b/src/main/scala/firrtl/stage/phases/Compiler.scala
@@ -44,14 +44,14 @@ private [stage] case class Defaults(
   */
 class Compiler extends Phase with Translator[AnnotationSeq, Seq[CompilerRun]] with PreservesAll[Phase] {
 
-  override val prerequisites =
+  override def prerequisites =
     Seq(Dependency[AddDefaults],
         Dependency[AddImplicitEmitter],
         Dependency[Checks],
         Dependency[AddCircuit],
         Dependency[AddImplicitOutputFile])
 
-  override val dependents = Seq(Dependency[WriteEmitted])
+  override def dependents = Seq(Dependency[WriteEmitted])
 
   /** Convert an [[AnnotationSeq]] into a sequence of compiler runs. */
   protected def aToB(a: AnnotationSeq): Seq[CompilerRun] = {

--- a/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
+++ b/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
@@ -124,9 +124,9 @@ object DriverCompatibility {
     */
   class AddImplicitAnnotationFile extends Phase with PreservesAll[Phase] {
 
-    override val prerequisites = Seq(Dependency[AddImplicitFirrtlFile])
+    override def prerequisites = Seq(Dependency[AddImplicitFirrtlFile])
 
-    override val dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
+    override def dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
 
     /** Try to add an [[firrtl.options.InputAnnotationFileAnnotation InputAnnotationFileAnnotation]] implicitly specified by
       * an [[AnnotationSeq]]. */
@@ -163,9 +163,9 @@ object DriverCompatibility {
     */
   class AddImplicitFirrtlFile extends Phase with PreservesAll[Phase] {
 
-    override val prerequisites = Seq.empty
+    override def prerequisites = Seq.empty
 
-    override val dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
+    override def dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
 
     /** Try to add a [[FirrtlFileAnnotation]] implicitly specified by an [[AnnotationSeq]]. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {
@@ -194,9 +194,9 @@ object DriverCompatibility {
               "1.2")
   class AddImplicitEmitter extends Phase with PreservesAll[Phase] {
 
-    override val prerequisites = Seq.empty
+    override def prerequisites = Seq.empty
 
-    override val dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
+    override def dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
 
     /** Add one [[EmitAnnotation]] foreach [[CompilerAnnotation]]. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {
@@ -220,9 +220,9 @@ object DriverCompatibility {
               "1.2")
   class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
 
-    override val prerequisites = Seq(Dependency[AddImplicitFirrtlFile])
+    override def prerequisites = Seq(Dependency[AddImplicitFirrtlFile])
 
-    override val dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
+    override def dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
 
     /** Add an [[OutputFileAnnotation]] derived from a [[TopNameAnnotation]] if needed. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
+++ b/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
@@ -26,9 +26,9 @@ import java.io.PrintWriter
   */
 class WriteEmitted extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq.empty
+  override def prerequisites = Seq.empty
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   /** Write any [[EmittedAnnotation]]s in an [[AnnotationSeq]] to files. Written [[EmittedAnnotation]]s are deleted. */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/stage/transforms/Compiler.scala
+++ b/src/main/scala/firrtl/stage/transforms/Compiler.scala
@@ -6,12 +6,16 @@ import firrtl.options.DependencyManagerUtils.CharSet
 import firrtl.stage.TransformManager
 import firrtl.{Transform, VerilogEmitter}
 
+/** A [[firrtl.stage.TransformManager TransformManager]] of
+  *
+  */
 class Compiler(
   targets: Seq[TransformManager.TransformDependency],
   currentState: Seq[TransformManager.TransformDependency] = Seq.empty,
   knownObjects: Set[Transform] = Set.empty) extends TransformManager(targets, currentState, knownObjects) {
 
   override val wrappers = Seq(
+    (a: Transform) => ExpandPrepares(a),
     (a: Transform) => CatchCustomTransformExceptions(a),
     (a: Transform) => UpdateAnnotations(a)
   )

--- a/src/main/scala/firrtl/stage/transforms/ExpandPrepares.scala
+++ b/src/main/scala/firrtl/stage/transforms/ExpandPrepares.scala
@@ -1,0 +1,26 @@
+// See LICENSE for license details.
+
+package firrtl.stage.transforms
+
+import firrtl.{CircuitState, Transform}
+
+class ExpandPrepares(val underlying: Transform) extends Transform with WrappedTransform {
+
+  /* Assert that this is not wrapping other transforms. */
+  underlying match {
+    case _: WrappedTransform => throw new Exception(
+      s"'ExpandPrepares' must not wrap other 'WrappedTransforms', but wraps '${underlying.getClass.getName}'")
+    case _ =>
+  }
+
+  override def execute(c: CircuitState): CircuitState = {
+    underlying.transform(underlying.prepare(c))
+  }
+
+}
+
+object ExpandPrepares {
+
+  def apply(a: Transform): ExpandPrepares = new ExpandPrepares(a)
+
+}

--- a/src/main/scala/firrtl/stage/transforms/UpdateAnnotations.scala
+++ b/src/main/scala/firrtl/stage/transforms/UpdateAnnotations.scala
@@ -33,8 +33,7 @@ class UpdateAnnotations(val underlying: Transform) extends Transform with Wrappe
   def internalTransform(b: (CircuitState, CircuitState)): (CircuitState, CircuitState) = {
     logger.info(s"======== Starting Transform $name ========")
 
-    /* @todo: prepare should likely be factored out of this */
-    val (timeMillis, result) = Utils.time { execute( trueUnderlying.prepare(b._2) ) }
+    val (timeMillis, result) = Utils.time { underlying.transform(b._2) }
 
     logger.info(s"""----------------------------${"-" * name.size}---------\n""")
     logger.info(f"Time: $timeMillis%.1f ms")

--- a/src/main/scala/firrtl/stage/transforms/WrappedTransform.scala
+++ b/src/main/scala/firrtl/stage/transforms/WrappedTransform.scala
@@ -23,10 +23,11 @@ trait WrappedTransform { this: Transform =>
     case _ => underlying
   }
 
-  override final val inputForm = underlying.inputForm
-  override final val outputForm = underlying.outputForm
-  override final val prerequisites = underlying.prerequisites
-  override final val dependents = underlying.dependents
+  override final def inputForm = underlying.inputForm
+  override final def outputForm = underlying.outputForm
+  override final def prerequisites = underlying.prerequisites
+  override final def optionalPrerequisites = underlying.optionalPrerequisites
+  override final def dependents = underlying.dependents
   override final def invalidates(b: Transform): Boolean = underlying.invalidates(b)
   override final lazy val name = underlying.name
 

--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -55,17 +55,15 @@ class BlackBoxNotFoundException(fileName: String, message: String) extends Firrt
   * will set the directory where the Verilog will be written.  This annotation is typically be
   * set by the execution harness, or directly in the tests
   */
-class BlackBoxSourceHelper extends firrtl.Transform with PreservesAll[Transform] {
+class BlackBoxSourceHelper extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
   import BlackBoxSourceHelper._
   private val DefaultTargetDir = new File(".")
-  override def inputForm: CircuitForm = LowForm
-  override def outputForm: CircuitForm = LowForm
 
-  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized
+  override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized
 
-  override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
+  override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   /** Collect BlackBoxHelperAnnos and and find the target dir if specified
     * @param annos a list of generic annotations for this transform

--- a/src/main/scala/firrtl/transforms/CheckCombLoops.scala
+++ b/src/main/scala/firrtl/transforms/CheckCombLoops.scala
@@ -94,18 +94,19 @@ case class CombinationalPath(sink: ReferenceTarget, sources: Seq[ReferenceTarget
   * @note The pass relies on ExtModulePathAnnotations to find loops through ExtModules
   * @note The pass will throw exceptions on "false paths"
   */
-class CheckCombLoops extends Transform with RegisteredTransform with PreservesAll[Transform] {
-  def inputForm = LowForm
-  def outputForm = LowForm
+class CheckCombLoops extends Transform
+    with RegisteredTransform
+    with DependencyAPIMigration
+    with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.MidForm ++
+  override def prerequisites = firrtl.stage.Forms.MidForm ++
     Seq( Dependency(passes.LowerTypes),
          Dependency(passes.Legalize),
          Dependency(firrtl.transforms.RemoveReset) )
 
-  override val optionalPrerequisites = Seq.empty
+  override def optionalPrerequisites = Seq.empty
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   import CheckCombLoops._
 

--- a/src/main/scala/firrtl/transforms/CombineCats.scala
+++ b/src/main/scala/firrtl/transforms/CombineCats.scala
@@ -53,19 +53,17 @@ object CombineCats {
   * Use [[MaxCatLenAnnotation]] to limit the number of elements that can be concatenated.
   * The default maximum number of elements is 10.
   */
-class CombineCats extends Transform with PreservesAll[Transform] {
-  def inputForm: LowForm.type = LowForm
-  def outputForm: LowForm.type = LowForm
+class CombineCats extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.LowForm ++
+  override def prerequisites = firrtl.stage.Forms.LowForm ++
     Seq( Dependency(passes.RemoveValidIf),
          Dependency[firrtl.transforms.ConstantPropagation],
          Dependency(firrtl.passes.memlib.VerilogMemDelays),
          Dependency(firrtl.passes.SplitExpressions) )
 
-  override val optionalPrerequisites = Seq.empty
+  override def optionalPrerequisites = Seq.empty
 
-  override val dependents = Seq(
+  override def dependents = Seq(
     Dependency[SystemVerilogEmitter],
     Dependency[VerilogEmitter] )
 

--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -98,20 +98,18 @@ object ConstantPropagation {
 
 }
 
-class ConstantPropagation extends Transform with ResolvedAnnotationPaths {
+class ConstantPropagation extends Transform with DependencyAPIMigration with ResolvedAnnotationPaths {
   import ConstantPropagation._
-  def inputForm = LowForm
-  def outputForm = LowForm
 
-  override val prerequisites =
+  override def prerequisites =
     ((new mutable.LinkedHashSet())
        ++ firrtl.stage.Forms.LowForm
        - Dependency(firrtl.passes.Legalize)
        + Dependency(firrtl.passes.RemoveValidIf)).toSeq
 
-  override val optionalPrerequisites = Seq.empty
+  override def optionalPrerequisites = Seq.empty
 
-  override val dependents =
+  override def dependents =
     Seq( Dependency(firrtl.passes.memlib.VerilogMemDelays),
          Dependency(firrtl.passes.SplitExpressions),
          Dependency[SystemVerilogEmitter],

--- a/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
+++ b/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
@@ -29,12 +29,13 @@ import collection.mutable
   * circumstances of their instantiation in their parent module, they will still not be removed. To
   * remove such modules, use the [[NoDedupAnnotation]] to prevent deduplication.
   */
-class DeadCodeElimination extends Transform with ResolvedAnnotationPaths with RegisteredTransform
+class DeadCodeElimination extends Transform
+    with ResolvedAnnotationPaths
+    with RegisteredTransform
+    with DependencyAPIMigration
     with PreservesAll[Transform] {
-  def inputForm = UnknownForm
-  def outputForm = UnknownForm
 
-  override val prerequisites = firrtl.stage.Forms.LowForm ++
+  override def prerequisites = firrtl.stage.Forms.LowForm ++
     Seq( Dependency(firrtl.passes.RemoveValidIf),
          Dependency[firrtl.transforms.ConstantPropagation],
          Dependency(firrtl.passes.memlib.VerilogMemDelays),
@@ -42,9 +43,9 @@ class DeadCodeElimination extends Transform with ResolvedAnnotationPaths with Re
          Dependency[firrtl.transforms.CombineCats],
          Dependency(passes.CommonSubexpressionElimination) )
 
-  override val optionalPrerequisites = Seq.empty
+  override def optionalPrerequisites = Seq.empty
 
-  override val dependents =
+  override def dependents =
     Seq( Dependency[firrtl.transforms.BlackBoxSourceHelper],
          Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
          Dependency[firrtl.transforms.FlattenRegUpdate],

--- a/src/main/scala/firrtl/transforms/Dedup.scala
+++ b/src/main/scala/firrtl/transforms/Dedup.scala
@@ -39,13 +39,11 @@ case object NoCircuitDedupAnnotation extends NoTargetAnnotation with HasShellOpt
   * Specifically, the restriction of instance loops must have been checked, or else this pass can
   *  infinitely recurse
   */
-class DedupModules extends Transform with PreservesAll[Transform] {
-  def inputForm: CircuitForm = HighForm
-  def outputForm: CircuitForm = HighForm
+class DedupModules extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.Resolved
+  override def prerequisites = firrtl.stage.Forms.Resolved
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   /** Deduplicate a Circuit
     * @param state Input Firrtl AST

--- a/src/main/scala/firrtl/transforms/FixAddingNegativeLiteralsTransform.scala
+++ b/src/main/scala/firrtl/transforms/FixAddingNegativeLiteralsTransform.scala
@@ -2,7 +2,7 @@
 
 package firrtl.transforms
 
-import firrtl.{CircuitState, Namespace, PrimOps, Transform, UnknownForm, Utils, WRef}
+import firrtl.{CircuitState, DependencyAPIMigration, Namespace, PrimOps, Transform, Utils, WRef}
 import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.options.{Dependency, PreservesAll}
@@ -107,15 +107,13 @@ object FixAddingNegativeLiterals {
   * the literal and thus not all expressions in the add are the same. This is fixed here when we directly
   * subtract the literal instead.
   */
-class FixAddingNegativeLiterals extends Transform with PreservesAll[Transform] {
-  def inputForm = UnknownForm
-  def outputForm = UnknownForm
+class FixAddingNegativeLiterals extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
 
-  override val prerequisites = Forms.LowFormMinimumOptimized :+ Dependency[BlackBoxSourceHelper]
+  override def prerequisites = Forms.LowFormMinimumOptimized :+ Dependency[BlackBoxSourceHelper]
 
-  override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
+  override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   def execute(state: CircuitState): CircuitState = {
     val modulesx = state.circuit.modules.map(FixAddingNegativeLiterals.fixupModule)

--- a/src/main/scala/firrtl/transforms/Flatten.scala
+++ b/src/main/scala/firrtl/transforms/Flatten.scala
@@ -7,7 +7,9 @@ import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.annotations._
 import scala.collection.mutable
+import firrtl.options.PreservesAll
 import firrtl.passes.{InlineInstances,PassException}
+import firrtl.stage.Forms
 
 /** Tags an annotation to be consumed by this transform */
 case class FlattenAnnotation(target: Named) extends SingleTargetAnnotation[Named] {
@@ -22,9 +24,11 @@ case class FlattenAnnotation(target: Named) extends SingleTargetAnnotation[Named
   * @note Flattening a module means inlining all its fully-defined child instances
   * @note Instances of extmodules are not (and cannot be) inlined
   */
-class Flatten extends Transform {
-   def inputForm = LowForm
-   def outputForm = LowForm
+class Flatten extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+
+   override def prerequisites = Forms.LowForm
+   override def optionalPrerequisites = Seq.empty
+   override def dependents = Forms.LowEmitters
 
    val inlineTransform = new InlineInstances
 

--- a/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
+++ b/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
@@ -105,11 +105,9 @@ object FlattenRegUpdate {
   * the register
   */
 // TODO Preserve source locators
-class FlattenRegUpdate extends Transform {
-  def inputForm = UnknownForm
-  def outputForm = UnknownForm
+class FlattenRegUpdate extends Transform with DependencyAPIMigration {
 
-  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
+  override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
     Seq( Dependency[BlackBoxSourceHelper],
          Dependency[FixAddingNegativeLiterals],
          Dependency[ReplaceTruncatingArithmetic],
@@ -117,9 +115,9 @@ class FlattenRegUpdate extends Transform {
          Dependency[InlineCastsTransform],
          Dependency[LegalizeClocksTransform] )
 
-  override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
+  override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: DeadCodeElimination => true

--- a/src/main/scala/firrtl/transforms/IdentityTransform.scala
+++ b/src/main/scala/firrtl/transforms/IdentityTransform.scala
@@ -7,9 +7,14 @@ import firrtl.{CircuitForm, CircuitState, Transform}
 /** Transform that applies an identity function. This returns an unmodified [[CircuitState]].
   * @param form the input and output [[CircuitForm]]
   */
+@deprecated(
+  "mix-in firrtl.options.IdentityLike[CircuitState]. IdentityTransform will be removed in 1.4.",
+  "FIRRTL 1.3"
+)
 class IdentityTransform(form: CircuitForm) extends Transform {
 
   final override def inputForm: CircuitForm = form
+
   final override def outputForm: CircuitForm = form
 
   final def execute(state: CircuitState): CircuitState = state

--- a/src/main/scala/firrtl/transforms/InferResets.scala
+++ b/src/main/scala/firrtl/transforms/InferResets.scala
@@ -110,12 +110,9 @@ object InferResets {
   *   generator languages like Chisel can infer differently
   */
 // TODO should we error if a DefMemory is of type AsyncReset? In CheckTypes?
-class InferResets extends Transform {
+class InferResets extends Transform with DependencyAPIMigration {
 
-  def inputForm: CircuitForm = UnknownForm
-  def outputForm: CircuitForm = UnknownForm
-
-  override val prerequisites =
+  override def prerequisites =
     Seq( Dependency(passes.ResolveKinds),
          Dependency(passes.InferTypes),
          Dependency(passes.Uniquify),

--- a/src/main/scala/firrtl/transforms/InlineBitExtractions.scala
+++ b/src/main/scala/firrtl/transforms/InlineBitExtractions.scala
@@ -94,18 +94,16 @@ object InlineBitExtractionsTransform {
 }
 
 /** Inline nodes that are simple bits */
-class InlineBitExtractionsTransform extends Transform with PreservesAll[Transform] {
-  def inputForm = UnknownForm
-  def outputForm = UnknownForm
+class InlineBitExtractionsTransform extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
+  override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
     Seq( Dependency[BlackBoxSourceHelper],
          Dependency[FixAddingNegativeLiterals],
          Dependency[ReplaceTruncatingArithmetic] )
 
-  override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
+  override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   def execute(state: CircuitState): CircuitState = {
     val modulesx = state.circuit.modules.map(InlineBitExtractionsTransform.onMod(_))

--- a/src/main/scala/firrtl/transforms/InlineCasts.scala
+++ b/src/main/scala/firrtl/transforms/InlineCasts.scala
@@ -66,20 +66,18 @@ object InlineCastsTransform {
 }
 
 /** Inline nodes that are simple casts */
-class InlineCastsTransform extends Transform {
-  def inputForm = UnknownForm
-  def outputForm = UnknownForm
+class InlineCastsTransform extends Transform with DependencyAPIMigration {
 
-  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
+  override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
     Seq( Dependency[BlackBoxSourceHelper],
          Dependency[FixAddingNegativeLiterals],
          Dependency[ReplaceTruncatingArithmetic],
          Dependency[InlineBitExtractionsTransform],
          Dependency[PropagatePresetAnnotations] )
 
-  override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
+  override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: LegalizeClocksTransform => true

--- a/src/main/scala/firrtl/transforms/LegalizeClocks.scala
+++ b/src/main/scala/firrtl/transforms/LegalizeClocks.scala
@@ -59,20 +59,18 @@ object LegalizeClocksTransform {
 }
 
 /** Ensure Clocks to be emitted are legal Verilog */
-class LegalizeClocksTransform extends Transform with PreservesAll[Transform] {
-  def inputForm = UnknownForm
-  def outputForm = UnknownForm
+class LegalizeClocksTransform extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
+  override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
     Seq( Dependency[BlackBoxSourceHelper],
          Dependency[FixAddingNegativeLiterals],
          Dependency[ReplaceTruncatingArithmetic],
          Dependency[InlineBitExtractionsTransform],
          Dependency[InlineCastsTransform] )
 
-  override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
+  override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   def execute(state: CircuitState): CircuitState = {
     val modulesx = state.circuit.modules.map(LegalizeClocksTransform.onMod(_))

--- a/src/main/scala/firrtl/transforms/PropagatePresetAnnotations.scala
+++ b/src/main/scala/firrtl/transforms/PropagatePresetAnnotations.scala
@@ -36,18 +36,16 @@ object PropagatePresetAnnotations {
   *
   * @note This pass must run before InlineCastsTransform
   */
-class PropagatePresetAnnotations extends Transform with PreservesAll[Transform] {
-  def inputForm = UnknownForm
-  def outputForm = UnknownForm
+class PropagatePresetAnnotations extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
+  override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
     Seq( Dependency[BlackBoxSourceHelper],
          Dependency[FixAddingNegativeLiterals],
          Dependency[ReplaceTruncatingArithmetic])
 
-  override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
+  override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
 
   import PropagatePresetAnnotations._

--- a/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
+++ b/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
@@ -20,9 +20,7 @@ import scala.collection.mutable
   * @define implicitNamespace @param ns an encolosing [[Namespace]] with which new names must not conflict
   * @define implicitScope @param scope the enclosing scope of this name. If [[None]], then this is a [[Circuit]] name
   */
-class RemoveKeywordCollisions(keywords: Set[String]) extends Transform {
-  val inputForm: CircuitForm = UnknownForm
-  val outputForm: CircuitForm = UnknownForm
+class RemoveKeywordCollisions(keywords: Set[String]) extends Transform with DependencyAPIMigration {
   private type ModuleType = mutable.HashMap[String, ir.Type]
   private val inlineDelim = "_"
 
@@ -235,7 +233,7 @@ class RemoveKeywordCollisions(keywords: Set[String]) extends Transform {
 /** Transform that removes collisions with Verilog keywords */
 class VerilogRename extends RemoveKeywordCollisions(v_keywords) with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
+  override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
     Seq( Dependency[BlackBoxSourceHelper],
          Dependency[FixAddingNegativeLiterals],
          Dependency[ReplaceTruncatingArithmetic],
@@ -245,8 +243,8 @@ class VerilogRename extends RemoveKeywordCollisions(v_keywords) with PreservesAl
          Dependency[FlattenRegUpdate],
          Dependency(passes.VerilogModulusCleanup) )
 
-  override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
+  override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
 }

--- a/src/main/scala/firrtl/transforms/RemoveReset.scala
+++ b/src/main/scala/firrtl/transforms/RemoveReset.scala
@@ -15,17 +15,15 @@ import scala.collection.{immutable, mutable}
   *
   * @note This pass must run after LowerTypes
   */
-object RemoveReset extends Transform {
-  def inputForm = LowForm
-  def outputForm = LowForm
+object RemoveReset extends Transform with DependencyAPIMigration {
 
-  override val prerequisites = firrtl.stage.Forms.MidForm ++
+  override def prerequisites = firrtl.stage.Forms.MidForm ++
     Seq( Dependency(passes.LowerTypes),
          Dependency(passes.Legalize) )
 
-  override val optionalPrerequisites = Seq.empty
+  override def optionalPrerequisites = Seq.empty
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   override def invalidates(a: Transform): Boolean = a match {
     case firrtl.passes.ResolveFlows => true

--- a/src/main/scala/firrtl/transforms/RemoveWires.scala
+++ b/src/main/scala/firrtl/transforms/RemoveWires.scala
@@ -20,19 +20,17 @@ import scala.util.{Try, Success, Failure}
   *  wires have multiple connections that may be impossible to order in a
   *  flow-foward way
   */
-class RemoveWires extends Transform with PreservesAll[Transform] {
-  def inputForm = LowForm
-  def outputForm = LowForm
+class RemoveWires extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.MidForm ++
+  override def prerequisites = firrtl.stage.Forms.MidForm ++
     Seq( Dependency(passes.LowerTypes),
          Dependency(passes.Legalize),
          Dependency(transforms.RemoveReset),
          Dependency[transforms.CheckCombLoops] )
 
-  override val optionalPrerequisites = Seq(Dependency[checks.CheckResets])
+  override def optionalPrerequisites = Seq(Dependency[checks.CheckResets])
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   // Extract all expressions that are references to a Node, Wire, or Reg
   // Since we are operating on LowForm, they can only be WRefs

--- a/src/main/scala/firrtl/transforms/RenameModules.scala
+++ b/src/main/scala/firrtl/transforms/RenameModules.scala
@@ -5,6 +5,8 @@ package firrtl.transforms
 import firrtl.analyses.{InstanceGraph, ModuleNamespaceAnnotation}
 import firrtl.ir._
 import firrtl._
+import firrtl.options.PreservesAll
+import firrtl.stage.Forms
 
 import scala.collection.mutable
 
@@ -12,9 +14,11 @@ import scala.collection.mutable
   *
   * using namespace created by [[analyses.GetNamespace]], create unique names for modules
   */
-class RenameModules extends Transform {
-  def inputForm: LowForm.type = LowForm
-  def outputForm: LowForm.type = LowForm
+class RenameModules extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+
+  override def prerequisites = Forms.LowForm
+  override def optionalPrerequisites = Seq.empty
+  override def dependents = Forms.LowEmitters
 
   def collectNameMapping(namespace: Namespace, moduleNameMap: mutable.HashMap[String, String])(mod: DefModule): Unit = {
     val newName = namespace.newName(mod.name)

--- a/src/main/scala/firrtl/transforms/ReplaceTruncatingArithmetic.scala
+++ b/src/main/scala/firrtl/transforms/ReplaceTruncatingArithmetic.scala
@@ -77,17 +77,15 @@ object ReplaceTruncatingArithmetic {
   * @note This replaces some FIRRTL primops with ops that are not actually legal FIRRTL. They are
   * useful for emission to languages that support non-expanding arithmetic (like Verilog)
   */
-class ReplaceTruncatingArithmetic extends Transform with PreservesAll[Transform] {
-  def inputForm = UnknownForm
-  def outputForm = UnknownForm
+class ReplaceTruncatingArithmetic extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
 
-  override val prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
+  override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
     Seq( Dependency[BlackBoxSourceHelper],
          Dependency[FixAddingNegativeLiterals] )
 
-  override val optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
+  override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override val dependents = Seq.empty
+  override def dependents = Seq.empty
 
   def execute(state: CircuitState): CircuitState = {
     val modulesx = state.circuit.modules.map(ReplaceTruncatingArithmetic.onMod(_))

--- a/src/main/scala/logger/phases/AddDefaults.scala
+++ b/src/main/scala/logger/phases/AddDefaults.scala
@@ -10,8 +10,8 @@ import logger.{LoggerOption, LogLevelAnnotation}
 /** Add default logger [[Annotation]]s */
 private [logger] class AddDefaults extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq.empty
-  override val dependents = Seq.empty
+  override def prerequisites = Seq.empty
+  override def dependents = Seq.empty
 
   /** Add missing default [[Logger]] [[Annotation]]s to an [[AnnotationSeq]]
     * @param annotations input annotations

--- a/src/main/scala/logger/phases/Checks.scala
+++ b/src/main/scala/logger/phases/Checks.scala
@@ -14,8 +14,8 @@ import scala.collection.mutable
   * for a [[Logger]] */
 object Checks extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(Dependency[AddDefaults])
-  override val dependents = Seq.empty
+  override def prerequisites = Seq(Dependency[AddDefaults])
+  override def dependents = Seq.empty
 
   /** Ensure that an [[firrtl.AnnotationSeq AnnotationSeq]] has necessary [[Logger]] [[firrtl.annotations.Annotation
     * Annotation]]s

--- a/src/test/scala/firrtlTests/AnnotationTests.scala
+++ b/src/test/scala/firrtlTests/AnnotationTests.scala
@@ -35,9 +35,21 @@ trait AnnotationSpec extends LowTransformSpec {
   }
 }
 
+object AnnotationTests {
+
+  class DeletingTransform extends Transform {
+    val inputForm = LowForm
+    val outputForm = LowForm
+    def execute(state: CircuitState) = state.copy(annotations = Seq())
+  }
+
+}
+
 // Abstract but with lots of tests defined so that we can use the same tests
 // for Legacy and newer Annotations
 abstract class AnnotationTests extends AnnotationSpec with Matchers {
+  import AnnotationTests._
+
   def anno(s: String, value: String ="this is a value", mod: String = "Top"): Annotation
   def manno(mod: String): Annotation
 
@@ -59,11 +71,6 @@ abstract class AnnotationTests extends AnnotationSpec with Matchers {
         |  module Top :
         |    input in: UInt<3>
         |""".stripMargin
-    class DeletingTransform extends Transform {
-      val inputForm = LowForm
-      val outputForm = LowForm
-      def execute(state: CircuitState) = state.copy(annotations = Seq())
-    }
     val transform = new DeletingTransform
     val tname = transform.name
     val inlineAnn = InlineAnnotation(CircuitName("Top"))

--- a/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+++ b/src/test/scala/firrtlTests/ConstantPropagationTests.scala
@@ -9,7 +9,7 @@ import firrtl.testutils._
 import firrtl.annotations.Annotation
 
 class ConstantPropagationSpec extends FirrtlFlatSpec {
-  val transforms = Seq(
+  val transforms: Seq[Transform] = Seq(
       ToWorkingIR,
       ResolveKinds,
       InferTypes,

--- a/src/test/scala/firrtlTests/DCETests.scala
+++ b/src/test/scala/firrtlTests/DCETests.scala
@@ -24,7 +24,7 @@ class DCETests extends FirrtlFlatSpec {
   // deleted
   private val customTransforms = Seq(
     new LowFirrtlOptimization,
-    new SimpleTransform(RemoveEmpty, LowForm)
+    RemoveEmpty
   )
   private def exec(input: String, check: String, annos: Seq[Annotation] = List.empty): Unit = {
     val state = CircuitState(parse(input), ChirrtlForm, annos)

--- a/src/test/scala/firrtlTests/InferReadWriteSpec.scala
+++ b/src/test/scala/firrtlTests/InferReadWriteSpec.scala
@@ -4,7 +4,9 @@ package firrtlTests
 
 import firrtl._
 import firrtl.ir._
+import firrtl.options.PreservesAll
 import firrtl.passes._
+import firrtl.stage.Forms
 import firrtl.testutils._
 import firrtl.testutils.FirrtlCheckers._
 
@@ -12,9 +14,11 @@ class InferReadWriteSpec extends SimpleTransformSpec {
   class InferReadWriteCheckException extends PassException(
     "Readwrite ports are not found!")
 
-  object InferReadWriteCheck extends Pass {
-    override def inputForm = MidForm
-    override def outputForm = MidForm
+  object InferReadWriteCheck extends Pass with PreservesAll[Transform] {
+    override def prerequisites = Forms.MidForm
+    override def optionalPrerequisites = Seq.empty
+    override def dependents = Forms.MidEmitters
+
     def findReadWrite(s: Statement): Boolean = s match {
       case s: DefMemory if s.readLatency > 0 && s.readwriters.size == 1 =>
         s.name == "mem" && s.readwriters.head == "rw"

--- a/src/test/scala/firrtlTests/options/PhaseManagerSpec.scala
+++ b/src/test/scala/firrtlTests/options/PhaseManagerSpec.scala
@@ -180,7 +180,7 @@ object DependentsFixture {
   }
 
   class Second extends IdentityPhase {
-    override val prerequisites = Seq(Dependency[First])
+    override def prerequisites = Seq(Dependency[First])
     override def invalidates(phase: Phase): Boolean = false
   }
 
@@ -189,8 +189,8 @@ object DependentsFixture {
    * loop detection.
    */
   class Custom extends IdentityPhase {
-    override val prerequisites = Seq(Dependency[First])
-    override val dependents = Seq(Dependency[Second])
+    override def prerequisites = Seq(Dependency[First])
+    override def dependents = Seq(Dependency[Second])
     override def invalidates(phase: Phase): Boolean = false
   }
 
@@ -220,7 +220,7 @@ object ChainedInvalidationFixture {
     override def invalidates(phase: Phase): Boolean = false
   }
   class E extends IdentityPhase {
-    override val prerequisites = Seq(Dependency[A], Dependency[B], Dependency[C], Dependency[D])
+    override def prerequisites = Seq(Dependency[A], Dependency[B], Dependency[C], Dependency[D])
     override def invalidates(phase: Phase): Boolean = false
   }
 
@@ -254,8 +254,8 @@ object UnrelatedFixture {
   class B15 extends IdentityPhase with PreservesAll[Phase]
 
   class B6Sub extends B6 {
-    override val prerequisites = Seq(Dependency[B6])
-    override val dependents = Seq(Dependency[B7])
+    override def prerequisites = Seq(Dependency[B6])
+    override def dependents = Seq(Dependency[B7])
   }
 
   class B6_0 extends B6Sub
@@ -276,7 +276,7 @@ object UnrelatedFixture {
   class B6_15 extends B6Sub
 
   class B8Dep extends B8 {
-    override val dependents = Seq(Dependency[B8])
+    override def dependents = Seq(Dependency[B8])
   }
 
   class B8_0 extends B8Dep
@@ -303,28 +303,28 @@ object CustomAfterOptimizationFixture {
   class Root extends IdentityPhase with PreservesAll[Phase]
 
   class OptMinimum extends IdentityPhase with PreservesAll[Phase] {
-    override val prerequisites = Seq(Dependency[Root])
-    override val dependents = Seq(Dependency[AfterOpt])
+    override def prerequisites = Seq(Dependency[Root])
+    override def dependents = Seq(Dependency[AfterOpt])
   }
 
   class OptFull extends IdentityPhase with PreservesAll[Phase] {
-    override val prerequisites = Seq(Dependency[Root], Dependency[OptMinimum])
-    override val dependents = Seq(Dependency[AfterOpt])
+    override def prerequisites = Seq(Dependency[Root], Dependency[OptMinimum])
+    override def dependents = Seq(Dependency[AfterOpt])
   }
 
   class AfterOpt extends IdentityPhase with PreservesAll[Phase]
 
   class DoneMinimum extends IdentityPhase with PreservesAll[Phase] {
-    override val prerequisites = Seq(Dependency[OptMinimum])
+    override def prerequisites = Seq(Dependency[OptMinimum])
   }
 
   class DoneFull extends IdentityPhase with PreservesAll[Phase] {
-    override val prerequisites = Seq(Dependency[OptFull])
+    override def prerequisites = Seq(Dependency[OptFull])
   }
 
   class Custom extends IdentityPhase with PreservesAll[Phase] {
-    override val prerequisites = Seq(Dependency[Root], Dependency[AfterOpt])
-    override val dependents = Seq(Dependency[DoneMinimum], Dependency[DoneFull])
+    override def prerequisites = Seq(Dependency[Root], Dependency[AfterOpt])
+    override def dependents = Seq(Dependency[DoneMinimum], Dependency[DoneFull])
   }
 
 }
@@ -334,25 +334,25 @@ object OptionalPrerequisitesFixture {
   class Root extends IdentityPhase
 
   class OptMinimum extends IdentityPhase with PreservesAll[Phase] {
-    override val prerequisites = Seq(Dependency[Root])
+    override def prerequisites = Seq(Dependency[Root])
   }
 
   class OptFull extends IdentityPhase with PreservesAll[Phase] {
-    override val prerequisites = Seq(Dependency[Root], Dependency[OptMinimum])
+    override def prerequisites = Seq(Dependency[Root], Dependency[OptMinimum])
   }
 
   class DoneMinimum extends IdentityPhase with PreservesAll[Phase] {
-    override val prerequisites = Seq(Dependency[OptMinimum])
+    override def prerequisites = Seq(Dependency[OptMinimum])
   }
 
   class DoneFull extends IdentityPhase with PreservesAll[Phase] {
-    override val prerequisites = Seq(Dependency[OptFull])
+    override def prerequisites = Seq(Dependency[OptFull])
   }
 
   class Custom extends IdentityPhase with PreservesAll[Phase] {
-    override val prerequisites = Seq(Dependency[Root])
-    override val optionalPrerequisites = Seq(Dependency[OptMinimum], Dependency[OptFull])
-    override val dependents = Seq(Dependency[DoneMinimum], Dependency[DoneFull])
+    override def prerequisites = Seq(Dependency[Root])
+    override def optionalPrerequisites = Seq(Dependency[OptMinimum], Dependency[OptFull])
+    override def dependents = Seq(Dependency[DoneMinimum], Dependency[DoneFull])
   }
 
 }
@@ -369,7 +369,7 @@ object OrderingFixture {
   }
 
   class C extends IdentityPhase {
-    override val prerequisites = Seq(Dependency[A], Dependency[B])
+    override def prerequisites = Seq(Dependency[A], Dependency[B])
     override def invalidates(phase: Phase): Boolean = phase match {
       case _: B => true
       case _    => false
@@ -377,7 +377,7 @@ object OrderingFixture {
   }
 
   class Cx extends C {
-    override val prerequisites = Seq(Dependency[B], Dependency[A])
+    override def prerequisites = Seq(Dependency[B], Dependency[A])
   }
 
 }

--- a/src/test/scala/firrtlTests/stage/phases/CompilerSpec.scala
+++ b/src/test/scala/firrtlTests/stage/phases/CompilerSpec.scala
@@ -27,7 +27,6 @@ class CompilerSpec extends AnyFlatSpec with Matchers {
     s"""|circuit $main:
         |  module $main:
         |    output foo: {bar: UInt}
-        |
         |    foo.bar <= UInt<4>("h0")
         |""".stripMargin
 
@@ -41,9 +40,7 @@ class CompilerSpec extends AnyFlatSpec with Matchers {
       FirrtlCircuitAnnotation(circuitIn),
       CompilerAnnotation(compiler) )
 
-    val expected = Seq(FirrtlCircuitAnnotation(circuitOut))
-
-    phase.transform(input).collect{ case a: FirrtlCircuitAnnotation => a }.toSeq should be (expected)
+    phase.transform(input).toSeq should be (Seq(FirrtlCircuitAnnotation(circuitOut)))
   }
 
   it should "compile multiple FirrtlCircuitAnnotations" in new Fixture {

--- a/src/test/scala/firrtlTests/transforms/GroupComponentsSpec.scala
+++ b/src/test/scala/firrtlTests/transforms/GroupComponentsSpec.scala
@@ -362,9 +362,9 @@ class GroupComponentsSpec extends MiddleTransformSpec {
          |    out <= add(in, wrapper.other_out)
          |  module Wrapper :
          |    output other_out: UInt<16>
-         |    inst other of Other
-         |    other_out <= other.out
-         |    other.in is invalid
+         |    inst other_ of Other
+         |    other_out <= other_.out
+         |    other_.in is invalid
          |  module Other:
          |    input in: UInt<16>
          |    output out: UInt<16>


### PR DESCRIPTION
This enables a smooth migration from `CircuitForm`-based dependency specification to Dependency API dependency specification. 

This adds a new trait `DependencyAPIMigration` that provides default implementations of Dependency API methods and `final override`s `inputForm`/`outputForm` to `UnknownForm`.

**Why is this PR touching so much stuff???**

Legacy infrastructure like `firrtl.Compiler`, `SeqTransform`, and `CoreTransform` (lowering compilers) and legacy testing infrastructure use legacy scheduling methods `getLoweringTransforms` and `mergeTransforms`. These methods cannot schedule transforms which have input/output forms of `UnknownForm`. Consequently, mixing in `DependencyAPIMigration` breaks **a ton** of stuff everywhere. To rectify this, this PR makes updates to legacy compiler infrastructure to have these use the Dependency API-based `firrtl.stage.transforms.Compiler` (a `TransformManager`) under the hood.

Closes https://github.com/freechipsproject/firrtl/pull/1533.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
- code refactoring
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
- new feature/API

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

This is both an expansion of the API and a modification of the API.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you mark as `Please Merge`?
