### PR TITLE
Uniquify mems as if they're vectors (emit Uniquified Verilog)

### DIFF
--- a/src/main/scala/firrtl/passes/Uniquify.scala
+++ b/src/main/scala/firrtl/passes/Uniquify.scala
@@ -92,7 +92,7 @@ object Uniquify extends Transform with DependencyAPIMigration {
       case sx: WDefInstance => Seq(Field(sx.name, Default, sx.tpe))
       case sx: DefMemory => sx.dataType match {
         case (_: UIntType | _: SIntType | _: FixedType) =>
-          Seq(Field(sx.name, Default, memType(sx)))
+          Seq(Field(sx.name, Default, VectorType(sx.dataType, sx.depth.toInt)))
         case tpe: BundleType =>
           val newFields = tpe.fields map ( f =>
             DefMemory(sx.info, f.name, f.tpe, sx.depth, sx.writeLatency,

--- a/src/test/scala/firrtlTests/UniquifySpec.scala
+++ b/src/test/scala/firrtlTests/UniquifySpec.scala
@@ -316,4 +316,24 @@ class UniquifySpec extends FirrtlFlatSpec {
     if (TestOptions.accurateTiming)
       renameMs shouldBe < (baseMs * threshold)
   }
+
+  it should "rename to avoid collisions with lowered bits" in {
+    val input =
+     """|circuit Foo:
+        |  module Foo:
+        |    mem _T :
+        |      data-type => UInt<1>
+        |      depth => 2
+        |      read-latency => 0
+        |      write-latency => 1
+        |      read-under-write => undefined
+        |    wire _T_1 : UInt<1>
+     """.stripMargin
+    val expected = Seq(
+      "mem _T_ :",
+      "wire _T_1 : UInt<1>") map normalized
+
+    executeTest(input, expected)
+  }
+
 }


### PR DESCRIPTION
Change the behavior of `Uniquify` when generating unique names for memories. Previously, memories are treated like instances with ports. However, memories are never actually lowered like this. Consider that memories are lowered in one of two ways:

1. Using `ReplSeqMem` -- The memory is blackboxed. It's only potential source of namespace conflict via lowering is due to the name of the memory.
2. By the Verilog emitter -- if this happens, then the memory is emitted as `reg foo [0:31]`. Here, the contribution to the Verilog namespace is actually a **vector**.

This PR changes `Uniquify` to view the contribution of a memory to a module's namespace as situation (2).

This allows for the postcondition of `Uniquify` (that you can blindly lower types) to be true for FIRRTL-emitted Verilog that includes memories. Currently this is not true. *In effect, the `VerilogEmitter` invalidates `Uniquify` and this PR makes it not do that.*

One test case is included to show this behavior. Something like this is reproduced below. If you start with the following module `Foo` which contains memory `bar` and a wire `bar_0`:
```
circuit Foo:
  module Foo:
    mem bar:
      data-type => UInt<1>
      depth => 2
      read-latency => 0
      write-latency => 1
      read-under-write => undefined
    wire bar_0: UInt<1>
    bar_0 is invalid
```

You get the following Verilog currently (with `--no-dce` and trimmed to exclude randomization logic):
```verilog
module Foo(
);
  reg  bar [0:1];
  wire  bar_0;
  assign bar_0 = 1'h0;
endmodule
```

If you were to then blindly lower `bar` in Verilog you'd get a name conflict on `bar_0`. This PR changes it so that you instead get `reg bar_` *which does not conflict with `bar_0` if lowered*.

Contrast this with the behavior of `bar` being a wire:

```
circuit Foo:
  module Foo:
    wire bar: UInt<1>[2]
    wire bar_0: UInt<1>

    bar is invalid
    bar_0 is invalid
```

This will compile to:
```verilog
module Foo(
);
  wire  bar__0;
  wire  bar__1;
  wire  bar_0;
  assign bar__0 = 1'h0;
  assign bar__1 = 1'h0;
  assign bar_0 = 1'h0;
endmodule
```

This PR can be viewed as aligning these two naming behaviors.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

No impact.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

Possible name changes in emitted Verilog for memories not blackboxed.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Prevent mems emitted as Verilog vectors from colliding with other signal names if lowered by a downstream tool

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
