### PR TITLE
backporting initialization macro PRs

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -1029,6 +1029,10 @@ class VerilogEmitter extends SeqTransform with Emitter {
         }
         emit(Seq("`endif"))
         emit(Seq("`ifndef SYNTHESIS"))
+        // User-defined macro of code to run before an initial block
+        emit(Seq("`ifdef FIRRTL_BEFORE_INITIAL"))
+        emit(Seq("`FIRRTL_BEFORE_INITIAL"))
+        emit(Seq("`endif"))
         emit(Seq("initial begin"))
         emit(Seq("  `ifdef RANDOMIZE"))
         emit(Seq("    `ifdef INIT_RANDOM"))
@@ -1054,6 +1058,10 @@ class VerilogEmitter extends SeqTransform with Emitter {
         for (x <- asyncInitials) emit(Seq(tab, x))
         emit(Seq("  `endif // RANDOMIZE"))
         emit(Seq("end // initial"))
+        // User-defined macro of code to run after an initial block
+        emit(Seq("`ifdef FIRRTL_AFTER_INITIAL"))
+        emit(Seq("`FIRRTL_AFTER_INITIAL"))
+        emit(Seq("`endif"))
         emit(Seq("`endif // SYNTHESIS"))
       }
 

--- a/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
+++ b/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
@@ -13,7 +13,7 @@ import firrtl.FileUtils
 
 import scala.sys.process.{ProcessBuilder, ProcessLogger, _}
 
