### PR TITLE
add Firrtl plugin info for intellij platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ sbt assembly
 * Firrtl syntax highlighting for Vim users: https://github.com/azidar/firrtl-syntax
 * Firrtl syntax highlighting for Sublime Text 3 users: https://github.com/codelec/highlight-firrtl
 * Firrtl syntax highlighting for Atom users: https://atom.io/packages/language-firrtl
+* Firrtl syntax highlighting, structure view, navigate to corresponding Chisel code for IntelliJ platform: https://plugins.jetbrains.com/plugin/14183-easysoc-firrtl
 * Firrtl mode for Emacs users: https://github.com/ibm/firrtl-mode
 * Chisel3, an embedded hardware DSL that generates Firrtl: https://github.com/freechipsproject/chisel3
 * Treadle, a Firrtl Interpreter: https://github.com/freechipsproject/treadle

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ sbt assembly
 * Firrtl syntax highlighting for Vim users: https://github.com/azidar/firrtl-syntax
 * Firrtl syntax highlighting for Sublime Text 3 users: https://github.com/codelec/highlight-firrtl
 * Firrtl syntax highlighting for Atom users: https://atom.io/packages/language-firrtl
-* Firrtl syntax highlighting, structure view, navigate to corresponding Chisel code for IntelliJ platform: https://plugins.jetbrains.com/plugin/14183-easysoc-firrtl
+* Firrtl syntax highlighting, structure view, navigate to corresponding Chisel code for IntelliJ platform: https://github.com/easysoc/easysoc-firrtl
 * Firrtl mode for Emacs users: https://github.com/ibm/firrtl-mode
 * Chisel3, an embedded hardware DSL that generates Firrtl: https://github.com/freechipsproject/chisel3
 * Treadle, a Firrtl Interpreter: https://github.com/freechipsproject/treadle

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ sbt assembly
 * Firrtl syntax highlighting for Vim users: https://github.com/azidar/firrtl-syntax
 * Firrtl syntax highlighting for Sublime Text 3 users: https://github.com/codelec/highlight-firrtl
 * Firrtl syntax highlighting for Atom users: https://atom.io/packages/language-firrtl
-* Firrtl syntax highlighting, structure view, navigate to corresponding Chisel code for IntelliJ platform: https://github.com/easysoc/easysoc-firrtl
+* Firrtl syntax highlighting, structure view, navigate to corresponding Chisel code for IntelliJ platform: [jetbrains plugin](https://plugins.jetbrains.com/plugin/14183-easysoc-firrtl),  [source code](https://github.com/easysoc/easysoc-firrtl)
 * Firrtl mode for Emacs users: https://github.com/ibm/firrtl-mode
 * Chisel3, an embedded hardware DSL that generates Firrtl: https://github.com/freechipsproject/chisel3
 * Treadle, a Firrtl Interpreter: https://github.com/freechipsproject/treadle


### PR DESCRIPTION
I developed a Firrtl plugin for intellij platform.
Currently it support Syntax highlighting, Structure View and jump to the corresponding Chisel code by navigate(Ctrl+Click) the Firrtl fileinfo comment.

plugin:
https://plugins.jetbrains.com/plugin/14183-easysoc-firrtl
code:
https://github.com/easysoc/easysoc-firrtl