### PR TITLE
[Mergify] Restore backporting to 1.2.x

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -35,19 +35,48 @@ pull_request_rules:
       label:
         add: [Backported]
 
+  - name: backport to 1.2.x and 1.3.x
+    conditions:
+      - merged
+      - base=master
+      - milestone=1.2.X
+    actions:
+      backport:
+        branches:
+          - 1.2.x
+          - 1.3.x
+        ignore_conflicts: True
+        label_conflicts: "bp-conflict"
+      label:
+        add: [Backported]
+
+
   - name: label Mergify backport PR
     conditions:
-      - base=1.3.x
       - body~=This is an automated backport of pull request \#\d+ done by Mergify
     actions:
       label:
         add: [Backport]
 
-  - name: automatic squash-and-merge of backport PRs
+  - name: automatic squash-and-merge of 1.3.x backport PRs
     conditions:
       - status-success=continuous-integration/travis-ci/pr
       - "#changes-requested-reviews-by=0"
       - base=1.3.x
+      - label="Backport"
+      - label!="DO NOT MERGE"
+      - label!="bp-conflict"
+    actions:
+      merge:
+        method: squash
+        strict: smart
+        strict_method: merge
+
+  - name: automatic squash-and-merge of 1.2.x backport PRs
+    conditions:
+      - status-success=continuous-integration/travis-ci/pr
+      - "#changes-requested-reviews-by=0"
+      - base=1.2.x
       - label="Backport"
       - label!="DO NOT MERGE"
       - label!="bp-conflict"


### PR DESCRIPTION
Labeling a PR with Milestone 1.2.X now will tell Mergify to backport it
to both 1.2.x and 1.3.x.

Note that duplication is necessary, Mergify does not directly support OR conditions: https://doc.mergify.io/conditions.html#impementing-or-conditions

I did make the labeling rule more generic by just having it not care about the base branch, we could technically do the same for backport PR merging, but I thought it might be better to have more safety on actual merging.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
  - new feature/API    

#### API Impact

No API impact, just improved automation

#### Backend Code Generation Impact

None

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
   - Squash: The PR will be squashed and merged 

#### Release Notes

NA

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
