### PR TITLE
consolidated wire+assign to just wire, with expression inlined (bp #1600 to 1.2.x)

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -746,8 +746,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
           regUpdate(e, sx.clock, sx.reset, sx.init)
           initialize(e, sx.reset, sx.init)
         case sx: DefNode =>
-          declare("wire", sx.name, sx.value.tpe, sx.info)
-          assign(WRef(sx.name, sx.value.tpe, NodeKind, SourceFlow), sx.value, sx.info)
+          declare("wire", sx.name, sx.value.tpe, sx.info, sx.value)
         case sx: Stop =>
           simulate(sx.clk, sx.en, stop(sx.ret), Some("STOP_COND"), sx.info)
         case sx: Print =>

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -519,6 +519,10 @@ class VerilogEmitter extends SeqTransform with Emitter {
       declares += Seq(b, " ", tpe, " ", n, " [0:", bigIntToVLit(size - 1), "];", info)
     }
 
+    private def declareAssign(b: String, n: String, t: Type, info: Info, rhs: Expression) = {
+      declares += Seq(b, " ", t, " ", n, " = ", rhs, ";", info)
+    }
+
     def declare(b: String, n: String, t: Type, info: Info) = t match {
       case tx: VectorType =>
         declareVectorType(b, n, tx.tpe, tx.size, info)
@@ -746,7 +750,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
           regUpdate(e, sx.clock, sx.reset, sx.init)
           initialize(e, sx.reset, sx.init)
         case sx: DefNode =>
-          declare("wire", sx.name, sx.value.tpe, sx.info, sx.value)
+          declareAssign("wire", sx.name, sx.value.tpe, sx.info, sx.value)
         case sx: Stop =>
           simulate(sx.clk, sx.en, stop(sx.ret), Some("STOP_COND"), sx.info)
         case sx: Print =>

--- a/src/test/scala/firrtlTests/CompilerTests.scala
+++ b/src/test/scala/firrtlTests/CompilerTests.scala
@@ -175,10 +175,8 @@ class MinimumVerilogCompilerSpec extends CompilerSpec with Matchers {
                  |  input  [2:0] i,
                  |  output [4:0] o
                  |);
-                 |  wire  c;
-                 |  wire  d;
-                 |  assign c = 1'h1;
-                 |  assign d = 1'h1;
+                 |  wire  c = 1'h1;
+                 |  wire  d = 1'h1;
                  |  assign b_0 = 1'h0;
                  |  assign b_1 = c;
                  |  assign b_2 = d;

--- a/src/test/scala/firrtlTests/DCETests.scala
+++ b/src/test/scala/firrtlTests/DCETests.scala
@@ -478,7 +478,7 @@ class DCECommandLineSpec extends FirrtlFlatSpec {
   "Dead Code Elimination" should "run by default" in {
     firrtl.Driver.execute(args) match {
       case FirrtlExecutionSuccess(_, verilog) =>
-        verilog should not include regex ("wire +a;")
+        verilog should not include regex ("wire +a")
       case _ => fail("Unexpected compilation failure")
     }
   }
@@ -486,7 +486,7 @@ class DCECommandLineSpec extends FirrtlFlatSpec {
   it should "not run when given --no-dce option" in {
     firrtl.Driver.execute(args :+ "--no-dce") match {
       case FirrtlExecutionSuccess(_, verilog) =>
-        verilog should include regex ("wire +a;")
+        verilog should include regex ("wire +a")
       case _ => fail("Unexpected compilation failure")
     }
   }

--- a/src/test/scala/firrtlTests/InfoSpec.scala
+++ b/src/test/scala/firrtlTests/InfoSpec.scala
@@ -60,10 +60,9 @@ class InfoSpec extends FirrtlFlatSpec {
     result should containTree { case DefRegister(Info1, "r", _,_,_,_) => true }
     result should containLine (s"reg [7:0] r; //$Info1")
     result should containTree { case DefNode(Info2, "w", _) => true }
-    result should containLine (s"wire [7:0] w; //$Info2") // Node "w" declaration in Verilog
+    result should containLine (s"wire [7:0] w = x & r; //$Info2") // Node "w" declaration in Verilog
     result should containTree { case DefNode(Info3, "n", _) => true }
-    result should containLine (s"wire [7:0] n; //$Info3")
-    result should containLine (s"assign n = w | x; //$Info3")
+    result should containLine (s"wire [7:0] n = w | x; //$Info3")
   }
 
   they should "be propagated on memories" in {

--- a/src/test/scala/firrtlTests/ReplaceTruncatingArithmeticSpec.scala
+++ b/src/test/scala/firrtlTests/ReplaceTruncatingArithmeticSpec.scala
@@ -53,7 +53,7 @@ class ReplaceTruncatingArithmeticSpec extends FirrtlFlatSpec {
       |node n = sub(x, y)
       |z <= tail(n, 2)""".stripMargin
     )
-    result should containLine (s"assign n = x - y;")
+    result should containLine (s"wire [8:0] n = x - y;")
     result should containLine (s"assign z = n[6:0];")
   }
 

--- a/src/test/scala/firrtlTests/VerilogEmitterTests.scala
+++ b/src/test/scala/firrtlTests/VerilogEmitterTests.scala
@@ -196,9 +196,8 @@ class DoPrimVerilog extends FirrtlFlatSpec {
         |  input  [7:0] in, 
         |  output  out 
         |);
-        |  wire [7:0] _GEN_0;
+        |  wire [7:0] _GEN_0 = in % 8'h1;
         |  assign out = _GEN_0[0];
-        |  assign _GEN_0 = in % 8'h1;
         |endmodule
         |""".stripMargin.split("\n") map normalized
     executeTest(input, check, compiler)
@@ -223,9 +222,8 @@ class DoPrimVerilog extends FirrtlFlatSpec {
         |  input  [3:0] in4,
         |  output [9:0] out
         |);
-        |  wire [5:0] _GEN_1;
+        |  wire [5:0] _GEN_1 = {in3,in2,in1};
         |  assign out = {in4,_GEN_1};
-        |  assign _GEN_1 = {in3,in2,in1};
         |endmodule
         |""".stripMargin.split("\n") map normalized
 
@@ -706,7 +704,7 @@ class VerilogEmitterSpec extends FirrtlFlatSpec {
         |""".stripMargin
     )
     result shouldNot containLine("assign z = $signed(x) + -2'sh2;")
-    result should    containLine("assign _GEN_0 = $signed(x) - 3'sh2;")
+    result should    containLine("wire [2:0] _GEN_0 = $signed(x) - 3'sh2;")
     result should    containLine("assign z = _GEN_0[1:0];")
   }
 }
@@ -765,13 +763,13 @@ class VerilogDescriptionEmitterSpec extends FirrtlFlatSpec {
       """  /* multi
         |   * line
         |   */
-        |  wire  d;""".stripMargin,
+        |  wire  d = """.stripMargin,
       """  /* multi
         |   * line
         |   */
         |  reg  e;""".stripMargin,
       """  // single line
-        |  wire  f;""".stripMargin
+        |  wire  f = """.stripMargin
     )
     // We don't use executeTest because we care about the spacing in the result
     val modName = ModuleName("Test", CircuitName("Test"))
@@ -850,7 +848,7 @@ class VerilogDescriptionEmitterSpec extends FirrtlFlatSpec {
         |   *
         |   * line6
         |   */
-        |  wire  d;""".stripMargin
+        |  wire  d = """.stripMargin
     )
     // We don't use executeTest because we care about the spacing in the result
     val modName = ModuleName("Test", CircuitName("Test"))

--- a/src/test/scala/firrtlTests/transforms/LegalizeClocks.scala
+++ b/src/test/scala/firrtlTests/transforms/LegalizeClocks.scala
@@ -57,10 +57,10 @@ class LegalizeClocksTransformSpec extends FirrtlFlatSpec {
         |    stop(asClock(UInt(1)), UInt(1), 1)
         |""".stripMargin
     val result = compile(input)
-    result should containLine (s"wire _GEN_0;")
+    result should containLine (s"wire  _GEN_0 = 1'h1;")
     // Check that there's only 1 _GEN_0 instantiation
     val verilog = result.getEmittedCircuit.value
-    val matches = "wire\\s+_GEN_0;".r.findAllIn(verilog)
+    val matches = "wire\\s+_GEN_0\\s+=\\s+1'h1".r.findAllIn(verilog)
     matches.size should be (1)
 
   }


### PR DESCRIPTION
Backport of #1600 to 1.2.x. Changed a method to a 1.2-friendly version (added as private).