### PR TITLE
deprecating BackendCompilationUtilities trait for object

### DIFF
--- a/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
+++ b/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
@@ -13,7 +13,7 @@ import firrtl.FileUtils
 
 import scala.sys.process.{ProcessBuilder, ProcessLogger, _}
 
-trait BackendCompilationUtilities extends LazyLogging {
+object BackendCompilationUtilities extends LazyLogging {
   /** Parent directory for tests */
   lazy val TestDirectory = new File("test_run_dir")
 
@@ -102,7 +102,7 @@ trait BackendCompilationUtilities extends LazyLogging {
     * @param resourceFileName specifies what filename to look for to find a .f file
     * @param extraCmdLineArgs list of additional command line arguments
     */
-  def verilogToCppWithExtraCmdLineArgs(
+  def verilogToCpp(
     dutFile: String,
     dir: File,
     vSources: Seq[File],
@@ -161,18 +161,6 @@ trait BackendCompilationUtilities extends LazyLogging {
         "--exe", cppHarness.getAbsolutePath)
     logger.info(s"${command.mkString(" ")}") // scalastyle:ignore regex
     command
-  }
-
-  @deprecated("use verilogtoCppWithExtraCmdLineArgs","1.3")
-  def verilogToCpp(
-    dutFile: String,
-    dir: File,
-    vSources: Seq[File],
-    cppHarness: File,
-    suppressVcd: Boolean = false,
-    resourceFileName: String = firrtl.transforms.BlackBoxSourceHelper.defaultFileListName
-  ): ProcessBuilder = {
-    verilogToCppWithExtraCmdLineArgs(dutFile, dir, vSources, cppHarness, suppressVcd, resourceFileName)
   }
 
   def cppToExe(prefix: String, dir: File): ProcessBuilder =
@@ -258,5 +246,46 @@ trait BackendCompilationUtilities extends LazyLogging {
     val resultFileName = testDir.getAbsolutePath + "/yosys_results"
     val command = s"yosys -s $scriptFileName" #> new File(resultFileName)
     command.! != 0
+  }
+}
+
+@deprecated("use object BackendCompilationUtilities", "1.3")
+trait BackendCompilationUtilities extends LazyLogging {
+  lazy val TestDirectory = BackendCompilationUtilities.TestDirectory
+  def timeStamp: String = BackendCompilationUtilities.timeStamp
+  def loggingProcessLogger: ProcessLogger = BackendCompilationUtilities.loggingProcessLogger
+  def copyResourceToFile(name: String, file: File): Unit = BackendCompilationUtilities.copyResourceToFile(name, file)
+  def createTestDirectory(testName: String): File = BackendCompilationUtilities.createTestDirectory(testName)
+  def makeHarness(template: String => String, post: String)(f: File): File = BackendCompilationUtilities.makeHarness(template, post)(f)
+  def firrtlToVerilog(prefix: String, dir: File): ProcessBuilder = BackendCompilationUtilities.firrtlToVerilog(prefix, dir)
+  def verilogToCpp(
+                    dutFile: String,
+                    dir: File,
+                    vSources: Seq[File],
+                    cppHarness: File,
+                    suppressVcd: Boolean = false,
+                    resourceFileName: String = firrtl.transforms.BlackBoxSourceHelper.defaultFileListName
+                  ): ProcessBuilder = {
+    BackendCompilationUtilities.verilogToCpp(dutFile, dir, vSources, cppHarness, suppressVcd, resourceFileName)
+  }
+  def cppToExe(prefix: String, dir: File): ProcessBuilder = BackendCompilationUtilities.cppToExe(prefix, dir)
+  def executeExpectingFailure(
+                               prefix: String,
+                               dir: File,
+                               assertionMsg: String = ""): Boolean = {
+    BackendCompilationUtilities.executeExpectingFailure(prefix, dir, assertionMsg)
+  }
+  def executeExpectingSuccess(prefix: String, dir: File): Boolean = BackendCompilationUtilities.executeExpectingSuccess(prefix, dir)
+  def yosysExpectSuccess(customTop: String,
+                         referenceTop: String,
+                         testDir: File,
+                         resets: Seq[(Int, String, Int)] = Seq.empty): Boolean = {
+    BackendCompilationUtilities.yosysExpectSuccess(customTop, referenceTop, testDir, resets)
+  }
+  def yosysExpectFailure(customTop: String,
+                         referenceTop: String,
+                         testDir: File,
+                         resets: Seq[(Int, String, Int)] = Seq.empty): Boolean = {
+    BackendCompilationUtilities.yosysExpectFailure(customTop, referenceTop, testDir, resets)
   }
 }

--- a/src/test/scala/firrtlTests/VerilogEmitterTests.scala
+++ b/src/test/scala/firrtlTests/VerilogEmitterTests.scala
@@ -11,6 +11,7 @@ import firrtl.transforms.VerilogRename
 import firrtl.transforms.CombineCats
 import firrtl.testutils._
 import firrtl.testutils.FirrtlCheckers._
+import firrtl.util.BackendCompilationUtilities
 
 import scala.sys.process.{Process, ProcessLogger}
 
@@ -891,7 +892,7 @@ class EmittedMacroSpec extends FirrtlPropSpec {
       "+define+FIRRTL_AFTER_INITIAL=initial begin $fwrite(32'h80000002, \"printing from FIRRTL_AFTER_INITIAL macro\\n\"); end"
     )
 
-    verilogToCppWithExtraCmdLineArgs(prefix, testDir, List.empty, harness, extraCmdLineArgs = cmdLineArgs) #&&
+    BackendCompilationUtilities.verilogToCpp(prefix, testDir, List.empty, harness, extraCmdLineArgs = cmdLineArgs) #&&
       cppToExe(prefix, testDir) !
       loggingProcessLogger
 


### PR DESCRIPTION
This is to fix the backporting issue with #1572, which was caused by adding a method to the `BackendCompilationUtilities` trait.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method? **_N/A_**
- [ ] Did you update the FIRRTL spec to include every new feature/behavior? **_N/A_**
- [ ] Did you add at least one test demonstrating the PR? **_N/A_**
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [ ] Did you specify the code generation impact? **_N/A_**
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix _(backporting failure)_
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
- code cleanup
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
This PR deprecates the `BackendCompilationUtilities` trait for an object of the same name.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
None

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.)
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
The `BackendCompilationUtilities` trait is deprecated for an object of the same name.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
