### PR TITLE
Speed up InferTypes and CInferTypes

### DIFF
--- a/src/main/scala/firrtl/passes/InferTypes.scala
+++ b/src/main/scala/firrtl/passes/InferTypes.scala
@@ -12,7 +12,10 @@ object InferTypes extends Pass with PreservesAll[Transform] {
 
   override def prerequisites = Dependency(ResolveKinds) +: firrtl.stage.Forms.WorkingIR
 
+  @deprecated("This should never have been public", "1.3.2")
   type TypeMap = collection.mutable.LinkedHashMap[String, Type]
+
+  private type TypeLookup = collection.mutable.HashMap[String, Type]
 
   def run(c: Circuit): Circuit = {
     val namespace = Namespace()
@@ -36,7 +39,7 @@ object InferTypes extends Pass with PreservesAll[Transform] {
       }
     }
 
-    def infer_types_e(types: TypeMap)(e: Expression): Expression =
+    def infer_types_e(types: TypeLookup)(e: Expression): Expression =
       e map infer_types_e(types) match {
         case e: WRef => e copy (tpe = types(e.name))
         case e: WSubField => e copy (tpe = field_type(e.expr.tpe, e.name))
@@ -48,7 +51,7 @@ object InferTypes extends Pass with PreservesAll[Transform] {
         case e @ (_: UIntLiteral | _: SIntLiteral) => e
       }
 
-    def infer_types_s(types: TypeMap)(s: Statement): Statement = s match {
+    def infer_types_s(types: TypeLookup)(s: Statement): Statement = s match {
       case sx: WDefInstance =>
         val t = mtypes(sx.module)
         types(sx.name) = t
@@ -73,14 +76,14 @@ object InferTypes extends Pass with PreservesAll[Transform] {
       case sx => sx map infer_types_s(types) map infer_types_e(types)
     }
 
-    def infer_types_p(types: TypeMap)(p: Port): Port = {
+    def infer_types_p(types: TypeLookup)(p: Port): Port = {
       val t = remove_unknowns(p.tpe)
       types(p.name) = t
       p copy (tpe = t)
     }
 
     def infer_types(m: DefModule): DefModule = {
-      val types = new TypeMap
+      val types = new TypeLookup
       m map infer_types_p(types) map infer_types_s(types)
     }
 
@@ -92,12 +95,15 @@ object CInferTypes extends Pass with PreservesAll[Transform] {
 
   override def prerequisites = firrtl.stage.Forms.ChirrtlForm
 
+  @deprecated("This should never have been public", "1.3.2")
   type TypeMap = collection.mutable.LinkedHashMap[String, Type]
+
+  private type TypeLookup = collection.mutable.HashMap[String, Type]
 
   def run(c: Circuit): Circuit = {
     val mtypes = (c.modules map (m => m.name -> module_type(m))).toMap
 
-    def infer_types_e(types: TypeMap)(e: Expression) : Expression =
+    def infer_types_e(types: TypeLookup)(e: Expression) : Expression =
       e map infer_types_e(types) match {
          case (e: Reference) => e copy (tpe = types.getOrElse(e.name, UnknownType))
          case (e: SubField) => e copy (tpe = field_type(e.expr.tpe, e.name))
@@ -109,7 +115,7 @@ object CInferTypes extends Pass with PreservesAll[Transform] {
          case e @ (_: UIntLiteral | _: SIntLiteral) => e
       }
 
-    def infer_types_s(types: TypeMap)(s: Statement): Statement = s match {
+    def infer_types_s(types: TypeLookup)(s: Statement): Statement = s match {
       case sx: DefRegister =>
         types(sx.name) = sx.tpe
         sx map infer_types_e(types)
@@ -136,13 +142,13 @@ object CInferTypes extends Pass with PreservesAll[Transform] {
       case sx => sx map infer_types_s(types) map infer_types_e(types)
     }
 
-    def infer_types_p(types: TypeMap)(p: Port): Port = {
+    def infer_types_p(types: TypeLookup)(p: Port): Port = {
       types(p.name) = p.tpe
       p
     }
 
     def infer_types(m: DefModule): DefModule = {
-      val types = new TypeMap
+      val types = new TypeLookup
       m map infer_types_p(types) map infer_types_s(types)
     }
 

--- a/src/main/scala/firrtl/passes/InferTypes.scala
+++ b/src/main/scala/firrtl/passes/InferTypes.scala
@@ -64,7 +64,7 @@ object InferTypes extends Pass with PreservesAll[Transform] {
         val sxx = (sx map infer_types_e(types)).asInstanceOf[DefNode]
         val t = remove_unknowns(sxx.value.tpe)
         types(sx.name) = t
-        sxx map infer_types_e(types)
+        sxx
       case sx: DefRegister =>
         val t = remove_unknowns(sx.tpe)
         types(sx.name) = t


### PR DESCRIPTION
A couple of minor improvements to performance of InferTypes and CInferTypes.

I've marked this for backporting but I did the deprecation warnings assuming it won't be included in the 1.3.1 release tomorrow.

The reason the traversal was redundant in `DefNode` was that it already mapped on its expression to get the type of the node itself. Due to declaration before use requirements, the node itself cannot be used in it's RHS.

## Benchmarks results

In a normal compilation of FIRRTL, InferTypes is run 6 times and CInferTypes is run once.

### Full compiler run

| Design | Before Runtime (s) | After Runtime (s) | Speedup |
| ---- | ---- | ---- | ----- |
| small | 47.10 ± 0.75 | 45.23 ± 0.33 | 4 % |
| medium | 117.8 ± 0.45 | 108.35 ± 2.5 | 8 % |
| large | 384.9 ± 30.7 | 380.64 ± 8.0 | uncertainty too high |

### JMH Results of LowerTypes

| Design | Before (ms) | After (ms) | Speedup |
| ---- | ---- | ---- | ---- |
| small | 283 ± 9.1 | 178 ± 12.8 | 37 % |
| medium | 698 ± 82.5 | 506 ± 23.6 | 28 % |
| large | 1715 ± 250 |  1290 ± 109 | 25% |

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->

  - performance improvement


#### API Impact

Deprecates type aliases in `InferTypes` and `CInferTypes`

#### Backend Code Generation Impact

None

#### Desired Merge Strategy

 - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. 

#### Release Notes

Improve performance of InferTypes and CInferTypes

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
