### PR TITLE
Improve anno logging

### DIFF
--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -6,6 +6,8 @@ import logger._
 import java.io.Writer
 
 import scala.collection.mutable
+import scala.util.Try
+import scala.util.control.NonFatal
 
 import firrtl.annotations._
 import firrtl.ir.Circuit
@@ -211,7 +213,14 @@ private[firrtl] object Transform {
 
     logger.info(s"Form: ${after.form}")
     logger.trace(s"Annotations:")
-    logger.trace(JsonProtocol.serialize(remappedAnnotations))
+    logger.trace {
+      JsonProtocol.serializeTry(remappedAnnotations).recoverWith {
+        case NonFatal(e) =>
+          val msg = s"Exception thrown during Annotation serialization:\n  " +
+                    e.toString.replaceAll("\n", "\n  ")
+          Try(msg)
+      }.get
+    }
 
     logger.trace(s"Circuit:\n${after.circuit.serialize}")
     logger.info(s"======== Finished Transform $name ========\n")


### PR DESCRIPTION
This does 2 things (each in its own)
1. DRY out the logic for running transforms and logging them into new private APIs. They're not great, but at least the code duplication is gone
2. Fix a bug where compilation would crash if you have an annotation that json4s can't serialize and have log-level trace

(2) should be backported to 1.2.x but (1) won't apply so I'll have to fix it up manually.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - bug fix
 - code cleanup  


#### API Impact

No impact on public API

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
