### PR TITLE
Backport ResolveKinds improvements from #1475 to 1.2.x

### DIFF
--- a/src/main/scala/firrtl/passes/ResolveKinds.scala
+++ b/src/main/scala/firrtl/passes/ResolveKinds.scala
@@ -7,6 +7,41 @@ import firrtl.ir._
 import firrtl.Mappers._
 
 object ResolveKinds extends Pass {
+  private def find_port(kinds: collection.mutable.HashMap[String, Kind])(p: Port): Port = {
+    kinds(p.name) = PortKind ; p
+  }
+
+  def find_stmt(kinds: collection.mutable.HashMap[String, Kind])(s: Statement):Statement = {
+    s match {
+      case sx: DefWire => kinds(sx.name) = WireKind
+      case sx: DefNode => kinds(sx.name) = NodeKind
+      case sx: DefRegister => kinds(sx.name) = RegKind
+      case sx: WDefInstance => kinds(sx.name) = InstanceKind
+      case sx: DefMemory => kinds(sx.name) = MemKind
+      case _ =>
+    }
+    s map find_stmt(kinds)
+  }
+
+  def resolve_expr(kinds: collection.mutable.HashMap[String, Kind])(e: Expression): Expression = e match {
+    case ex: WRef => ex copy (kind = kinds(ex.name))
+    case _ => e map resolve_expr(kinds)
+  }
+
+  def resolve_stmt(kinds: collection.mutable.HashMap[String, Kind])(s: Statement): Statement =
+    s map resolve_stmt(kinds) map resolve_expr(kinds)
+
+
+  def resolve_kinds(m: DefModule): DefModule = {
+    val kinds = new collection.mutable.HashMap[String, Kind]
+    (m map find_port(kinds)
+       map find_stmt(kinds)
+       map resolve_stmt(kinds))
+  }
+
+  def run(c: Circuit): Circuit =
+    c copy (modules = c.modules map resolve_kinds)
+
   type KindMap = collection.mutable.LinkedHashMap[String, Kind]
 
   def find_port(kinds: KindMap)(p: Port): Port = {
@@ -32,14 +67,4 @@ object ResolveKinds extends Pass {
 
   def resolve_stmt(kinds: KindMap)(s: Statement): Statement =
     s map resolve_stmt(kinds) map resolve_expr(kinds)
-
-  def resolve_kinds(m: DefModule): DefModule = {
-    val kinds = new KindMap
-    (m map find_port(kinds)
-       map find_stmt(kinds)
-       map resolve_stmt(kinds))
-  }
-
-  def run(c: Circuit): Circuit =
-    c copy (modules = c.modules map resolve_kinds)
 }

--- a/src/main/scala/firrtl/passes/ResolveKinds.scala
+++ b/src/main/scala/firrtl/passes/ResolveKinds.scala
@@ -5,10 +5,13 @@ package firrtl.passes
 import firrtl._
 import firrtl.ir._
 import firrtl.Mappers._
+import firrtl.traversals.Foreachers._
+import firrtl.options.PreservesAll
 
 object ResolveKinds extends Pass {
-  private def find_port(kinds: collection.mutable.HashMap[String, Kind])(p: Port): Port = {
-    kinds(p.name) = PortKind ; p
+
+  private def find_port(kinds: collection.mutable.HashMap[String, Kind])(p: Port): Unit = {
+    kinds(p.name) = PortKind
   }
 
   def resolve_expr(kinds: collection.mutable.HashMap[String, Kind])(e: Expression): Expression = e match {
@@ -31,7 +34,7 @@ object ResolveKinds extends Pass {
 
   def resolve_kinds(m: DefModule): DefModule = {
     val kinds = new collection.mutable.HashMap[String, Kind]
-    m.map(find_port(kinds))
+    m.foreach(find_port(kinds))
     m.map(resolve_stmt(kinds))
   }
 

--- a/src/main/scala/firrtl/passes/ResolveKinds.scala
+++ b/src/main/scala/firrtl/passes/ResolveKinds.scala
@@ -11,7 +11,12 @@ object ResolveKinds extends Pass {
     kinds(p.name) = PortKind ; p
   }
 
-  def find_stmt(kinds: collection.mutable.HashMap[String, Kind])(s: Statement):Statement = {
+  def resolve_expr(kinds: collection.mutable.HashMap[String, Kind])(e: Expression): Expression = e match {
+    case ex: WRef => ex copy (kind = kinds(ex.name))
+    case _ => e map resolve_expr(kinds)
+  }
+
+  def resolve_stmt(kinds: collection.mutable.HashMap[String, Kind])(s: Statement): Statement = {
     s match {
       case sx: DefWire => kinds(sx.name) = WireKind
       case sx: DefNode => kinds(sx.name) = NodeKind
@@ -20,23 +25,14 @@ object ResolveKinds extends Pass {
       case sx: DefMemory => kinds(sx.name) = MemKind
       case _ =>
     }
-    s map find_stmt(kinds)
+    s.map(resolve_stmt(kinds))
+     .map(resolve_expr(kinds))
   }
-
-  def resolve_expr(kinds: collection.mutable.HashMap[String, Kind])(e: Expression): Expression = e match {
-    case ex: WRef => ex copy (kind = kinds(ex.name))
-    case _ => e map resolve_expr(kinds)
-  }
-
-  def resolve_stmt(kinds: collection.mutable.HashMap[String, Kind])(s: Statement): Statement =
-    s map resolve_stmt(kinds) map resolve_expr(kinds)
-
 
   def resolve_kinds(m: DefModule): DefModule = {
     val kinds = new collection.mutable.HashMap[String, Kind]
-    (m map find_port(kinds)
-       map find_stmt(kinds)
-       map resolve_stmt(kinds))
+    m.map(find_port(kinds))
+    m.map(resolve_stmt(kinds))
   }
 
   def run(c: Circuit): Circuit =
@@ -68,3 +64,4 @@ object ResolveKinds extends Pass {
   def resolve_stmt(kinds: KindMap)(s: Statement): Statement =
     s map resolve_stmt(kinds) map resolve_expr(kinds)
 }
+


### PR DESCRIPTION
See #1475. This backports the `ResolveKinds` speedup, but unlike #1622, it doesn't backport the benchmarking infrastructure, since I don't think that should go all the way to 1.2.x.