### PR TITLE
Emitter: revert Unit result type to ArrayBuffer

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -589,7 +589,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
       if (bi.isValidInt) bi.toString else s"${bi.bitLength}'d$bi"
 
     // declare vector type with no preset and optionally with an ifdef guard
-    private def declareVectorType(b: String, n: String, tpe: Type, size: BigInt, info: Info, ifdefOpt: Option[String]): Unit = {
+    private def declareVectorType(b: String, n: String, tpe: Type, size: BigInt, info: Info, ifdefOpt: Option[String]): ArrayBuffer[Seq[Any]] = {
       val decl = Seq(b, " ", tpe, " ", n, " [0:", bigIntToVLit(size - 1), "];", info)
       if (ifdefOpt.isDefined) {
         ifdefDeclares(ifdefOpt.get) += decl
@@ -599,18 +599,18 @@ class VerilogEmitter extends SeqTransform with Emitter {
     }
 
     // original vector type declare without initial value
-    def declareVectorType(b: String, n: String, tpe: Type, size: BigInt, info: Info): Unit =
+    def declareVectorType(b: String, n: String, tpe: Type, size: BigInt, info: Info): ArrayBuffer[Seq[Any]] =
       declareVectorType(b, n, tpe, size, info, None)
 
     // declare vector type with initial value
-    def declareVectorType(b: String, n: String, tpe: Type, size: BigInt, info: Info, preset: Expression): Unit = {
+    def declareVectorType(b: String, n: String, tpe: Type, size: BigInt, info: Info, preset: Expression): ArrayBuffer[Seq[Any]] = {
       declares += Seq(b, " ", tpe, " ", n, " [0:", bigIntToVLit(size - 1), "] = ", preset, ";", info)
     }
 
     val moduleTarget = CircuitTarget(circuitName).module(m.name)
 
     // declare with initial value
-    def declare(b: String, n: String, t: Type, info: Info, preset: Expression) = t match {
+    def declare(b: String, n: String, t: Type, info: Info, preset: Expression): ArrayBuffer[Seq[Any]] = t match {
       case tx: VectorType =>
         declareVectorType(b, n, tx.tpe, tx.size, info, preset)
       case tx =>
@@ -618,7 +618,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
     }
 
     // original declare without initial value and optinally with an ifdef guard
-    private def declare(b: String, n: String, t: Type, info: Info, ifdefOpt: Option[String]): Unit = t match {
+    private def declare(b: String, n: String, t: Type, info: Info, ifdefOpt: Option[String]): ArrayBuffer[Seq[Any]] = t match {
       case tx: VectorType =>
         declareVectorType(b, n, tx.tpe, tx.size, info, ifdefOpt)
       case tx =>
@@ -631,11 +631,11 @@ class VerilogEmitter extends SeqTransform with Emitter {
     }
 
     // original declare without initial value and with an ifdef guard
-    private def declare(b: String, n: String, t: Type, info: Info, ifdef: String): Unit =
+    private def declare(b: String, n: String, t: Type, info: Info, ifdef: String): ArrayBuffer[Seq[Any]] =
       declare(b, n, t, info, Some(ifdef))
 
     // original declare without initial value
-    def declare(b: String, n: String, t: Type, info: Info): Unit =
+    def declare(b: String, n: String, t: Type, info: Info): ArrayBuffer[Seq[Any]] =
       declare(b, n, t, info, None)
 
     def assign(e: Expression, value: Expression, info: Info): Unit = {


### PR DESCRIPTION
PR against https://github.com/freechipsproject/firrtl/pull/1553. I thought ArrayBuffer `+=` had `Unit` return type so I set the return types to `Unit` in the original PR. This PR sets the return type to `ArrayBuffer[Seq[Any]]` to preserve binary compatibility.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
reverts return type of `declare` methods from `Unit` back to `ArrayBuffer[Seq[Any]]`

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
none

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
