### PR TITLE
moving initializations to end of module

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -999,6 +999,20 @@ class VerilogEmitter extends SeqTransform with Emitter {
         for (x <- attachAliases) emit(Seq(tab, x))
         emit(Seq("`endif"))
       }
+
+      for ((clk, content) <- noResetAlwaysBlocks if content.nonEmpty) {
+        emit(Seq(tab, "always @(posedge ", clk, ") begin"))
+        for (line <- content) emit(Seq(tab, tab, line))
+        emit(Seq(tab, "end"))
+      }
+
+      for ((clk, reset, content) <- asyncResetAlwaysBlocks if content.nonEmpty) {
+        emit(Seq(tab, "always @(posedge ", clk, " or posedge ", reset, ") begin"))
+        for (line <- content) emit(Seq(tab, tab, line))
+        emit(Seq(tab, "end"))
+      }
+
+      emit(Seq("// Register and memory initialization"))
       if (initials.nonEmpty || ifdefInitials.nonEmpty) {
         emit(Seq("`ifdef RANDOMIZE_GARBAGE_ASSIGN"))
         emit(Seq("`define RANDOMIZE"))
@@ -1064,17 +1078,6 @@ class VerilogEmitter extends SeqTransform with Emitter {
         emit(Seq("`endif // SYNTHESIS"))
       }
 
-      for ((clk, content) <- noResetAlwaysBlocks if content.nonEmpty) {
-        emit(Seq(tab, "always @(posedge ", clk, ") begin"))
-        for (line <- content) emit(Seq(tab, tab, line))
-        emit(Seq(tab, "end"))
-      }
-
-      for ((clk, reset, content) <- asyncResetAlwaysBlocks if content.nonEmpty) {
-        emit(Seq(tab, "always @(posedge ", clk, " or posedge ", reset, ") begin"))
-        for (line <- content) emit(Seq(tab, tab, line))
-        emit(Seq(tab, "end"))
-      }
       emit(Seq("endmodule"))
     }
 

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -1012,8 +1012,8 @@ class VerilogEmitter extends SeqTransform with Emitter {
         emit(Seq(tab, "end"))
       }
 
