### PR TITLE
Canonicalize init of regs with zero as reset in RemoveReset

### DIFF
--- a/src/main/scala/firrtl/transforms/RemoveReset.scala
+++ b/src/main/scala/firrtl/transforms/RemoveReset.scala
@@ -56,8 +56,9 @@ object RemoveReset extends Transform with DependencyAPIMigration {
         /* A register is initialized to an invalid expression */
         case reg @ DefRegister(_, _, _, _, _, init) if invalids.contains(we(init)) =>
           reg.copy(reset = Utils.zero, init = WRef(reg))
-        case reg @ DefRegister(_, rname, _, _, reset, init)
-            if reset != Utils.zero && reset.tpe != AsyncResetType =>
+        case reg @ DefRegister(_, rname, _, _, Utils.zero, _) =>
+          reg.copy(init = WRef(reg)) // canonicalize
+        case reg @ DefRegister(_, rname, _, _, reset, init) if reset.tpe != AsyncResetType =>
           // Add register reset to map
           resets(rname) = Reset(reset, init)
           reg.copy(reset = Utils.zero, init = WRef(reg))


### PR DESCRIPTION
**Type of change:** bugfix
**API impact:** none
**Backend code-generation impact:** properly handles regs with zero as reset an non-self init values
**Desired merge strategy: squash**
**Release notes:**
Support for input circuits that include registers with a constant zero as the reset signal has been enhanced.

* Fixes #1561
* Add test for zero-reset reg from #1561

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you mark as `Please Merge`?
