### PR TITLE
[1.3.x] Add binary compatibility checking to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,3 +90,8 @@ jobs:
     - stage: test
       script:
         - benchmark/scripts/benchmark_cold_compile.py -N 2 --designs regress/ICache.fir --versions HEAD
+    - stage: test
+      name: "[Release Branch] Check Binary-compatibility"
+      script:
+        - sbt compile
+        - sbt +mimaReportBinaryIssues

--- a/build.sbt
+++ b/build.sbt
@@ -96,6 +96,12 @@ lazy val antlrSettings = Seq(
   javaSource in Antlr4 := (sourceManaged in Compile).value
 )
 
+import com.typesafe.tools.mima.core._
+lazy val mimaSettings = Seq(
+  mimaPreviousArtifacts := Set("edu.berkeley.cs" %% "firrtl" % "1.3.0"),
+  mimaBinaryIssueFilters ++= Seq()
+)
+
 lazy val publishSettings = Seq(
   publishMavenStyle := true,
   publishArtifact in Test := false,
@@ -185,3 +191,4 @@ lazy val firrtl = (project in file("."))
   .settings(testAssemblySettings)
   .settings(publishSettings)
   .settings(docSettings)
+  .settings(mimaSettings)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,8 @@ resolvers += Classpaths.sbtPluginReleases
 
 resolvers += "jgit-repo" at "https://download.eclipse.org/jgit/maven"
 
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.7.0")
+
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
  - testing
#### API Impact

Enforces binary compatibility for 1.3.x branch

#### Backend Code Generation Impact

None

#### Desired Merge Strategy

Don't care

#### Release Notes

None

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