-trait BackendCompilationUtilities extends LazyLogging {
+object BackendCompilationUtilities extends LazyLogging {
   /** Parent directory for tests */
   lazy val TestDirectory = new File("test_run_dir")
 
@@ -102,7 +102,7 @@ trait BackendCompilationUtilities extends LazyLogging {
     * @param resourceFileName specifies what filename to look for to find a .f file
     * @param extraCmdLineArgs list of additional command line arguments
     */
-  def verilogToCppWithExtraCmdLineArgs(
+  def verilogToCpp(
     dutFile: String,
     dir: File,
     vSources: Seq[File],
@@ -161,18 +161,6 @@ trait BackendCompilationUtilities extends LazyLogging {
         "--exe", cppHarness.getAbsolutePath)
     logger.info(s"${command.mkString(" ")}") // scalastyle:ignore regex
     command
-  }
-
-  @deprecated("use verilogtoCppWithExtraCmdLineArgs","1.3")
-  def verilogToCpp(
-    dutFile: String,
-    dir: File,
-    vSources: Seq[File],
-    cppHarness: File,
-    suppressVcd: Boolean = false,
-    resourceFileName: String = firrtl.transforms.BlackBoxSourceHelper.defaultFileListName
-  ): ProcessBuilder = {
-    verilogToCppWithExtraCmdLineArgs(dutFile, dir, vSources, cppHarness, suppressVcd, resourceFileName)
   }
 
   def cppToExe(prefix: String, dir: File): ProcessBuilder =
@@ -258,5 +246,46 @@ trait BackendCompilationUtilities extends LazyLogging {
     val resultFileName = testDir.getAbsolutePath + "/yosys_results"
     val command = s"yosys -s $scriptFileName" #> new File(resultFileName)
     command.! != 0
+  }
+}
+
+@deprecated("use object BackendCompilationUtilities", "1.3")
+trait BackendCompilationUtilities extends LazyLogging {
+  lazy val TestDirectory = BackendCompilationUtilities.TestDirectory
+  def timeStamp: String = BackendCompilationUtilities.timeStamp
+  def loggingProcessLogger: ProcessLogger = BackendCompilationUtilities.loggingProcessLogger
+  def copyResourceToFile(name: String, file: File): Unit = BackendCompilationUtilities.copyResourceToFile(name, file)
+  def createTestDirectory(testName: String): File = BackendCompilationUtilities.createTestDirectory(testName)
+  def makeHarness(template: String => String, post: String)(f: File): File = BackendCompilationUtilities.makeHarness(template, post)(f)
+  def firrtlToVerilog(prefix: String, dir: File): ProcessBuilder = BackendCompilationUtilities.firrtlToVerilog(prefix, dir)
+  def verilogToCpp(
+                    dutFile: String,
+                    dir: File,
+                    vSources: Seq[File],
+                    cppHarness: File,
+                    suppressVcd: Boolean = false,
+                    resourceFileName: String = firrtl.transforms.BlackBoxSourceHelper.defaultFileListName
+                  ): ProcessBuilder = {
+    BackendCompilationUtilities.verilogToCpp(dutFile, dir, vSources, cppHarness, suppressVcd, resourceFileName)
+  }
+  def cppToExe(prefix: String, dir: File): ProcessBuilder = BackendCompilationUtilities.cppToExe(prefix, dir)
+  def executeExpectingFailure(
+                               prefix: String,
+                               dir: File,
+                               assertionMsg: String = ""): Boolean = {
+    BackendCompilationUtilities.executeExpectingFailure(prefix, dir, assertionMsg)
+  }
+  def executeExpectingSuccess(prefix: String, dir: File): Boolean = BackendCompilationUtilities.executeExpectingSuccess(prefix, dir)
+  def yosysExpectSuccess(customTop: String,
+                         referenceTop: String,
+                         testDir: File,
+                         resets: Seq[(Int, String, Int)] = Seq.empty): Boolean = {
+    BackendCompilationUtilities.yosysExpectSuccess(customTop, referenceTop, testDir, resets)
+  }
+  def yosysExpectFailure(customTop: String,
+                         referenceTop: String,
+                         testDir: File,
+                         resets: Seq[(Int, String, Int)] = Seq.empty): Boolean = {
+    BackendCompilationUtilities.yosysExpectFailure(customTop, referenceTop, testDir, resets)
   }
 }

--- a/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
+++ b/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
@@ -100,14 +100,16 @@ trait BackendCompilationUtilities extends LazyLogging {
     * @param cppHarness C++ testharness to compile/link against
     * @param suppressVcd specifies if VCD tracing should be suppressed
     * @param resourceFileName specifies what filename to look for to find a .f file
+    * @param extraCmdLineArgs list of additional command line arguments
     */
-  def verilogToCpp(
+  def verilogToCppWithExtraCmdLineArgs(
     dutFile: String,
     dir: File,
     vSources: Seq[File],
     cppHarness: File,
     suppressVcd: Boolean = false,
-    resourceFileName: String = firrtl.transforms.BlackBoxSourceHelper.defaultFileListName
+    resourceFileName: String = firrtl.transforms.BlackBoxSourceHelper.defaultFileListName,
+    extraCmdLineArgs: Seq[String] = Seq.empty
   ): ProcessBuilder = {
 
     val topModule = dutFile
@@ -138,6 +140,7 @@ trait BackendCompilationUtilities extends LazyLogging {
       "verilator",
       "--cc", s"${dir.getAbsolutePath}/$dutFile.v"
     ) ++
+      extraCmdLineArgs ++
       blackBoxVerilogList ++
       vSourcesFiltered.flatMap(file => Seq("-v", file.getCanonicalPath)) ++
       Seq("--assert",
@@ -158,6 +161,18 @@ trait BackendCompilationUtilities extends LazyLogging {
         "--exe", cppHarness.getAbsolutePath)
     logger.info(s"${command.mkString(" ")}") // scalastyle:ignore regex
     command
+  }
+
+  @deprecated("use verilogtoCppWithExtraCmdLineArgs","1.3")
+  def verilogToCpp(
+    dutFile: String,
+    dir: File,
+    vSources: Seq[File],
+    cppHarness: File,
+    suppressVcd: Boolean = false,
+    resourceFileName: String = firrtl.transforms.BlackBoxSourceHelper.defaultFileListName
+  ): ProcessBuilder = {
+    verilogToCppWithExtraCmdLineArgs(dutFile, dir, vSources, cppHarness, suppressVcd, resourceFileName)
   }
 
   def cppToExe(prefix: String, dir: File): ProcessBuilder =

--- a/src/test/scala/firrtl/testutils/FirrtlSpec.scala
+++ b/src/test/scala/firrtl/testutils/FirrtlSpec.scala
@@ -254,7 +254,9 @@ object FirrtlCheckers extends FirrtlMatchers {
   /** Checks that the emitted circuit has the expected line, both will be normalized */
   def containLine(expectedLine: String) = containLines(expectedLine)
 
-  /** Checks that the emitted circuit has the expected lines in order, all lines will be normalized */
+  /** Checks that the emitted circuit contains the expected lines contiguously and in order;
+    * all lines will be normalized
+    */
   def containLines(expectedLines: String*) = new CircuitStateStringsMatcher(expectedLines)
 
   class CircuitStateStringsMatcher(expectedLines: Seq[String]) extends Matcher[CircuitState] {

--- a/src/test/scala/firrtlTests/VerilogEmitterTests.scala
+++ b/src/test/scala/firrtlTests/VerilogEmitterTests.scala
@@ -11,6 +11,7 @@ import firrtl.transforms.VerilogRename
 import firrtl.transforms.CombineCats
 import firrtl.testutils._
 import firrtl.testutils.FirrtlCheckers._
+import firrtl.util.BackendCompilationUtilities
 
 import scala.sys.process.{Process, ProcessLogger}
 
@@ -891,7 +892,7 @@ class EmittedMacroSpec extends FirrtlPropSpec {
       "+define+FIRRTL_AFTER_INITIAL=initial begin $fwrite(32'h80000002, \"printing from FIRRTL_AFTER_INITIAL macro\\n\"); end"
     )
 
-    verilogToCppWithExtraCmdLineArgs(prefix, testDir, List.empty, harness, extraCmdLineArgs = cmdLineArgs) #&&
+    BackendCompilationUtilities.verilogToCpp(prefix, testDir, List.empty, harness, extraCmdLineArgs = cmdLineArgs) #&&
       cppToExe(prefix, testDir) !
       loggingProcessLogger
 


### PR DESCRIPTION
Backports changes in #1550 and #1575.

#1550 was previously not backported due to a binary compatibility issue resolved in #1575.