### PR TITLE
Speed up Deduplication

### DIFF
--- a/src/main/scala/firrtl/transforms/Dedup.scala
+++ b/src/main/scala/firrtl/transforms/Dedup.scala
@@ -74,7 +74,11 @@ class DedupModules extends Transform with DependencyAPIMigration with PreservesA
     val dedupMap = DedupModules.deduplicate(c, noDedups.toSet, annos, renameMap)
 
     // Use old module list to preserve ordering
-    val dedupedModules = c.modules.map(m => dedupMap(m.name)).distinct
+    // Lookup what a module deduped to, if its a duplicate, remove it
+    val dedupedModules = c.modules.flatMap { m =>
+      val mx = dedupMap(m.name)
+      if (mx.name == m.name) Some(mx) else None
+    }
 
     val cname = CircuitName(c.main)
     val map = dedupMap.map { case (from, to) =>


### PR DESCRIPTION
Dedup was accidentally hashing every module in the design twice. For large designs this is _very_ expensive.

I am running benchmarks overnight 🤞 but from my Flamegraph for a very large design, these two changes account for 50% of the runtime of Dedup which is the most expensive transform.

It will probably be less impactful for most designs.

## Benchmark Results

Unfortunately, the results are much more modest than I had hoped for normal, single-tile designs. The design from the Flamegraph was a large multi-core design, I suspect I should check more multi-core configs.

### Full compiler run

| Design | Before Runtime (s) | After Runtime (s) | Speedup |
| ---- | ---- | ---- | ----- |
| small | 48.8 ± 1.5 | 48.0 ± 0.9 | 1.7 % |
| medium | 122.0 ± 1.0 | 119.7 ± 1.9 | 1.9% |
| large | 395.7 ± 13.6 | 371.2 ± 21.2 | 6.6% (high uncertainty) |

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement


 - performance improvement


#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy


 - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. 

#### Release Notes

Improve performance of Deduplication

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
