### PR TITLE
Make benchmark_cold_compile.py work even if it can't fetch

### DIFF
--- a/benchmark/scripts/benchmark_cold_compile.py
+++ b/benchmark/scripts/benchmark_cold_compile.py
@@ -94,7 +94,8 @@ def parseargs():
 
 def get_version_hashes(versions):
     res = subprocess.run(['git', '-C', firrtl_repo, 'fetch'])
-    assert res.returncode == 0, '"{}" must be an existing repo!'.format(firrtl_repo)
+    if res.returncode != 0:
+        print("Warning, unable to git fetch in {}! May cause errors finding commits.".format(firrtl_repo))
     hashes = OrderedDict()
     for version in versions :
         res = subprocess.run(['git', '-C', firrtl_repo, 'rev-parse', '--short', version], stdout=subprocess.PIPE)


### PR DESCRIPTION
I've started using this script with batch infrastructure that can't fetch because it doesn't have my ssh-agent. If you've fetched before, it shouldn't matter if it fails.

Should this be backported? I don't really care.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
   - code cleanup                       

#### API Impact

None

#### Backend Code Generation Impact

None

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference. 

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
