### PR TITLE
Speed up CheckHighForm

### DIFF
--- a/src/main/scala/firrtl/passes/CheckHighForm.scala
+++ b/src/main/scala/firrtl/passes/CheckHighForm.scala
@@ -191,7 +191,6 @@ trait CheckHighFormLike { this: Pass =>
         case ex => ex foreach validSubexp(info, mname)
       }
       e foreach checkHighFormW(info, mname + "/" + e.serialize)
-      e foreach checkHighFormT(info, mname + "/" + e.serialize)
       e foreach checkHighFormE(info, mname, names)
     }
 

--- a/src/main/scala/firrtl/passes/CheckHighForm.scala
+++ b/src/main/scala/firrtl/passes/CheckHighForm.scala
@@ -151,14 +151,14 @@ trait CheckHighFormLike { this: Pass =>
       case _ => // Do Nothing
     }
 
-    def checkHighFormW(info: Info, mname: String)(w: Width): Unit = {
+    def checkHighFormW(info: Info, mname: => String)(w: Width): Unit = {
       w match {
         case wx: IntWidth if wx.width < 0 => errors.append(new NegWidthException(info, mname))
         case wx => // Do nothing
       }
     }
 
-    def checkHighFormT(info: Info, mname: String)(t: Type): Unit = {
+    def checkHighFormT(info: Info, mname: => String)(t: Type): Unit = {
       t foreach checkHighFormT(info, mname)
       t match {
         case tx: VectorType if tx.size < 0 =>


### PR DESCRIPTION
This fixes a subtle performance regression from https://github.com/freechipsproject/firrtl/pull/870 and then because it highlighted some unnecessary error checking I improved performance further.

I have manually checked that this does not violate binary compatibility when backported to `1.3.x`

### Improvement 1

https://github.com/freechipsproject/firrtl/pull/870 made the error reporting in `CheckHighForm` (and `CheckChirrtl`) more detailed for Expressions when it's a type or width error. This includes eagerly serializing every single `Expression` twice. I made the functions accepting the serialization take their arguments lazily which prevents the serialization unless it's an error. 6-characters for a huge performance win.

### Improvement 2

In debugging (1), I noticed that we are checking the types of all Expressions in `CheckHighForm` (and `CheckChirrtl`). Because `Expressions` are recursive, this is `O(2^d*n)` where `d` is the depth of aggregate types and `n` is the number of types. 

There are no `Expressions` that have user-specified `Types`--all `Expression` types are derived from `Statement` declarations. The only errors found on `Types` here are negative Vec sizes and negative widths. Because such errors will be caught on the `Statement`s upstream, and errors for derived values in `Expressions` aren't useful anyway, I solve this issue by just turning off checking of `Types`. I'm pretty sure this is correct but would appreciate a second opinion

### Benchmark results

I have some benchmarking infrastructure I've been working on (see https://github.com/freechipsproject/firrtl/pull/1475 although I'm migrating to JMH). I haven't finished #1475 because it's really hard to measure the small improvements that those changes give, but using the same approach these improvements are obvious:

For a medium-sized design benchmarking `CheckHighForm`:
| commit | runtime (ms) | error (ms) |
| --- | --- | --- |
| master | 941 | 103 |
| Improvement 1 | 296 | 24 |
| Both improvements | 169 | 21 |

From a 4-7x speedup

**EDIT**: For a larger design, unsurprisingly improvements are larger:

| commit | runtime (ms) | error (ms) |
| --- | --- | --- |
| master | 18092 | 1804 |
| Improvement 1 | 14476 | 1090 |
| Both improvements | 1011 | 77 |

~15-20x speedup

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
   - performance improvement      


#### API Impact

No effect

#### Backend Code Generation Impact

No effect

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->

  - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. 

#### Release Notes
Fix performance regression in CheckChirrtl and CheckHighForm in `1.3.0` and improve performance further.

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
