### PR TITLE
Make Utils.expandRef actually return intermediate expressions per API docs

### DIFF
--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -280,10 +280,10 @@ object Utils extends LazyLogging {
     case ex: ValidIf => expandRef(ex.value) map (e1 => ValidIf(ex.cond, e1, e1.tpe))
     case ex => ex.tpe match {
       case (_: GroundType) => Seq(ex)
-      case (t: BundleType) => (t.fields foldLeft Seq[Expression](ex))((exps, f) =>
-        exps ++ create_exps(WSubField(ex, f.name, f.tpe,times(flow(ex), f.flip))))
-      case (t: VectorType) => (0 until t.size foldLeft Seq[Expression](ex))((exps, i) =>
-        exps ++ create_exps(WSubIndex(ex, i, t.tpe,flow(ex))))
+      case (t: BundleType) =>
+        ex +: t.fields.flatMap(f => expandRef(WSubField(ex, f.name, f.tpe, times(flow(ex), f.flip))))
+      case (t: VectorType) =>
+        ex +: (0 until t.size).flatMap(i => expandRef(WSubIndex(ex, i, t.tpe, flow(ex))))
     }
   }
   def toTarget(main: String, module: String)(expression: Expression): ReferenceTarget = {

--- a/src/test/scala/firrtlTests/UtilsSpec.scala
+++ b/src/test/scala/firrtlTests/UtilsSpec.scala
@@ -1,5 +1,7 @@
 package firrtlTests
 
+import firrtl._
+import firrtl.ir._
 import firrtl.Utils
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -21,5 +23,22 @@ class UtilsSpec extends AnyFlatSpec {
 
   for ((description, delimiter, in, out) <- expandPrefixTests) {
     it should description in { Utils.expandPrefixes(in, delimiter).toSet should be (out)}
+  }
+
+  "expandRef" should "return intermediate expressions" in {
+    val bTpe = VectorType(Utils.BoolType, 2)
+    val topTpe = BundleType(Seq(Field("a", Default, Utils.BoolType), Field("b", Default, bTpe)))
+    val wr = WRef("out", topTpe, PortKind, SourceFlow)
+  
+
+    val expected = Seq(
+      wr,
+      WSubField(wr, "a", Utils.BoolType, SourceFlow),
+      WSubField(wr, "b", bTpe, SourceFlow),
+      WSubIndex(WSubField(wr, "b", bTpe, SourceFlow), 0, Utils.BoolType, SourceFlow),
+      WSubIndex(WSubField(wr, "b", bTpe, SourceFlow), 1, Utils.BoolType, SourceFlow)
+    )
+
+    (Utils.expandRef(wr)) should be (expected)
   }
 }

--- a/src/test/scala/firrtlTests/transforms/DedupTests.scala
+++ b/src/test/scala/firrtlTests/transforms/DedupTests.scala
@@ -3,6 +3,7 @@
 package firrtlTests
 package transforms
 
+import firrtl._
 import firrtl.RenameMap
 import firrtl.annotations._
 import firrtl.transforms.{DedupModules, NoCircuitDedupAnnotation}
@@ -760,6 +761,59 @@ class DedupModuleTests extends HighTransformSpec {
       Top.instOf("a2", "A").instOf("b", "B").instOf("c", "C")
     ),0))
     cs.deletedAnnotations.isEmpty should be (true)
+  }
+
+  "dedup" should "properly rename target components after retyping" in {
+    val input = """
+      |circuit top:
+      |  module top:
+      |    input ia: {z: {y: {x: UInt<1>}}, a: UInt<1>}
+      |    input ib: {a: {b: {c: UInt<1>}}, z: UInt<1>}
+      |    output oa: {z: {y: {x: UInt<1>}}, a: UInt<1>}
+      |    output ob: {a: {b: {c: UInt<1>}}, z: UInt<1>}
+      |    inst a of a
+      |    a.i <= ia
+      |    oa <= a.o
+      |    inst b of b
+      |    b.q <= ib
+      |    ob <= b.r
+      |  module a:
+      |    input i: {z: {y: {x: UInt<1>}}, a: UInt<1>}
+      |    output o: {z: {y: {x: UInt<1>}}, a: UInt<1>}
+      |    o <= i
+      |  module b:
+      |    input q: {a: {b: {c: UInt<1>}}, z: UInt<1>}
+      |    output r: {a: {b: {c: UInt<1>}}, z: UInt<1>}
+      |    r <= q
+      |""".stripMargin
+
+    case class DummyRTAnnotation(target: ReferenceTarget) extends SingleTargetAnnotation[ReferenceTarget] {
+      def duplicate(n: ReferenceTarget) = DummyRTAnnotation(n)
+    }
+
+    val annA = DummyRTAnnotation(ReferenceTarget("top", "a", Nil, "i", Seq(TargetToken.Field("a"))))
+    val annB = DummyRTAnnotation(ReferenceTarget("top", "b", Nil, "q", Seq(TargetToken.Field("a"))))
+
+
+    val cs = CircuitState(Parser.parseString(input, Parser.IgnoreInfo), Seq(annA, annB))
+
+    val deduper = new stage.transforms.Compiler(stage.Forms.Deduped, Nil)
+    val csDeduped = deduper.execute(cs)
+
+    /*
+     During dedup, input q of b gets "retyped." The connections get updated to reflect this
+     retyping, and annotations with a non-empty "component" must get renamed to reflect this
+     retyping. Since the "retyping" maps b.q.a onto a.i.z in its structural significance and
+     connection, and since failure to rename "component" will result in annotations that are
+     fundamentally illegal, the deduplication of these modules (if it occurs) must include a rename
+     mapping from ~top|b>q.a to ~top|a>i.z to best capture the retyping.
+     */
+    val aPath = Seq((TargetToken.Instance("a"), TargetToken.OfModule("a")))
+    val bPath = Seq((TargetToken.Instance("b"), TargetToken.OfModule("a")))
+    val expectedAnnA = DummyRTAnnotation(ReferenceTarget("top", "top", aPath, "i", Seq(TargetToken.Field("a"))))
+    val expectedAnnB = DummyRTAnnotation(ReferenceTarget("top", "top", aPath, "i", Seq(TargetToken.Field("a"))))
+    csDeduped.annotations.toSeq should contain (expectedAnnA)
+    csDeduped.annotations.toSeq should contain (expectedAnnB)
   }
 }
 


### PR DESCRIPTION
**Type of improvement:** bug fix
**API impact:** changes behavior of `Utils.expandRef` to match description
**Backend code-generation impact:** Will cause `DedupModules` to rename intermediate targets for composite types
**Release notes:**
The `expandRef` method in `Utils` now correctly returns possible intermediate references to subfields or subindices of composite types.

### Contributor Checklist
- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