-      emit(Seq("// Register and memory initialization"))
       if (initials.nonEmpty || ifdefInitials.nonEmpty) {
+        emit(Seq("// Register and memory initialization"))
         emit(Seq("`ifdef RANDOMIZE_GARBAGE_ASSIGN"))
         emit(Seq("`define RANDOMIZE"))
         emit(Seq("`endif"))


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method? **_N/A_**
- [ ] Did you update the FIRRTL spec to include every new feature/behavior? **_N/A_**
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change? **_N/A_**

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
- code refactoring
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
No API impact.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

Initialization code for registers/memory will be emitted at the end of modules for better readability.

For comparison, this is the **original** `ZeroWithMem.v` generated from `firrtlTests/MemSpec.scala`:
```verilog
module ZeroWidthMem(
  input        clock,
  input        reset,
  input  [3:0] waddr,
  input  [9:0] in_0,
  input  [3:0] raddr,
  output [9:0] out_0
);
`ifdef RANDOMIZE_MEM_INIT
  reg [31:0] _RAND_0;
`endif // RANDOMIZE_MEM_INIT
  reg [9:0] ram_0 [0:15];
  wire [9:0] ram_0_ramout_data;
  wire [3:0] ram_0_ramout_addr;
  wire [9:0] ram_0_ramin_data;
  wire [3:0] ram_0_ramin_addr;
  wire  ram_0_ramin_mask;
  wire  ram_0_ramin_en;
  assign ram_0_ramout_addr = raddr;
  assign ram_0_ramout_data = ram_0[ram_0_ramout_addr];
  assign ram_0_ramin_data = in_0;
  assign ram_0_ramin_addr = waddr;
  assign ram_0_ramin_mask = 1'h1;
  assign ram_0_ramin_en = 1'h1;
  assign out_0 = ram_0_ramout_data;
`ifdef RANDOMIZE_GARBAGE_ASSIGN
`define RANDOMIZE
`endif
`ifdef RANDOMIZE_INVALID_ASSIGN
`define RANDOMIZE
`endif
`ifdef RANDOMIZE_REG_INIT
`define RANDOMIZE
`endif
`ifdef RANDOMIZE_MEM_INIT
`define RANDOMIZE
`endif
`ifndef RANDOM
`define RANDOM $random
`endif
`ifdef RANDOMIZE_MEM_INIT
  integer initvar;
`endif
`ifndef SYNTHESIS
`ifdef FIRRTL_BEFORE_INITIAL
`FIRRTL_BEFORE_INITIAL
`endif
initial begin
  `ifdef RANDOMIZE
    `ifdef INIT_RANDOM
      `INIT_RANDOM
    `endif
    `ifndef VERILATOR
      `ifdef RANDOMIZE_DELAY
        #`RANDOMIZE_DELAY begin end
      `else
        #0.002 begin end
      `endif
    `endif
`ifdef RANDOMIZE_MEM_INIT
  _RAND_0 = {1{`RANDOM}};
  for (initvar = 0; initvar < 16; initvar = initvar+1)
    ram_0[initvar] = _RAND_0[9:0];
`endif // RANDOMIZE_MEM_INIT
  `endif // RANDOMIZE
end // initial
`ifdef FIRRTL_AFTER_INITIAL
`FIRRTL_AFTER_INITIAL
`endif
`endif // SYNTHESIS
  always @(posedge clock) begin
    if(ram_0_ramin_en & ram_0_ramin_mask) begin
      ram_0[ram_0_ramin_addr] <= ram_0_ramin_data;
    end
    `ifndef SYNTHESIS
    `ifdef STOP_COND
      if (`STOP_COND) begin
    `endif
        if (~reset) begin
          $finish;
        end
    `ifdef STOP_COND
      end
    `endif
    `endif // SYNTHESIS
  end
endmodule
```

In the **new** generated code, the initializations are moved to the end of the module:
```verilog
module ZeroWidthMem(
  input        clock,
  input        reset,
  input  [3:0] waddr,
  input  [9:0] in_0,
  input  [3:0] raddr,
  output [9:0] out_0
);
  reg [9:0] ram_0 [0:15];
  wire [9:0] ram_0_ramout_data;
  wire [3:0] ram_0_ramout_addr;
  wire [9:0] ram_0_ramin_data;
  wire [3:0] ram_0_ramin_addr;
  wire  ram_0_ramin_mask;
  wire  ram_0_ramin_en;
  assign ram_0_ramout_addr = raddr;
  assign ram_0_ramout_data = ram_0[ram_0_ramout_addr];
  assign ram_0_ramin_data = in_0;
  assign ram_0_ramin_addr = waddr;
  assign ram_0_ramin_mask = 1'h1;
  assign ram_0_ramin_en = 1'h1;
  assign out_0 = ram_0_ramout_data;
  always @(posedge clock) begin
    if(ram_0_ramin_en & ram_0_ramin_mask) begin
      ram_0[ram_0_ramin_addr] <= ram_0_ramin_data;
    end
    `ifndef SYNTHESIS
    `ifdef STOP_COND
      if (`STOP_COND) begin
    `endif
        if (~reset) begin
          $finish;
        end
    `ifdef STOP_COND
      end
    `endif
    `endif // SYNTHESIS
  end
// Register and memory initialization
`ifdef RANDOMIZE_MEM_INIT
  reg [31:0] _RAND_0;
`endif // RANDOMIZE_MEM_INIT
`ifdef RANDOMIZE_GARBAGE_ASSIGN
`define RANDOMIZE
`endif
`ifdef RANDOMIZE_INVALID_ASSIGN
`define RANDOMIZE
`endif
`ifdef RANDOMIZE_REG_INIT
`define RANDOMIZE
`endif
`ifdef RANDOMIZE_MEM_INIT
`define RANDOMIZE
`endif
`ifndef RANDOM
`define RANDOM $random
`endif
`ifdef RANDOMIZE_MEM_INIT
  integer initvar;
`endif
`ifndef SYNTHESIS
`ifdef FIRRTL_BEFORE_INITIAL
`FIRRTL_BEFORE_INITIAL
`endif
initial begin
  `ifdef RANDOMIZE
    `ifdef INIT_RANDOM
      `INIT_RANDOM
    `endif
    `ifndef VERILATOR
      `ifdef RANDOMIZE_DELAY
        #`RANDOMIZE_DELAY begin end
      `else
        #0.002 begin end
      `endif
    `endif
`ifdef RANDOMIZE_MEM_INIT
  _RAND_0 = {1{`RANDOM}};
  for (initvar = 0; initvar < 16; initvar = initvar+1)
    ram_0[initvar] = _RAND_0[9:0];
`endif // RANDOMIZE_MEM_INIT
  `endif // RANDOMIZE
end // initial
`ifdef FIRRTL_AFTER_INITIAL
`FIRRTL_AFTER_INITIAL
`endif
`endif // SYNTHESIS
endmodule

```

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
