### PR TITLE
Emitter: guard _RAND_* declarations with ifdef

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -544,6 +544,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
     }
 
     val portdefs = ArrayBuffer[Seq[Any]]()
+    val ifdefDeclares = mutable.Map[String, ArrayBuffer[Seq[Any]]]()
     val declares = ArrayBuffer[Seq[Any]]()
     val instdeclares = ArrayBuffer[Seq[Any]]()
     val assigns = ArrayBuffer[Seq[Any]]()
@@ -576,15 +577,21 @@ class VerilogEmitter extends SeqTransform with Emitter {
     def bigIntToVLit(bi: BigInt): String =
       if (bi.isValidInt) bi.toString else s"${bi.bitLength}'d$bi"
 
-    def declareVectorType(b: String, n: String, tpe: Type, size: BigInt, info: Info) = {
-      declares += Seq(b, " ", tpe, " ", n, " [0:", bigIntToVLit(size - 1), "];", info)
+    def declareVectorType(b: String, n: String, tpe: Type, size: BigInt, info: Info, ifdefOpt: Option[String]): Unit = {
+      val decl = Seq(b, " ", tpe, " ", n, " [0:", bigIntToVLit(size - 1), "];", info)
+      if (ifdefOpt.isDefined) {
+        ifdefDeclares.getOrElseUpdate(ifdefOpt.get, ArrayBuffer[Seq[Any]]()) += decl
+      } else {
+        declares += decl
+      }
     }
-    def declareVectorType(b: String, n: String, tpe: Type, size: BigInt, info: Info, preset: Expression) = {
+
+    def declareVectorType(b: String, n: String, tpe: Type, size: BigInt, info: Info, preset: Expression): Unit = {
       declares += Seq(b, " ", tpe, " ", n, " [0:", bigIntToVLit(size - 1), "] = ", preset, ";", info)
     }
     
     val moduleTarget = CircuitTarget(circuitName).module(m.name)
-      
+
     // declare with initial value
     def declare(b: String, n: String, t: Type, info: Info, preset: Expression) = t match {
       case tx: VectorType =>
@@ -593,13 +600,30 @@ class VerilogEmitter extends SeqTransform with Emitter {
         declares += Seq(b, " ", tx, " ", n, " = ", preset, ";", info)
     }
     
+    def declareVectorType(b: String, n: String, tpe: Type, size: BigInt, info: Info): Unit =
+      declareVectorType(b, n, tpe, size, info, None)
+
+    def declareVectorType(b: String, n: String, tpe: Type, size: BigInt, info: Info, ifdef: String): Unit =
+      declareVectorType(b, n, tpe, size, info, Some(ifdef))
+
     // original declare without initial value
-    def declare(b: String, n: String, t: Type, info: Info) = t match {
+    def declare(b: String, n: String, t: Type, info: Info, ifdefOpt: Option[String]): Unit = t match {
       case tx: VectorType =>
-        declareVectorType(b, n, tx.tpe, tx.size, info)
+        declareVectorType(b, n, tx.tpe, tx.size, info, ifdefOpt)
       case tx =>
-        declares += Seq(b, " ", tx, " ", n,";",info)
+        val decl = Seq(b, " ", tx, " ", n,";",info)
+        if (ifdefOpt.isDefined) {
+          ifdefDeclares.getOrElseUpdate(ifdefOpt.get, ArrayBuffer[Seq[Any]]()) += decl
+        } else {
+          declares += decl
+        }
     }
+
+    def declare(b: String, n: String, t: Type, info: Info, ifdef: String): Unit =
+      declare(b, n, t, info, Some(ifdef))
+
+    def declare(b: String, n: String, t: Type, info: Info): Unit =
+      declare(b, n, t, info, None)
 
     def assign(e: Expression, value: Expression, info: Info): Unit = {
       assigns += Seq("assign ", e, " = ", value, ";", info)
@@ -610,14 +634,14 @@ class VerilogEmitter extends SeqTransform with Emitter {
       assigns += Seq("`ifndef RANDOMIZE_GARBAGE_ASSIGN")
       assigns += Seq("assign ", e, " = ", syn, ";", info)
       assigns += Seq("`else")
-      assigns += Seq("assign ", e, " = ", garbageCond, " ? ", rand_string(syn.tpe), " : ", syn,
+      assigns += Seq("assign ", e, " = ", garbageCond, " ? ", rand_string(syn.tpe, "RANDOMIZE_GARBAGE_ASSIGN"), " : ", syn,
                      ";", info)
       assigns += Seq("`endif // RANDOMIZE_GARBAGE_ASSIGN")
     }
 
     def invalidAssign(e: Expression) = {
       assigns += Seq("`ifdef RANDOMIZE_INVALID_ASSIGN")
-      assigns += Seq("assign ", e, " = ", rand_string(e.tpe), ";")
+      assigns += Seq("assign ", e, " = ", rand_string(e.tpe, "RANDOMIZE_INVALID_ASSIGN"), ";")
       assigns += Seq("`endif // RANDOMIZE_INVALID_ASSIGN")
     }
 
@@ -681,18 +705,22 @@ class VerilogEmitter extends SeqTransform with Emitter {
 
     // Declares an intermediate wire to hold a large enough random number.
     // Then, return the correct number of bits selected from the random value
-    def rand_string(t: Type): Seq[Any] = {
+    def rand_string(t: Type, ifdefOpt: Option[String]): Seq[Any] = {
       val nx = namespace.newName("_RAND")
       val rand = VRandom(bitWidth(t))
       val tx = SIntType(IntWidth(rand.realWidth))
-      declare("reg", nx, tx, NoInfo)
+      declare("reg", nx, tx, NoInfo, ifdefOpt)
       initials += Seq(wref(nx, tx), " = ", VRandom(bitWidth(t)), ";")
       Seq(nx, "[", bitWidth(t) - 1, ":0]")
     }
 
+    def rand_string(t: Type, ifdef: String): Seq[Any] = rand_string(t, Some(ifdef))
+
+    def rand_string(t: Type): Seq[Any] = rand_string(t, None)
+
     def initialize(e: Expression, reset: Expression, init: Expression) = {
       initials += Seq("`ifdef RANDOMIZE_REG_INIT")
-      initials += Seq(e, " = ", rand_string(e.tpe), ";")
+      initials += Seq(e, " = ", rand_string(e.tpe, "RANDOMIZE_REG_INIT"), ";")
       initials += Seq("`endif // RANDOMIZE_REG_INIT")
       reset.tpe match {
         case AsyncResetType =>
@@ -708,7 +736,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
         maxMemSize = s.depth
       }
       val index = wref("initvar", s.dataType)
-      val rstring = rand_string(s.dataType)
+      val rstring = rand_string(s.dataType, "RANDOMIZE_MEM_INIT")
       initials += Seq("`ifdef RANDOMIZE_MEM_INIT")
       initials += Seq("for (initvar = 0; initvar < ", bigIntToVLit(s.depth), "; initvar = initvar+1)")
       initials += Seq(tab, WSubAccess(wref(s.name, s.dataType), index, s.dataType, SinkFlow),
@@ -937,6 +965,11 @@ class VerilogEmitter extends SeqTransform with Emitter {
       for (x <- portdefs) emit(Seq(tab, x))
       emit(Seq(");"))
 
+      ifdefDeclares.toSeq.sortWith(_._1 < _._1).foreach { case (ifdef, declares) =>
+        emit(Seq("`ifdef " + ifdef))
+        for (x <- declares) emit(Seq(tab, x))
+        emit(Seq("`endif"))
+      }
       if (declares.isEmpty && assigns.isEmpty) emit(Seq(tab, "initial begin end"))
       for (x <- declares) emit(Seq(tab, x))
       for (x <- instdeclares) emit(Seq(tab, x))

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -544,6 +544,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
     }
 
     val portdefs = ArrayBuffer[Seq[Any]]()
+    // mapps ifdef guard to declaration blocks
     val ifdefDeclares = mutable.Map[String, ArrayBuffer[Seq[Any]]]()
     val declares = ArrayBuffer[Seq[Any]]()
     val instdeclares = ArrayBuffer[Seq[Any]]()
@@ -558,6 +559,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
     val asyncResetAlwaysBlocks = mutable.ArrayBuffer[(Expression, Expression, Seq[Any])]()
     // Used to determine type of initvar for initializing memories
     var maxMemSize: BigInt = BigInt(0)
+    // mapps ifdef guard to initial blocks
     val ifdefInitials = mutable.Map[String, ArrayBuffer[Seq[Any]]]()
     val initials = ArrayBuffer[Seq[Any]]()
     // In Verilog, async reset registers are expressed using always blocks of the form:
@@ -588,6 +590,11 @@ class VerilogEmitter extends SeqTransform with Emitter {
       }
     }
 
+    // original vector type declare without initial value
+    def declareVectorType(b: String, n: String, tpe: Type, size: BigInt, info: Info): Unit =
+      declareVectorType(b, n, tpe, size, info, None)
+
+    // declare vector type with initial value
     def declareVectorType(b: String, n: String, tpe: Type, size: BigInt, info: Info, preset: Expression): Unit = {
       declares += Seq(b, " ", tpe, " ", n, " [0:", bigIntToVLit(size - 1), "] = ", preset, ";", info)
     }
@@ -601,14 +608,6 @@ class VerilogEmitter extends SeqTransform with Emitter {
       case tx =>
         declares += Seq(b, " ", tx, " ", n, " = ", preset, ";", info)
     }
-
-    // original vector type declare without initial value
-    def declareVectorType(b: String, n: String, tpe: Type, size: BigInt, info: Info): Unit =
-      declareVectorType(b, n, tpe, size, info, None)
-
-    // original vector type declare without initial value and with an ifdef guard
-    def declareVectorType(b: String, n: String, tpe: Type, size: BigInt, info: Info, ifdef: String): Unit =
-      declareVectorType(b, n, tpe, size, info, Some(ifdef))
 
     // original declare without initial value and optinally with an ifdef guard
     def declare(b: String, n: String, t: Type, info: Info, ifdefOpt: Option[String]): Unit = t match {

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -544,8 +544,12 @@ class VerilogEmitter extends SeqTransform with Emitter {
     }
 
     val portdefs = ArrayBuffer[Seq[Any]]()
-    // mapps ifdef guard to declaration blocks
-    val ifdefDeclares = mutable.Map[String, ArrayBuffer[Seq[Any]]]()
+    // maps ifdef guard to declaration blocks
+    val ifdefDeclares: mutable.Map[String, ArrayBuffer[Seq[Any]]] = mutable.Map().withDefault { key =>
+      val value = ArrayBuffer[Seq[Any]]()
+      ifdefDeclares(key) = value
+      value
+    }
     val declares = ArrayBuffer[Seq[Any]]()
     val instdeclares = ArrayBuffer[Seq[Any]]()
     val assigns = ArrayBuffer[Seq[Any]]()
@@ -559,8 +563,12 @@ class VerilogEmitter extends SeqTransform with Emitter {
     val asyncResetAlwaysBlocks = mutable.ArrayBuffer[(Expression, Expression, Seq[Any])]()
     // Used to determine type of initvar for initializing memories
     var maxMemSize: BigInt = BigInt(0)
-    // mapps ifdef guard to initial blocks
-    val ifdefInitials = mutable.Map[String, ArrayBuffer[Seq[Any]]]()
+    // maps ifdef guard to initial blocks
+    val ifdefInitials: mutable.Map[String, ArrayBuffer[Seq[Any]]] = mutable.Map().withDefault { key =>
+      val value = ArrayBuffer[Seq[Any]]()
+      ifdefInitials(key) = value
+      value
+    }
     val initials = ArrayBuffer[Seq[Any]]()
     // In Verilog, async reset registers are expressed using always blocks of the form:
     // always @(posedge clock or posedge reset) begin
@@ -581,10 +589,10 @@ class VerilogEmitter extends SeqTransform with Emitter {
       if (bi.isValidInt) bi.toString else s"${bi.bitLength}'d$bi"
 
     // declare vector type with no preset and optionally with an ifdef guard
-    def declareVectorType(b: String, n: String, tpe: Type, size: BigInt, info: Info, ifdefOpt: Option[String]): Unit = {
+    private def declareVectorType(b: String, n: String, tpe: Type, size: BigInt, info: Info, ifdefOpt: Option[String]): Unit = {
       val decl = Seq(b, " ", tpe, " ", n, " [0:", bigIntToVLit(size - 1), "];", info)
       if (ifdefOpt.isDefined) {
-        ifdefDeclares.getOrElseUpdate(ifdefOpt.get, ArrayBuffer[Seq[Any]]()) += decl
+        ifdefDeclares(ifdefOpt.get) += decl
       } else {
         declares += decl
       }
@@ -610,20 +618,20 @@ class VerilogEmitter extends SeqTransform with Emitter {
     }
 
     // original declare without initial value and optinally with an ifdef guard
-    def declare(b: String, n: String, t: Type, info: Info, ifdefOpt: Option[String]): Unit = t match {
+    private def declare(b: String, n: String, t: Type, info: Info, ifdefOpt: Option[String]): Unit = t match {
       case tx: VectorType =>
         declareVectorType(b, n, tx.tpe, tx.size, info, ifdefOpt)
       case tx =>
         val decl = Seq(b, " ", tx, " ", n,";",info)
         if (ifdefOpt.isDefined) {
-          ifdefDeclares.getOrElseUpdate(ifdefOpt.get, ArrayBuffer[Seq[Any]]()) += decl
+          ifdefDeclares(ifdefOpt.get) += decl
         } else {
           declares += decl
         }
     }
 
     // original declare without initial value and with an ifdef guard
-    def declare(b: String, n: String, t: Type, info: Info, ifdef: String): Unit =
+    private def declare(b: String, n: String, t: Type, info: Info, ifdef: String): Unit =
       declare(b, n, t, info, Some(ifdef))
 
     // original declare without initial value
@@ -717,7 +725,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
       declare("reg", nx, tx, NoInfo, ifdefOpt)
       val initial = Seq(wref(nx, tx), " = ", VRandom(bitWidth(t)), ";")
       if (ifdefOpt.isDefined) {
-        ifdefInitials.getOrElseUpdate(ifdefOpt.get, ArrayBuffer[Seq[Any]]()) += initial
+        ifdefInitials(ifdefOpt.get) += initial
       } else {
         initials += initial
       }
@@ -977,7 +985,6 @@ class VerilogEmitter extends SeqTransform with Emitter {
         for (x <- declares) emit(Seq(tab, x))
         emit(Seq("`endif // " + ifdef))
       }
-      if (declares.isEmpty && ifdefDeclares.isEmpty && assigns.isEmpty) emit(Seq(tab, "initial begin end"))
       for (x <- declares) emit(Seq(tab, x))
       for (x <- instdeclares) emit(Seq(tab, x))
       for (x <- assigns) emit(Seq(tab, x))


### PR DESCRIPTION
fixes https://github.com/freechipsproject/firrtl/issues/1372. This adds `ifdefInitials` and `ifdefDeclares` fields to `VerilogRenderer` which map ifdef strings to their declaration/initial blocks and adds versions of `declare`, `declareVectorType`, and `rand_string` that take an optional ifdef string.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
- backend code generation
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
extends the declare/declareVectorType/rand_string methods in `VerilogRender` to include versions that accept an ifdef string.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
`_RAND_*` declarations are gated by `ifdef`s and grouped together. Instead of having `_RAND_*` regs mixed with normal regs the `_RAND_*` regs will be grouped into ifdef blocks. Initialization code for `_RAND_*` regs will also be grouped by ifdefs. This is what ICache.v looks like
```
module ICache(
...
);
`ifdef RANDOMIZE_MEM_INIT
  reg [31:0] _RAND_0;
  reg [31:0] _RAND_3;
...
`endif // RANDOMIZE_MEM_INIT
`ifdef RANDOMIZE_REG_INIT
  reg [31:0] _RAND_1;
  reg [31:0] _RAND_2;
...
`endif // RANDOMIZE_REG_INIT
  reg [19:0] tag_array_0 [0:63];
  wire [19:0] tag_array_0_tag_rdata_data;
...
initial begin
  `ifdef RANDOMIZE
    `ifdef INIT_RANDOM
      `INIT_RANDOM
    `endif
    `ifndef VERILATOR
      `ifdef RANDOMIZE_DELAY
        #`RANDOMIZE_DELAY begin end
      `else
        #0.002 begin end
      `endif
    `endif
`ifdef RANDOMIZE_MEM_INIT
  _RAND_0 = {1{`RANDOM}};
  for (initvar = 0; initvar < 64; initvar = initvar+1)
    tag_array_0[initvar] = _RAND_0[19:0];
  _RAND_3 = {1{`RANDOM}};
  for (initvar = 0; initvar < 64; initvar = initvar+1)
    tag_array_1[initvar] = _RAND_3[19:0];
  ...
`endif // RANDOMIZE_MEM_INIT
`ifdef RANDOMIZE_REG_INIT
  _RAND_1 = {1{`RANDOM}};
  tag_array_0_tag_rdata_en_pipe_0 = _RAND_1[0:0];
  _RAND_2 = {1{`RANDOM}};
  tag_array_0_tag_rdata_addr_pipe_0 = _RAND_2[5:0];
  ...
`endif // RANDOMIZE_REG_INIT
  `endif // RANDOMIZE
end // initial
...
```

and this is what the old ICache looked like
```
module ICache(
...
)
  reg [19:0] tag_array_0 [0:63];
  reg [31:0] _RAND_0;
  wire [19:0] tag_array_0_tag_rdata_data;
  wire [5:0] tag_array_0_tag_rdata_addr;
  wire [19:0] tag_array_0__T_328_data;
  wire [5:0] tag_array_0__T_328_addr;
  wire  tag_array_0__T_328_mask;
  wire  tag_array_0__T_328_en;
  reg  tag_array_0_tag_rdata_en_pipe_0;
  reg [31:0] _RAND_1;
  reg [5:0] tag_array_0_tag_rdata_addr_pipe_0;
  reg [31:0] _RAND_2;
  reg [19:0] tag_array_1 [0:63];
  reg [31:0] _RAND_3;
...
initial begin
  `ifdef RANDOMIZE
    `ifdef INIT_RANDOM
      `INIT_RANDOM
    `endif
    `ifndef VERILATOR
      `ifdef RANDOMIZE_DELAY
        #`RANDOMIZE_DELAY begin end
      `else
        #0.002 begin end
      `endif
    `endif
  _RAND_0 = {1{`RANDOM}};
  `ifdef RANDOMIZE_MEM_INIT
  for (initvar = 0; initvar < 64; initvar = initvar+1)
    tag_array_0[initvar] = _RAND_0[19:0];
  `endif // RANDOMIZE_MEM_INIT
  `ifdef RANDOMIZE_REG_INIT
  _RAND_1 = {1{`RANDOM}};
  tag_array_0_tag_rdata_en_pipe_0 = _RAND_1[0:0];
  `endif // RANDOMIZE_REG_INIT
  `ifdef RANDOMIZE_REG_INIT
  _RAND_2 = {1{`RANDOM}};
  tag_array_0_tag_rdata_addr_pipe_0 = _RAND_2[5:0];
  `endif // RANDOMIZE_REG_INIT
  _RAND_3 = {1{`RANDOM}};
  `ifdef RANDOMIZE_MEM_INIT
...
  `endif // RANDOMIZE
end // initial
...
```
I wasn't sure about what the indentation should look like. right now `ifdef`/`endif` lines are not indented and the statements inside are indented once.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Guard `_RAND_*` randomization registers with `ifdef`s.


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
