### PR TITLE
Make WrappedTransform work with --class-log-level

### DIFF
--- a/src/main/scala/firrtl/stage/transforms/WrappedTransform.scala
+++ b/src/main/scala/firrtl/stage/transforms/WrappedTransform.scala
@@ -4,6 +4,8 @@ package firrtl.stage.transforms
 
 import firrtl.Transform
 
+import logger.Logger
+
 /** A [[firrtl.Transform]] that "wraps" a second [[firrtl.Transform Transform]] to do some work before and after the
   * second [[firrtl.Transform Transform]].
   *
@@ -22,6 +24,8 @@ trait WrappedTransform { this: Transform =>
     case a: WrappedTransform => a.trueUnderlying
     case _ => underlying
   }
+
+  final override protected val logger = new Logger(trueUnderlying.getClass.getName)
 
   override def inputForm = underlying.inputForm
   override def outputForm = underlying.outputForm


### PR DESCRIPTION
Change WrappedTransforms to be sensitive to the --class-log-level of
their true underlying transform. In effect, information logged in a
wrapper (like timing information) will now print as expected.

#### Demo

On current `master`, you get:

```bash
./utils/bin/firrtl \
  -i regress/ICache.fir \
  --class-log-level firrtl.passes.InferTypes$:info \
  -td test_run_dir
# Computed transform order in: 534.7 ms
# Total FIRRTL Compile Time: 1914.4 ms
```

With this PR, you get:

```bash
./utils/bin/firrtl \
  -i regress/ICache.fir \
  --class-log-level firrtl.passes.InferTypes$:info \
  -td test_run_dir
# Computed transform order in: 569.3 ms
# ======== Starting Transform firrtl.passes.InferTypes$ ========
# --------------------------------------------------------------
# 
# Time: 39.6 ms
# Form: ChirrtlForm
# ======== Finished Transform firrtl.passes.InferTypes$ ========
# 
# ======== Starting Transform firrtl.passes.InferTypes$ ========
# --------------------------------------------------------------
# 
# Time: 9.0 ms
# Form: ChirrtlForm
# ======== Finished Transform firrtl.passes.InferTypes$ ========
# 
# ======== Starting Transform firrtl.passes.InferTypes$ ========
# --------------------------------------------------------------
# 
# Time: 4.1 ms
# Form: ChirrtlForm
# ======== Finished Transform firrtl.passes.InferTypes$ ========
# 
# ======== Starting Transform firrtl.passes.InferTypes$ ========
# --------------------------------------------------------------
# 
# Time: 6.6 ms
# Form: ChirrtlForm
# ======== Finished Transform firrtl.passes.InferTypes$ ========
# 
# ======== Starting Transform firrtl.passes.InferTypes$ ========
# --------------------------------------------------------------
# 
# Time: 5.5 ms
# Form: UnknownForm
# ======== Finished Transform firrtl.passes.InferTypes$ ========
# 
# ======== Starting Transform firrtl.passes.InferTypes$ ========
# --------------------------------------------------------------
# 
# Time: 5.6 ms
# Form: UnknownForm
# ======== Finished Transform firrtl.passes.InferTypes$ ========
# 
# Total FIRRTL Compile Time: 1908.6 ms
```

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [N/A] Did you update the FIRRTL spec to include every new feature/behavior?
- [Nope] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

None. --class-log-level will now work correctly for the new Dependency API-based transform infrastructure.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Fix bug where --class-log-level wouldn't show timing information

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
