### PR TITLE
Have AppendInfo use MultiInfo, rather than appending with :

### DIFF
--- a/src/main/scala/firrtl/Visitor.scala
+++ b/src/main/scala/firrtl/Visitor.scala
@@ -60,7 +60,7 @@ class Visitor(infoMode: InfoMode) extends AbstractParseTreeVisitor[FirrtlNode] w
 
   private def visitInfo(ctx: Option[InfoContext], parentCtx: ParserRuleContext): Info = {
     def genInfo(filename: String): String =
-      stripPath(filename) + "@" + parentCtx.getStart.getLine + "." +
+      stripPath(filename) + " " + parentCtx.getStart.getLine + "." +
         parentCtx.getStart.getCharPositionInLine
     lazy val useInfo: String = ctx match {
       case Some(info) => info.getText.drop(2).init // remove surrounding @[ ... ]
@@ -71,8 +71,9 @@ class Visitor(infoMode: InfoMode) extends AbstractParseTreeVisitor[FirrtlNode] w
         if (useInfo.length == 0) NoInfo
         else ir.FileInfo(ir.StringLit.unescape(useInfo))
       case AppendInfo(filename) =>
-        val newInfo = useInfo + ":" + genInfo(filename)
-        ir.FileInfo(ir.StringLit.unescape(newInfo))
+        val useFileInfo = ir.FileInfo(ir.StringLit.unescape(useInfo))
+        val newFileInfo = ir.FileInfo(ir.StringLit.unescape(genInfo(filename)))
+        ir.MultiInfo(useFileInfo, newFileInfo)
       case GenInfo(filename) =>
         ir.FileInfo(ir.StringLit.unescape(genInfo(filename)))
       case IgnoreInfo => NoInfo

--- a/src/main/scala/firrtl/Visitor.scala
+++ b/src/main/scala/firrtl/Visitor.scala
@@ -60,7 +60,7 @@ class Visitor(infoMode: InfoMode) extends AbstractParseTreeVisitor[FirrtlNode] w
 
   private def visitInfo(ctx: Option[InfoContext], parentCtx: ParserRuleContext): Info = {
     def genInfo(filename: String): String =
-      stripPath(filename) + " " + parentCtx.getStart.getLine + "." +
+      stripPath(filename) + " " + parentCtx.getStart.getLine + ":" +
         parentCtx.getStart.getCharPositionInLine
     lazy val useInfo: String = ctx match {
       case Some(info) => info.getText.drop(2).init // remove surrounding @[ ... ]
@@ -70,6 +70,8 @@ class Visitor(infoMode: InfoMode) extends AbstractParseTreeVisitor[FirrtlNode] w
       case UseInfo =>
         if (useInfo.length == 0) NoInfo
         else ir.FileInfo(ir.StringLit.unescape(useInfo))
+      case AppendInfo(filename) if (useInfo.length == 0) =>
+        ir.FileInfo(ir.StringLit.unescape(genInfo(filename)))
       case AppendInfo(filename) =>
         val useFileInfo = ir.FileInfo(ir.StringLit.unescape(useInfo))
         val newFileInfo = ir.FileInfo(ir.StringLit.unescape(genInfo(filename)))

--- a/src/test/scala/firrtlTests/InfoSpec.scala
+++ b/src/test/scala/firrtlTests/InfoSpec.scala
@@ -8,7 +8,7 @@ import firrtl.testutils._
 import FirrtlCheckers._
 import firrtl.Parser.AppendInfo
 
-class InfoSpec extends FirrtlFlatSpec {
+class InfoSpec extends FirrtlFlatSpec with FirrtlMatchers {
   def compile(input: String): CircuitState =
     (new VerilogCompiler).compileAndEmit(CircuitState(parse(input), ChirrtlForm), List.empty)
   def compileBody(body: String) = {
@@ -169,7 +169,8 @@ class InfoSpec extends FirrtlFlatSpec {
                   |    out <= in @[Top.scala 15:14]
                   |""".stripMargin
     val circuit = firrtl.Parser.parse(input.split("\n").toIterator, AppendInfo("myfile.fir"))
-    val result = circuit.serialize
-    result.split("\n") should contain ("    out <= in @[Top.scala 15:14 myfile.fir 6.4]")
+    val circuitState = CircuitState(circuit, UnknownForm)
+    val expectedInfos = Seq(FileInfo(StringLit("Top.scala 15:14")), FileInfo(StringLit("myfile.fir 6:4")))
+    circuitState should containTree { case MultiInfo(`expectedInfos`) => true }
   }
 }

--- a/src/test/scala/firrtlTests/InfoSpec.scala
+++ b/src/test/scala/firrtlTests/InfoSpec.scala
@@ -6,6 +6,7 @@ import firrtl._
 import firrtl.ir._
 import firrtl.testutils._
 import FirrtlCheckers._
+import firrtl.Parser.AppendInfo
 
 class InfoSpec extends FirrtlFlatSpec {
   def compile(input: String): CircuitState =
@@ -157,5 +158,18 @@ class InfoSpec extends FirrtlFlatSpec {
     val result = (new LowFirrtlCompiler).compileAndEmit(CircuitState(parse(input), ChirrtlForm), List.empty)
     result should containLine ("x <= _GEN_2 @[GCD.scala 17:22 GCD.scala 19:19]")
     result should containLine ("y <= _GEN_3 @[GCD.scala 18:22 GCD.scala 19:30]")
+  }
+
+  "source locators for append option" should "use multiinfo" in {
+    val input = """circuit Top :
+                  |  module Top :
+                  |    input clock : Clock
+                  |    input in: UInt<32>
+                  |    output out: UInt<32>
+                  |    out <= in @[Top.scala 15:14]
+                  |""".stripMargin
+    val circuit = firrtl.Parser.parse(input.split("\n").toIterator, AppendInfo("myfile.fir"))
+    val result = circuit.serialize
+    result.split("\n") should contain ("    out <= in @[Top.scala 15:14 myfile.fir 6.4]")
   }
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
- backend code generation

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
Very slight change that the `GenInfo` has different syntax:

`@[File.fir@1.1]` to `@[File.fir 1.1]`

Slight syntax change when using `AppendInfo` option:

`@[File.scala 1.1: File.fir@1.1]` to `@[File.scala 1.1 File.fir 1.1]`

#### Backend Code Generation Impact

Yes, the source info (emitted as a Verilog comment) will have slightly different syntax under the previously specified parser options.

#### Release Notes
Slight syntax change to source info generated from a FIRRTL file:

`@[File.fir@1.1]` to `@[File.fir 1.1]`

Slight syntax change to source info generated from both a FIRRTL file and Chisel file:

`@[File.scala 1.1: File.fir@1.1]` to `@[File.scala 1.1 File.fir 1.1]`

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
