### PR TITLE
Update Mergify rules to backport to 1.3.x

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,15 +21,15 @@ pull_request_rules:
         strict: smart
         strict_method: merge
 
-  - name: backport to 1.2.x
+  - name: backport to 1.3.x
     conditions:
       - merged
       - base=master
-      - milestone=1.2.X
+      - milestone=1.3.x
     actions:
       backport:
         branches:
-          - 1.2.x
+          - 1.3.x
         ignore_conflicts: True
         label_conflicts: "bp-conflict"
       label:
@@ -37,7 +37,7 @@ pull_request_rules:
 
   - name: label Mergify backport PR
     conditions:
-      - base=1.2.x
+      - base=1.3.x
       - body~=This is an automated backport of pull request \#\d+ done by Mergify
     actions:
       label:
@@ -47,7 +47,7 @@ pull_request_rules:
     conditions:
       - status-success=continuous-integration/travis-ci/pr
       - "#changes-requested-reviews-by=0"
-      - base=1.2.x
+      - base=1.3.x
       - label="Backport"
       - label!="DO NOT MERGE"
       - label!="bp-conflict"


### PR DESCRIPTION
This replaces the rules for 1.2.x

This implementation is assuming we are no longer backporting to 1.2.x. If we wish to backport to multiple stable branches, we need to change from using milestones to using Labels.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- automation

#### API Impact

None

#### Backend Code Generation Impact

None

#### Desired Merge Strategy

Don't care

#### Release Notes

None

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
