### PR TITLE
Change `dependents` to `optionalPrerequisiteOf`

### DIFF
--- a/src/main/scala/firrtl/AddDescriptionNodes.scala
+++ b/src/main/scala/firrtl/AddDescriptionNodes.scala
@@ -85,7 +85,7 @@ class AddDescriptionNodes extends Transform with DependencyAPIMigration with Pre
 
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   def onStmt(compMap: Map[String, Seq[String]])(stmt: Statement): Statement = {
     stmt.map(onStmt(compMap)) match {

--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -238,7 +238,7 @@ trait Transform extends TransformLike[CircuitState] with DependencyAPI[Transform
 
   private lazy val fullCompilerSet = new mutable.LinkedHashSet[Dependency[Transform]] ++ Forms.VerilogOptimized
 
-  override def dependents: Seq[Dependency[Transform]] = {
+  override def optionalPrerequisiteOf: Seq[Dependency[Transform]] = {
     val lowEmitters = Dependency[LowFirrtlEmitter] :: Dependency[VerilogEmitter] :: Dependency[MinimumVerilogEmitter] ::
       Dependency[SystemVerilogEmitter] :: Nil
 

--- a/src/main/scala/firrtl/DependencyAPIMigration.scala
+++ b/src/main/scala/firrtl/DependencyAPIMigration.scala
@@ -10,7 +10,7 @@ import firrtl.stage.TransformManager.TransformDependency
   *
   *    - `prerequisites` are empty
   *    - `optionalPrerequisites` are empty
-  *    - `dependents` are empty
+  *    - `optionalPrerequisiteOf` are empty
   *    - all transforms are invalidated
   *
   * For more information, see: https://bit.ly/2Voppre
@@ -31,7 +31,7 @@ trait DependencyAPIMigration { this: Transform =>
 
   override def optionalPrerequisites: Seq[TransformDependency] = Seq.empty
 
-  override def dependents: Seq[TransformDependency] = Seq.empty
+  override def optionalPrerequisiteOf: Seq[TransformDependency] = Seq.empty
 
   override def invalidates(a: Transform): Boolean = true
 

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -182,7 +182,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
 
   override def prerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   val outputSuffix = ".v"
   val tab = "  "

--- a/src/main/scala/firrtl/analyses/GetNamespace.scala
+++ b/src/main/scala/firrtl/analyses/GetNamespace.scala
@@ -16,7 +16,7 @@ case class ModuleNamespaceAnnotation(namespace: Namespace) extends NoTargetAnnot
 class GetNamespace extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
   override def prerequisites = Forms.LowForm
   override def optionalPrerequisites = Seq.empty
-  override def dependents = Forms.LowEmitters
+  override def optionalPrerequisiteOf = Forms.LowEmitters
 
   def execute(state: CircuitState): CircuitState = {
     val namespace = Namespace(state.circuit)

--- a/src/main/scala/firrtl/annotations/transforms/EliminateTargetPaths.scala
+++ b/src/main/scala/firrtl/annotations/transforms/EliminateTargetPaths.scala
@@ -47,7 +47,7 @@ class EliminateTargetPaths extends Transform with DependencyAPIMigration with Pr
 
   override def prerequisites = Forms.MinimalHighForm
   override def optionalPrerequisites = Seq.empty
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   /** Replaces old ofModules with new ofModules by calling dupMap methods
     * Updates oldUsedOfModules, newUsedOfModules

--- a/src/main/scala/firrtl/checks/CheckResets.scala
+++ b/src/main/scala/firrtl/checks/CheckResets.scala
@@ -37,7 +37,7 @@ class CheckResets extends Transform with DependencyAPIMigration with PreservesAl
 
   override def optionalPrerequisites = Seq(Dependency[firrtl.transforms.CheckCombLoops])
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   import CheckResets._
 

--- a/src/main/scala/firrtl/options/phases/AddDefaults.scala
+++ b/src/main/scala/firrtl/options/phases/AddDefaults.scala
@@ -14,7 +14,7 @@ class AddDefaults extends Phase with PreservesAll[Phase] {
 
   override def prerequisites = Seq(Dependency[GetIncludes], Dependency[ConvertLegacyAnnotations])
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = {
     val td = annotations.collectFirst{ case a: TargetDirAnnotation => a}.isEmpty

--- a/src/main/scala/firrtl/options/phases/Checks.scala
+++ b/src/main/scala/firrtl/options/phases/Checks.scala
@@ -14,7 +14,7 @@ class Checks extends Phase with PreservesAll[Phase] {
 
   override def prerequisites = Seq(Dependency[GetIncludes], Dependency[ConvertLegacyAnnotations], Dependency[AddDefaults])
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   /** Validate an [[AnnotationSeq]] for [[StageOptions]]
     * @throws OptionsException if annotations are invalid

--- a/src/main/scala/firrtl/options/phases/ConvertLegacyAnnotations.scala
+++ b/src/main/scala/firrtl/options/phases/ConvertLegacyAnnotations.scala
@@ -11,7 +11,7 @@ class ConvertLegacyAnnotations extends Phase with PreservesAll[Phase] {
 
   override def prerequisites = Seq(Dependency[GetIncludes])
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = LegacyAnnotation.convertLegacyAnnos(annotations)
 

--- a/src/main/scala/firrtl/options/phases/DeletedWrapper.scala
+++ b/src/main/scala/firrtl/options/phases/DeletedWrapper.scala
@@ -17,7 +17,7 @@ class DeletedWrapper(p: Phase) extends Phase with Translator[AnnotationSeq, (Ann
 
   override def prerequisites = Seq.empty
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   override lazy val name: String = p.name
 

--- a/src/main/scala/firrtl/options/phases/GetIncludes.scala
+++ b/src/main/scala/firrtl/options/phases/GetIncludes.scala
@@ -20,7 +20,7 @@ class GetIncludes extends Phase with PreservesAll[Phase] {
 
   override def prerequisites = Seq.empty
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   /** Read all [[annotations.Annotation]] from a file in JSON or YAML format
     * @param filename a JSON or YAML file of [[annotations.Annotation]]

--- a/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
+++ b/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
@@ -20,7 +20,7 @@ class WriteOutputAnnotations extends Phase with PreservesAll[Phase] {
          Dependency[AddDefaults],
          Dependency[Checks] )
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   /** Write the input [[AnnotationSeq]] to a fie. */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/passes/CheckChirrtl.scala
+++ b/src/main/scala/firrtl/passes/CheckChirrtl.scala
@@ -8,7 +8,7 @@ import firrtl.options.{Dependency, PreservesAll}
 
 object CheckChirrtl extends Pass with CheckHighFormLike with PreservesAll[Transform] {
 
-  override val dependents = firrtl.stage.Forms.ChirrtlForm ++
+  override val optionalPrerequisiteOf = firrtl.stage.Forms.ChirrtlForm ++
     Seq( Dependency(CInferTypes),
          Dependency(CInferMDir),
          Dependency(RemoveCHIRRTL) )

--- a/src/main/scala/firrtl/passes/CheckFlows.scala
+++ b/src/main/scala/firrtl/passes/CheckFlows.scala
@@ -12,7 +12,7 @@ object CheckFlows extends Pass with PreservesAll[Transform] {
 
   override def prerequisites = Dependency(passes.ResolveFlows) +: firrtl.stage.Forms.WorkingIR
 
-  override def dependents =
+  override def optionalPrerequisiteOf =
     Seq( Dependency[passes.InferBinaryPoints],
          Dependency[passes.TrimIntervals],
          Dependency[passes.InferWidths],

--- a/src/main/scala/firrtl/passes/CheckHighForm.scala
+++ b/src/main/scala/firrtl/passes/CheckHighForm.scala
@@ -285,7 +285,7 @@ object CheckHighForm extends Pass with CheckHighFormLike with PreservesAll[Trans
 
   override def prerequisites = firrtl.stage.Forms.WorkingIR
 
-  override def dependents =
+  override def optionalPrerequisiteOf =
     Seq( Dependency(passes.ResolveKinds),
          Dependency(passes.InferTypes),
          Dependency(passes.Uniquify),

--- a/src/main/scala/firrtl/passes/CheckTypes.scala
+++ b/src/main/scala/firrtl/passes/CheckTypes.scala
@@ -15,7 +15,7 @@ object CheckTypes extends Pass with PreservesAll[Transform] {
 
   override def prerequisites = Dependency(InferTypes) +: firrtl.stage.Forms.WorkingIR
 
-  override def dependents =
+  override def optionalPrerequisiteOf =
     Seq( Dependency(passes.Uniquify),
          Dependency(passes.ResolveFlows),
          Dependency(passes.CheckFlows),

--- a/src/main/scala/firrtl/passes/CheckWidths.scala
+++ b/src/main/scala/firrtl/passes/CheckWidths.scala
@@ -15,7 +15,7 @@ object CheckWidths extends Pass with PreservesAll[Transform] {
 
   override def prerequisites = Dependency[passes.InferWidths] +: firrtl.stage.Forms.WorkingIR
 
-  override def dependents = Seq(Dependency[transforms.InferResets])
+  override def optionalPrerequisiteOf = Seq(Dependency[transforms.InferResets])
 
   /** The maximum allowed width for any circuit element */
   val MaxWidth = 1000000

--- a/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
+++ b/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
@@ -16,7 +16,7 @@ object CommonSubexpressionElimination extends Pass with PreservesAll[Transform] 
          Dependency(firrtl.passes.SplitExpressions),
          Dependency[firrtl.transforms.CombineCats] )
 
-  override def dependents =
+  override def optionalPrerequisiteOf =
     Seq( Dependency[SystemVerilogEmitter],
          Dependency[VerilogEmitter] )
 

--- a/src/main/scala/firrtl/passes/InferBinaryPoints.scala
+++ b/src/main/scala/firrtl/passes/InferBinaryPoints.scala
@@ -18,7 +18,7 @@ class InferBinaryPoints extends Pass with PreservesAll[Transform] {
          Dependency(Uniquify),
          Dependency(ResolveFlows) )
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   private val constraintSolver = new ConstraintSolver()
 

--- a/src/main/scala/firrtl/passes/Inline.scala
+++ b/src/main/scala/firrtl/passes/Inline.scala
@@ -28,7 +28,7 @@ class InlineInstances extends Transform with DependencyAPIMigration with Registe
 
   override def prerequisites = Forms.LowForm
   override def optionalPrerequisites = Seq.empty
-  override def dependents = Forms.LowEmitters
+  override def optionalPrerequisiteOf = Forms.LowEmitters
 
   override def invalidates(a: Transform): Boolean = a == ResolveKinds
 

--- a/src/main/scala/firrtl/passes/Legalize.scala
+++ b/src/main/scala/firrtl/passes/Legalize.scala
@@ -16,7 +16,7 @@ object Legalize extends Pass with PreservesAll[Transform] {
 
   override def optionalPrerequisites = Seq.empty
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   private def legalizeShiftRight(e: DoPrim): Expression = {
     require(e.op == Shr)

--- a/src/main/scala/firrtl/passes/LowerTypes.scala
+++ b/src/main/scala/firrtl/passes/LowerTypes.scala
@@ -26,7 +26,7 @@ object LowerTypes extends Transform with DependencyAPIMigration {
 
   override def prerequisites = firrtl.stage.Forms.MidForm
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   override def invalidates(a: Transform): Boolean = a match {
     case ResolveKinds | InferTypes | ResolveFlows | _: InferWidths => true

--- a/src/main/scala/firrtl/passes/PadWidths.scala
+++ b/src/main/scala/firrtl/passes/PadWidths.scala
@@ -21,7 +21,7 @@ object PadWidths extends Pass {
 
   override def optionalPrerequisites = Seq(Dependency[firrtl.transforms.ConstantPropagation])
 
-  override def dependents =
+  override def optionalPrerequisiteOf =
     Seq( Dependency(firrtl.passes.memlib.VerilogMemDelays),
          Dependency[SystemVerilogEmitter],
          Dependency[VerilogEmitter] )

--- a/src/main/scala/firrtl/passes/RemoveEmpty.scala
+++ b/src/main/scala/firrtl/passes/RemoveEmpty.scala
@@ -11,7 +11,7 @@ object RemoveEmpty extends Pass with DependencyAPIMigration with PreservesAll[Tr
 
   override def prerequisites = Seq.empty
   override def optionalPrerequisites = Forms.LowFormOptimized
-  override def dependents = Forms.ChirrtlEmitters
+  override def optionalPrerequisiteOf = Forms.ChirrtlEmitters
 
   private def onModule(m: DefModule): DefModule = {
     m match {

--- a/src/main/scala/firrtl/passes/RemoveValidIf.scala
+++ b/src/main/scala/firrtl/passes/RemoveValidIf.scala
@@ -31,7 +31,7 @@ object RemoveValidIf extends Pass {
 
   override def prerequisites = firrtl.stage.Forms.LowForm
 
-  override def dependents =
+  override def optionalPrerequisiteOf =
     Seq( Dependency[SystemVerilogEmitter],
          Dependency[VerilogEmitter] )
 

--- a/src/main/scala/firrtl/passes/SplitExpressions.scala
+++ b/src/main/scala/firrtl/passes/SplitExpressions.scala
@@ -20,7 +20,7 @@ object SplitExpressions extends Pass with PreservesAll[Transform] {
     Seq( Dependency(firrtl.passes.RemoveValidIf),
          Dependency(firrtl.passes.memlib.VerilogMemDelays) )
 
-  override def dependents =
+  override def optionalPrerequisiteOf =
     Seq( Dependency[SystemVerilogEmitter],
          Dependency[VerilogEmitter] )
 

--- a/src/main/scala/firrtl/passes/TrimIntervals.scala
+++ b/src/main/scala/firrtl/passes/TrimIntervals.scala
@@ -29,7 +29,7 @@ class TrimIntervals extends Pass with PreservesAll[Transform] {
          Dependency(ResolveFlows),
          Dependency[InferBinaryPoints] )
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   def run(c: Circuit): Circuit = {
     // Open -> closed

--- a/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
+++ b/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
@@ -37,7 +37,7 @@ object VerilogModulusCleanup extends Pass with PreservesAll[Transform] {
 
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   private def onModule(m: Module): Module = {
     val namespace = Namespace(m)

--- a/src/main/scala/firrtl/passes/VerilogPrep.scala
+++ b/src/main/scala/firrtl/passes/VerilogPrep.scala
@@ -33,7 +33,7 @@ object VerilogPrep extends Pass with PreservesAll[Transform] {
 
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   type AttachSourceMap = Map[WrappedExpression, Expression]
 

--- a/src/main/scala/firrtl/passes/clocklist/ClockListTransform.scala
+++ b/src/main/scala/firrtl/passes/clocklist/ClockListTransform.scala
@@ -55,7 +55,7 @@ class ClockListTransform extends Transform with DependencyAPIMigration with Regi
 
    override def prerequisites = Forms.LowForm
    override def optionalPrerequisites = Seq.empty
-   override def dependents = Forms.LowEmitters
+   override def optionalPrerequisiteOf = Forms.LowEmitters
 
   val options = Seq(
     new ShellOption[String](

--- a/src/main/scala/firrtl/passes/memlib/DecorateMems.scala
+++ b/src/main/scala/firrtl/passes/memlib/DecorateMems.scala
@@ -13,7 +13,7 @@ class CreateMemoryAnnotations(reader: Option[YamlFileReader]) extends Transform
 
   override def prerequisites = Forms.MidForm
   override def optionalPrerequisites = Seq.empty
-  override def dependents = Forms.MidEmitters
+  override def optionalPrerequisiteOf = Forms.MidEmitters
 
   def execute(state: CircuitState): CircuitState = reader match {
     case None => state

--- a/src/main/scala/firrtl/passes/memlib/InferReadWrite.scala
+++ b/src/main/scala/firrtl/passes/memlib/InferReadWrite.scala
@@ -152,7 +152,7 @@ class InferReadWrite extends Transform
 
   override def prerequisites = Forms.MidForm
   override def optionalPrerequisites = Seq.empty
-  override def dependents = Forms.MidEmitters
+  override def optionalPrerequisiteOf = Forms.MidEmitters
 
   val options = Seq(
     new ShellOption[Unit](

--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemMacros.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemMacros.scala
@@ -30,7 +30,7 @@ class ReplaceMemMacros(writer: ConfWriter) extends Transform with DependencyAPIM
 
   override def prerequisites = Forms.MidForm
   override def optionalPrerequisites = Seq.empty
-  override def dependents = Forms.MidEmitters
+  override def optionalPrerequisiteOf = Forms.MidEmitters
 
   /** Return true if mask granularity is per bit, false if per byte or unspecified
     */

--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
@@ -107,7 +107,7 @@ class ReplSeqMem extends Transform with HasShellOptions with DependencyAPIMigrat
 
   override def prerequisites = Forms.MidForm
   override def optionalPrerequisites = Seq.empty
-  override def dependents = Forms.MidEmitters
+  override def optionalPrerequisiteOf = Forms.MidEmitters
 
   val options = Seq(
     new ShellOption[String](

--- a/src/main/scala/firrtl/passes/memlib/ResolveMemoryReference.scala
+++ b/src/main/scala/firrtl/passes/memlib/ResolveMemoryReference.scala
@@ -20,7 +20,7 @@ class ResolveMemoryReference extends Transform with DependencyAPIMigration with 
 
   override def prerequisites = Forms.MidForm
   override def optionalPrerequisites = Seq.empty
-  override def dependents = Forms.MidEmitters
+  override def optionalPrerequisiteOf = Forms.MidEmitters
 
   /** Helper class for determining when two memories are equivalent while igoring
     * irrelevant details like name and info

--- a/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
+++ b/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
@@ -170,7 +170,7 @@ object VerilogMemDelays extends Pass {
 
   override def prerequisites = firrtl.stage.Forms.LowForm :+ Dependency(firrtl.passes.RemoveValidIf)
 
-  override val dependents =
+  override val optionalPrerequisiteOf =
     Seq( Dependency[VerilogEmitter],
          Dependency[SystemVerilogEmitter] )
 

--- a/src/main/scala/firrtl/passes/wiring/WiringTransform.scala
+++ b/src/main/scala/firrtl/passes/wiring/WiringTransform.scala
@@ -42,7 +42,7 @@ class WiringTransform extends Transform with DependencyAPIMigration {
 
   override def prerequisites = Forms.MidForm
   override def optionalPrerequisites = Seq.empty
-  override def dependents = Forms.MidEmitters
+  override def optionalPrerequisiteOf = Forms.MidEmitters
 
   private val invalidates = Forms.VerilogOptimized.toSet -- Forms.MinimalHighForm
   override def invalidates(a: Transform): Boolean = invalidates(Dependency.fromTransform(a))

--- a/src/main/scala/firrtl/stage/FirrtlStage.scala
+++ b/src/main/scala/firrtl/stage/FirrtlStage.scala
@@ -21,9 +21,9 @@ class FirrtlStage extends Stage {
 
   override def prerequisites = phase.prerequisites
 
-  override def dependents = phase.dependents
-
   override def optionalPrerequisites = phase.optionalPrerequisites
+
+  override def optionalPrerequisiteOf = phase.optionalPrerequisiteOf
 
   override def invalidates(a: Phase): Boolean = phase.invalidates(a)
 

--- a/src/main/scala/firrtl/stage/phases/AddCircuit.scala
+++ b/src/main/scala/firrtl/stage/phases/AddCircuit.scala
@@ -29,7 +29,7 @@ class AddCircuit extends Phase with PreservesAll[Phase] {
 
   override val prerequisites = Seq(Dependency[AddDefaults], Dependency[Checks])
 
-  override val dependents = Seq.empty
+  override val optionalPrerequisiteOf = Seq.empty
 
   /** Extract the info mode from an [[AnnotationSeq]] or use the default info mode if no annotation exists
     * @param annotations some annotations

--- a/src/main/scala/firrtl/stage/phases/AddDefaults.scala
+++ b/src/main/scala/firrtl/stage/phases/AddDefaults.scala
@@ -14,7 +14,7 @@ class AddDefaults extends Phase with PreservesAll[Phase] {
 
   override def prerequisites = Seq.empty
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   /** Append any missing default annotations to an annotation sequence */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/stage/phases/AddImplicitEmitter.scala
+++ b/src/main/scala/firrtl/stage/phases/AddImplicitEmitter.scala
@@ -13,7 +13,7 @@ class AddImplicitEmitter extends Phase with PreservesAll[Phase] {
 
   override def prerequisites = Seq(Dependency[AddDefaults])
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   def transform(annos: AnnotationSeq): AnnotationSeq = {
     val emitter = annos.collectFirst{ case a: EmitAnnotation => a }

--- a/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
+++ b/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
@@ -24,7 +24,7 @@ class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
 
   override def prerequisites = Seq(Dependency[AddCircuit])
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   /** Add an [[OutputFileAnnotation]] to an [[AnnotationSeq]] */
   def transform(annotations: AnnotationSeq): AnnotationSeq =

--- a/src/main/scala/firrtl/stage/phases/CatchExceptions.scala
+++ b/src/main/scala/firrtl/stage/phases/CatchExceptions.scala
@@ -13,8 +13,12 @@ import scala.util.control.ControlThrowable
 class CatchExceptions(val underlying: Phase) extends Phase {
 
   override final def prerequisites = underlying.prerequisites
-  override final def optionalPrerequisites = underlying.optionalPrerequisites
+  @deprecated(
+    "Due to confusion, 'dependents' is being renamed to 'optionalPrerequisiteOf'. Override the latter instead.",
+    "FIRRTL 1.3"
+  )
   override final def dependents = underlying.dependents
+  override final def optionalPrerequisiteOf = underlying.optionalPrerequisiteOf
   override final def invalidates(a: Phase): Boolean = underlying.invalidates(a)
   override final lazy val name = underlying.name
 

--- a/src/main/scala/firrtl/stage/phases/Checks.scala
+++ b/src/main/scala/firrtl/stage/phases/Checks.scala
@@ -20,7 +20,7 @@ class Checks extends Phase with PreservesAll[Phase] {
 
   override val prerequisites = Seq(Dependency[AddDefaults], Dependency[AddImplicitEmitter])
 
-  override val dependents = Seq.empty
+  override val optionalPrerequisiteOf = Seq.empty
 
   /** Determine if annotations are sane
     *

--- a/src/main/scala/firrtl/stage/phases/Compiler.scala
+++ b/src/main/scala/firrtl/stage/phases/Compiler.scala
@@ -51,7 +51,7 @@ class Compiler extends Phase with Translator[AnnotationSeq, Seq[CompilerRun]] wi
         Dependency[AddCircuit],
         Dependency[AddImplicitOutputFile])
 
-  override def dependents = Seq(Dependency[WriteEmitted])
+  override def optionalPrerequisiteOf = Seq(Dependency[WriteEmitted])
 
   /** Convert an [[AnnotationSeq]] into a sequence of compiler runs. */
   protected def aToB(a: AnnotationSeq): Seq[CompilerRun] = {

--- a/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
+++ b/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
@@ -126,7 +126,7 @@ object DriverCompatibility {
 
     override def prerequisites = Seq(Dependency[AddImplicitFirrtlFile])
 
-    override def dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
+    override def optionalPrerequisiteOf = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
 
     /** Try to add an [[firrtl.options.InputAnnotationFileAnnotation InputAnnotationFileAnnotation]] implicitly specified by
       * an [[AnnotationSeq]]. */
@@ -165,7 +165,8 @@ object DriverCompatibility {
 
     override def prerequisites = Seq.empty
 
-    override def dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
+    override def optionalPrerequisiteOf = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
+
 
     /** Try to add a [[FirrtlFileAnnotation]] implicitly specified by an [[AnnotationSeq]]. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {
@@ -196,7 +197,7 @@ object DriverCompatibility {
 
     override def prerequisites = Seq.empty
 
-    override def dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
+    override def optionalPrerequisiteOf = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
 
     /** Add one [[EmitAnnotation]] foreach [[CompilerAnnotation]]. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {
@@ -222,7 +223,7 @@ object DriverCompatibility {
 
     override def prerequisites = Seq(Dependency[AddImplicitFirrtlFile])
 
-    override def dependents = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
+    override def optionalPrerequisiteOf = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
 
     /** Add an [[OutputFileAnnotation]] derived from a [[TopNameAnnotation]] if needed. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
+++ b/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
@@ -28,7 +28,7 @@ class WriteEmitted extends Phase with PreservesAll[Phase] {
 
   override def prerequisites = Seq.empty
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   /** Write any [[EmittedAnnotation]]s in an [[AnnotationSeq]] to files. Written [[EmittedAnnotation]]s are deleted. */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/stage/transforms/WrappedTransform.scala
+++ b/src/main/scala/firrtl/stage/transforms/WrappedTransform.scala
@@ -23,11 +23,15 @@ trait WrappedTransform { this: Transform =>
     case _ => underlying
   }
 
-  override final def inputForm = underlying.inputForm
-  override final def outputForm = underlying.outputForm
-  override final def prerequisites = underlying.prerequisites
-  override final def optionalPrerequisites = underlying.optionalPrerequisites
-  override final def dependents = underlying.dependents
+  override def inputForm = underlying.inputForm
+  override def outputForm = underlying.outputForm
+  override def prerequisites = underlying.prerequisites
+  @deprecated(
+    "Due to confusion, 'dependents' is being renamed to 'optionalPrerequisiteOf'. Override the latter instead.",
+    "FIRRTL 1.3"
+  )
+  override def dependents = underlying.dependents
+  override def optionalPrerequisiteOf = underlying.optionalPrerequisiteOf
   override final def invalidates(b: Transform): Boolean = underlying.invalidates(b)
   override final lazy val name = underlying.name
 

--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -63,7 +63,7 @@ class BlackBoxSourceHelper extends Transform with DependencyAPIMigration with Pr
 
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   /** Collect BlackBoxHelperAnnos and and find the target dir if specified
     * @param annos a list of generic annotations for this transform

--- a/src/main/scala/firrtl/transforms/CheckCombLoops.scala
+++ b/src/main/scala/firrtl/transforms/CheckCombLoops.scala
@@ -106,7 +106,7 @@ class CheckCombLoops extends Transform
 
   override def optionalPrerequisites = Seq.empty
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   import CheckCombLoops._
 

--- a/src/main/scala/firrtl/transforms/CombineCats.scala
+++ b/src/main/scala/firrtl/transforms/CombineCats.scala
@@ -63,7 +63,7 @@ class CombineCats extends Transform with DependencyAPIMigration with PreservesAl
 
   override def optionalPrerequisites = Seq.empty
 
-  override def dependents = Seq(
+  override def optionalPrerequisiteOf = Seq(
     Dependency[SystemVerilogEmitter],
     Dependency[VerilogEmitter] )
 

--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -109,7 +109,7 @@ class ConstantPropagation extends Transform with DependencyAPIMigration with Res
 
   override def optionalPrerequisites = Seq.empty
 
-  override def dependents =
+  override def optionalPrerequisiteOf =
     Seq( Dependency(firrtl.passes.memlib.VerilogMemDelays),
          Dependency(firrtl.passes.SplitExpressions),
          Dependency[SystemVerilogEmitter],

--- a/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
+++ b/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
@@ -45,7 +45,7 @@ class DeadCodeElimination extends Transform
 
   override def optionalPrerequisites = Seq.empty
 
-  override def dependents =
+  override def optionalPrerequisiteOf =
     Seq( Dependency[firrtl.transforms.BlackBoxSourceHelper],
          Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
          Dependency[firrtl.transforms.FlattenRegUpdate],

--- a/src/main/scala/firrtl/transforms/Dedup.scala
+++ b/src/main/scala/firrtl/transforms/Dedup.scala
@@ -43,7 +43,7 @@ class DedupModules extends Transform with DependencyAPIMigration with PreservesA
 
   override def prerequisites = firrtl.stage.Forms.Resolved
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   /** Deduplicate a Circuit
     * @param state Input Firrtl AST

--- a/src/main/scala/firrtl/transforms/FixAddingNegativeLiteralsTransform.scala
+++ b/src/main/scala/firrtl/transforms/FixAddingNegativeLiteralsTransform.scala
@@ -113,7 +113,7 @@ class FixAddingNegativeLiterals extends Transform with DependencyAPIMigration wi
 
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   def execute(state: CircuitState): CircuitState = {
     val modulesx = state.circuit.modules.map(FixAddingNegativeLiterals.fixupModule)

--- a/src/main/scala/firrtl/transforms/Flatten.scala
+++ b/src/main/scala/firrtl/transforms/Flatten.scala
@@ -28,7 +28,7 @@ class Flatten extends Transform with DependencyAPIMigration with PreservesAll[Tr
 
    override def prerequisites = Forms.LowForm
    override def optionalPrerequisites = Seq.empty
-   override def dependents = Forms.LowEmitters
+   override def optionalPrerequisiteOf = Forms.LowEmitters
 
    val inlineTransform = new InlineInstances
 

--- a/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
+++ b/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
@@ -117,7 +117,7 @@ class FlattenRegUpdate extends Transform with DependencyAPIMigration {
 
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: DeadCodeElimination => true

--- a/src/main/scala/firrtl/transforms/GroupComponents.scala
+++ b/src/main/scala/firrtl/transforms/GroupComponents.scala
@@ -50,7 +50,7 @@ class GroupComponents extends Transform with DependencyAPIMigration {
 
   override def prerequisites = Forms.MidForm
   override def optionalPrerequisites = Seq.empty
-  override def dependents = Forms.MidEmitters
+  override def optionalPrerequisiteOf = Forms.MidEmitters
 
   override def invalidates(a: Transform): Boolean = a match {
     case InferTypes | ResolveKinds => true

--- a/src/main/scala/firrtl/transforms/InlineBitExtractions.scala
+++ b/src/main/scala/firrtl/transforms/InlineBitExtractions.scala
@@ -103,7 +103,7 @@ class InlineBitExtractionsTransform extends Transform with DependencyAPIMigratio
 
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   def execute(state: CircuitState): CircuitState = {
     val modulesx = state.circuit.modules.map(InlineBitExtractionsTransform.onMod(_))

--- a/src/main/scala/firrtl/transforms/InlineCasts.scala
+++ b/src/main/scala/firrtl/transforms/InlineCasts.scala
@@ -77,7 +77,7 @@ class InlineCastsTransform extends Transform with DependencyAPIMigration {
 
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   override def invalidates(a: Transform): Boolean = a match {
     case _: LegalizeClocksTransform => true

--- a/src/main/scala/firrtl/transforms/LegalizeClocks.scala
+++ b/src/main/scala/firrtl/transforms/LegalizeClocks.scala
@@ -70,7 +70,7 @@ class LegalizeClocksTransform extends Transform with DependencyAPIMigration with
 
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   def execute(state: CircuitState): CircuitState = {
     val modulesx = state.circuit.modules.map(LegalizeClocksTransform.onMod(_))

--- a/src/main/scala/firrtl/transforms/PropagatePresetAnnotations.scala
+++ b/src/main/scala/firrtl/transforms/PropagatePresetAnnotations.scala
@@ -45,7 +45,7 @@ class PropagatePresetAnnotations extends Transform with DependencyAPIMigration w
 
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
 
   import PropagatePresetAnnotations._

--- a/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
+++ b/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
@@ -245,6 +245,6 @@ class VerilogRename extends RemoveKeywordCollisions(v_keywords) with PreservesAl
 
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
 }

--- a/src/main/scala/firrtl/transforms/RemoveReset.scala
+++ b/src/main/scala/firrtl/transforms/RemoveReset.scala
@@ -23,7 +23,7 @@ object RemoveReset extends Transform with DependencyAPIMigration {
 
   override def optionalPrerequisites = Seq.empty
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   override def invalidates(a: Transform): Boolean = a match {
     case firrtl.passes.ResolveFlows => true

--- a/src/main/scala/firrtl/transforms/RemoveWires.scala
+++ b/src/main/scala/firrtl/transforms/RemoveWires.scala
@@ -30,7 +30,7 @@ class RemoveWires extends Transform with DependencyAPIMigration with PreservesAl
 
   override def optionalPrerequisites = Seq(Dependency[checks.CheckResets])
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   // Extract all expressions that are references to a Node, Wire, or Reg
   // Since we are operating on LowForm, they can only be WRefs

--- a/src/main/scala/firrtl/transforms/RenameModules.scala
+++ b/src/main/scala/firrtl/transforms/RenameModules.scala
@@ -18,7 +18,7 @@ class RenameModules extends Transform with DependencyAPIMigration with Preserves
 
   override def prerequisites = Forms.LowForm
   override def optionalPrerequisites = Seq.empty
-  override def dependents = Forms.LowEmitters
+  override def optionalPrerequisiteOf = Forms.LowEmitters
 
   def collectNameMapping(namespace: Namespace, moduleNameMap: mutable.HashMap[String, String])(mod: DefModule): Unit = {
     val newName = namespace.newName(mod.name)

--- a/src/main/scala/firrtl/transforms/ReplaceTruncatingArithmetic.scala
+++ b/src/main/scala/firrtl/transforms/ReplaceTruncatingArithmetic.scala
@@ -85,7 +85,7 @@ class ReplaceTruncatingArithmetic extends Transform with DependencyAPIMigration 
 
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   def execute(state: CircuitState): CircuitState = {
     val modulesx = state.circuit.modules.map(ReplaceTruncatingArithmetic.onMod(_))

--- a/src/main/scala/firrtl/transforms/SimplifyMems.scala
+++ b/src/main/scala/firrtl/transforms/SimplifyMems.scala
@@ -23,7 +23,7 @@ class SimplifyMems extends Transform with DependencyAPIMigration with PreservesA
 
   override def prerequisites = Forms.MidForm
   override def optionalPrerequisites = Seq.empty
-  override def dependents = Forms.MidEmitters
+  override def optionalPrerequisiteOf = Forms.MidEmitters
 
   def onModule(c: Circuit, renames: RenameMap)(m: DefModule): DefModule = {
     val moduleNS = Namespace(m)

--- a/src/main/scala/firrtl/transforms/TopWiring.scala
+++ b/src/main/scala/firrtl/transforms/TopWiring.scala
@@ -33,7 +33,7 @@ class TopWiringTransform extends Transform with DependencyAPIMigration {
 
   override def prerequisites = Forms.MidForm
   override def optionalPrerequisites = Seq.empty
-  override def dependents = Forms.MidEmitters
+  override def optionalPrerequisiteOf = Forms.MidEmitters
 
   override def invalidates(a: Transform): Boolean = a match {
     case InferTypes | ResolveKinds | ResolveFlows | ExpandConnects => true

--- a/src/main/scala/logger/phases/AddDefaults.scala
+++ b/src/main/scala/logger/phases/AddDefaults.scala
@@ -11,7 +11,7 @@ import logger.{LoggerOption, LogLevelAnnotation}
 private [logger] class AddDefaults extends Phase with PreservesAll[Phase] {
 
   override def prerequisites = Seq.empty
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   /** Add missing default [[Logger]] [[Annotation]]s to an [[AnnotationSeq]]
     * @param annotations input annotations

--- a/src/main/scala/logger/phases/Checks.scala
+++ b/src/main/scala/logger/phases/Checks.scala
@@ -15,7 +15,7 @@ import scala.collection.mutable
 object Checks extends Phase with PreservesAll[Phase] {
 
   override def prerequisites = Seq(Dependency[AddDefaults])
-  override def dependents = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
 
   /** Ensure that an [[firrtl.AnnotationSeq AnnotationSeq]] has necessary [[Logger]] [[firrtl.annotations.Annotation
     * Annotation]]s

--- a/src/test/scala/firrtl/testutils/FirrtlSpec.scala
+++ b/src/test/scala/firrtl/testutils/FirrtlSpec.scala
@@ -39,7 +39,7 @@ object RenameTop extends Transform with PreservesAll[Transform] {
 
   override val optionalPrerequisites = Seq(Dependency[RenameModules])
 
-  override val dependents = Seq(Dependency[VerilogEmitter], Dependency[MinimumVerilogEmitter])
+  override val optionalPrerequisiteOf = Seq(Dependency[VerilogEmitter], Dependency[MinimumVerilogEmitter])
 
   def execute(state: CircuitState): CircuitState = {
     val c = state.circuit

--- a/src/test/scala/firrtl/testutils/PassTests.scala
+++ b/src/test/scala/firrtl/testutils/PassTests.scala
@@ -73,7 +73,7 @@ class CustomResolveAndCheck(form: CircuitForm) extends SeqTransform {
 object ReRunResolveAndCheck extends Transform with DependencyAPIMigration with IdentityLike[CircuitState] {
 
   override val optionalPrerequisites = Forms.LowFormOptimized
-  override val dependents = Forms.ChirrtlEmitters
+  override val optionalPrerequisiteOf = Forms.ChirrtlEmitters
 
   override def invalidates(a: Transform) = {
     val resolveAndCheck = Forms.Resolved.toSet -- Forms.WorkingIR

--- a/src/test/scala/firrtlTests/InferReadWriteSpec.scala
+++ b/src/test/scala/firrtlTests/InferReadWriteSpec.scala
@@ -17,7 +17,7 @@ class InferReadWriteSpec extends SimpleTransformSpec {
   object InferReadWriteCheck extends Pass with PreservesAll[Transform] {
     override def prerequisites = Forms.MidForm
     override def optionalPrerequisites = Seq.empty
-    override def dependents = Forms.MidEmitters
+    override def optionalPrerequisiteOf = Forms.MidEmitters
 
     def findReadWrite(s: Statement): Boolean = s match {
       case s: DefMemory if s.readLatency > 0 && s.readwriters.size == 1 =>

--- a/src/test/scala/firrtlTests/options/PhaseManagerSpec.scala
+++ b/src/test/scala/firrtlTests/options/PhaseManagerSpec.scala
@@ -173,7 +173,7 @@ object InvertedAnalysisFixture {
 
 }
 
-object DependentsFixture {
+object OptionalPrerequisitesOfFixture {
 
   class First extends IdentityPhase {
     override def invalidates(phase: Phase): Boolean = false
@@ -190,7 +190,7 @@ object DependentsFixture {
    */
   class Custom extends IdentityPhase {
     override def prerequisites = Seq(Dependency[First])
-    override def dependents = Seq(Dependency[Second])
+    override def optionalPrerequisiteOf = Seq(Dependency[Second])
     override def invalidates(phase: Phase): Boolean = false
   }
 
@@ -255,7 +255,7 @@ object UnrelatedFixture {
 
   class B6Sub extends B6 {
     override def prerequisites = Seq(Dependency[B6])
-    override def dependents = Seq(Dependency[B7])
+    override def optionalPrerequisiteOf = Seq(Dependency[B7])
   }
 
   class B6_0 extends B6Sub
@@ -276,7 +276,7 @@ object UnrelatedFixture {
   class B6_15 extends B6Sub
 
   class B8Dep extends B8 {
-    override def dependents = Seq(Dependency[B8])
+    override def optionalPrerequisiteOf = Seq(Dependency[B8])
   }
 
   class B8_0 extends B8Dep
@@ -304,12 +304,12 @@ object CustomAfterOptimizationFixture {
 
   class OptMinimum extends IdentityPhase with PreservesAll[Phase] {
     override def prerequisites = Seq(Dependency[Root])
-    override def dependents = Seq(Dependency[AfterOpt])
+    override def optionalPrerequisiteOf = Seq(Dependency[AfterOpt])
   }
 
   class OptFull extends IdentityPhase with PreservesAll[Phase] {
     override def prerequisites = Seq(Dependency[Root], Dependency[OptMinimum])
-    override def dependents = Seq(Dependency[AfterOpt])
+    override def optionalPrerequisiteOf = Seq(Dependency[AfterOpt])
   }
 
   class AfterOpt extends IdentityPhase with PreservesAll[Phase]
@@ -324,7 +324,7 @@ object CustomAfterOptimizationFixture {
 
   class Custom extends IdentityPhase with PreservesAll[Phase] {
     override def prerequisites = Seq(Dependency[Root], Dependency[AfterOpt])
-    override def dependents = Seq(Dependency[DoneMinimum], Dependency[DoneFull])
+    override def optionalPrerequisiteOf = Seq(Dependency[DoneMinimum], Dependency[DoneFull])
   }
 
 }
@@ -352,7 +352,7 @@ object OptionalPrerequisitesFixture {
   class Custom extends IdentityPhase with PreservesAll[Phase] {
     override def prerequisites = Seq(Dependency[Root])
     override def optionalPrerequisites = Seq(Dependency[OptMinimum], Dependency[OptFull])
-    override def dependents = Seq(Dependency[DoneMinimum], Dependency[DoneFull])
+    override def optionalPrerequisiteOf = Seq(Dependency[DoneMinimum], Dependency[DoneFull])
   }
 
 }
@@ -524,9 +524,9 @@ class PhaseManagerSpec extends AnyFlatSpec with Matchers {
     pm.flattenedTransformOrder.map(_.getClass) should be (order)
   }
 
-  /** This test shows how the dependents member can be used to run one transform before another. */
-  it should "handle a custom Phase with a dependent" in {
-    val f = DependentsFixture
+  /** This test shows how the optionalPrerequisiteOf member can be used to run one transform before another. */
+  it should "handle a custom Phase with an optionalPrerequisiteOf" in {
+    val f = OptionalPrerequisitesOfFixture
 
     info("without the custom transform it runs: First -> Second")
     val pm = new PhaseManager(Seq(Dependency[f.Second]))
@@ -578,7 +578,7 @@ class PhaseManagerSpec extends AnyFlatSpec with Matchers {
            Dependency[f.B14],
            Dependency[f.B15] )
     /** A sequence of custom transforms that should all run after B6 and before B7. This exercises correct ordering of the
-      * prerequisiteGraph and dependentsGraph.
+      * prerequisiteGraph and optionalPrerequisiteOfGraph.
       */
     val prerequisiteTargets =
       Seq( Dependency[f.B6_0],
@@ -597,8 +597,8 @@ class PhaseManagerSpec extends AnyFlatSpec with Matchers {
            Dependency[f.B6_13],
            Dependency[f.B6_14],
            Dependency[f.B6_15] )
-    /** A sequence of transforms that are invalidated by B0 and only define dependents on B8. This exercises the ordering
-      * defined by "otherDependents".
+    /** A sequence of transforms that are invalidated by B0 and only define optionalPrerequisiteOf on B8. This exercises
+      * the ordering defined by "otherPrerequisites".
       */
     val current =
       Seq( Dependency[f.B8_0],


### PR DESCRIPTION
**Edit: the new name is now `optionalPrerequisiteOf` and not `optionalPrerequisitesOf`!**

This changes the name of the Dependency API member `dependents` to `optionalPrerequisiteOf`. The former name was causing large amounts of confusion where users thought that declaring a dependent meant that the downstream dependent would get scheduled. In actuality, declaring a dependent meant injecting an optional prerequisites.

This makes the migration in a backwards-compatible way by adding a new `optionalPrerequisiteOf` member with a default implementation of `dependents`. The PR then deprecates `dependents` and changes names/comments in the `DependencyManager` to remove references to "dependents". All transforms are then migrated to set `optionalPrerequisiteOf` instead of `dependents`.

This is currently sitting on top of #1534 and should be merged after that.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR? (**N/A, no new feature added.**)
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
- new feature/API

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

- deprecates `firrtl.options.DependencyAPI[_].dependents`
- adds `firrtl.options.DependencyAPI[_].optionalPrerequisiteOf`

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Deprecate Dependency API dependents, renames dependents to optionalPrerequisiteOf

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
