### PR TITLE
recore of Attributes

### DIFF
--- a/src/main/scala/firrtl/AddDescriptionNodes.scala
+++ b/src/main/scala/firrtl/AddDescriptionNodes.scala
@@ -42,12 +42,12 @@ private object MakeDescription {
   def apply(s: FirrtlNode)(descs: Seq[(String, DescriptionType)]): Seq[Description] = {
     // combine DocStringDescriptions (multi-line comment)
     val docString = descs.collect({
-      case (s: String, _: DocStringDescription.type) => s
+      case (s: String, DocStringDescription) => s
     }).mkString("\n\n")
     val docStringDesc = if (docString.length > 0) Some(MakeDescription(s, docString, DocStringDescription)) else None
     // combine AttributeDescriptions (comma separated)
     val attr = descs.collect({
-      case (s: String, _: AttributeDescription.type) => s
+      case (s: String, AttributeDescription) => s
     }).mkString(", ")
     val attrDesc = if (attr.length > 0) Some(MakeDescription(s, attr, AttributeDescription)) else None
     Seq(docStringDesc, attrDesc).flatten

--- a/src/main/scala/firrtl/AddDescriptionNodes.scala
+++ b/src/main/scala/firrtl/AddDescriptionNodes.scala
@@ -209,7 +209,7 @@ class AddDescriptionNodes extends Transform with DependencyAPIMigration with Pre
   }
 
   def collectMaps(annos: Seq[Annotation]): (Map[String, Seq[Description]], Map[String, Map[String, Seq[Description]]]) = {
-    val modList: Map[String, Seq[Description]] = annos.collect {
+    val modList = annos.collect {
       case DocStringAnnotation(ModuleName(m, _), desc) => (m, DocString(StringLit.unescape(desc)))
       case AttributeAnnotation(ModuleName(m, _), desc) => (m, Attribute(StringLit.unescape(desc)))
     }

--- a/src/main/scala/firrtl/AddDescriptionNodes.scala
+++ b/src/main/scala/firrtl/AddDescriptionNodes.scala
@@ -10,7 +10,6 @@ import firrtl.options.{Dependency, PreservesAll}
 sealed trait DescriptionType
 case object DocStringDescription extends DescriptionType
 case object AttributeDescription extends DescriptionType
-case class IfdefDescription(alternative: FirrtlNode => String, ifndef: Boolean = false) extends DescriptionType
 
 case class DescriptionAnnotation(named: Named, description: String, tpe: DescriptionType) extends Annotation {
   def update(renames: RenameMap): Seq[DescriptionAnnotation] = {
@@ -78,8 +77,6 @@ private object MakeDescription {
   def apply(s: FirrtlNode, str: String, tpe: DescriptionType): Description = tpe match {
     case DocStringDescription => DocString(StringLit.unescape(str))
     case AttributeDescription => Attribute(StringLit.unescape(str))
-    case IfdefDescription(alt, true) => Ifdef(StringLit.unescape(str), IfndefFirstSection(StringLit(alt(s))))
-    case IfdefDescription(alt, false) => Ifdef(StringLit.unescape(str), IfdefFirstSection(StringLit(alt(s))))
   }
   def apply(s: FirrtlNode)(descs: Seq[(String, DescriptionType)]): Description = {
     descs.foldLeft[Description](EmptyDescription) { (_, _) match {

--- a/src/main/scala/firrtl/AddDescriptionNodes.scala
+++ b/src/main/scala/firrtl/AddDescriptionNodes.scala
@@ -35,32 +35,6 @@ private case class Attribute(string: StringLit) extends SimpleDescription {
   def serialize: String = "@[" + string.serialize + "]"
 }
 
-private sealed trait IfdefSection {
-  def serialize: String
-}
-private sealed trait MultiSection extends IfdefSection {
-  val body: StringLit
-  val elseSection: IfdefSection
-  def serialize : String = body.string + s"{ ${elseSection.serialize} }"
-}
-private object MultiSection {
-  def unapply(section: MultiSection): Some[(StringLit, IfdefSection)] = {
-    Some((section.body, section.elseSection))
-  }
-}
-private case class IfdefFirstSection(body: StringLit, elseSection: IfdefSection = IfdefElseSection) extends MultiSection
-private case class IfndefFirstSection(body: StringLit, elseSection: IfdefSection = IfdefElseSection) extends MultiSection
-private case class IfdefElseifSection(condition: StringLit, body: StringLit, elseSection: IfdefSection) extends MultiSection {
-  override def serialize: String = s"{ (${condition.string }) ${body.string} : { ${elseSection.serialize} } }"
-}
-private case object IfdefElseSection extends IfdefSection {
-  def serialize: String = ""
-}
-
-private case class Ifdef(condition: StringLit, body: MultiSection) extends SimpleDescription {
-  def serialize: String = "@[ ${condition.string} : ${body.serialize}]"
-}
-
 private case class MultipleDescriptions(descs: Seq[Description]) extends Description {
   def serialize: String = descs.map(_.serialize).mkString("\n")
   def add(d: Description): MultipleDescriptions = d match {

--- a/src/main/scala/firrtl/AddDescriptionNodes.scala
+++ b/src/main/scala/firrtl/AddDescriptionNodes.scala
@@ -185,11 +185,11 @@ class AddDescriptionNodes extends Transform with DependencyAPIMigration with Pre
     * @return List of `Description`s with some descriptions merged
     */
   def mergeDescriptions(descs: Seq[Description]): Seq[Description] = {
-    val (docs: Seq[DocString], nodocs) = descs.partition {
+    val (docs: Seq[DocString] @unchecked, nodocs) = descs.partition {
       case _: DocString => true
       case _ => false
     }
-    val (attrs: Seq[Attribute], rest) = nodocs.partition {
+    val (attrs: Seq[Attribute] @unchecked, rest) = nodocs.partition {
       case _: Attribute => true
       case _ => false
     }

--- a/src/main/scala/firrtl/AddDescriptionNodes.scala
+++ b/src/main/scala/firrtl/AddDescriptionNodes.scala
@@ -7,12 +7,20 @@ import firrtl.annotations._
 import firrtl.Mappers._
 import firrtl.options.{Dependency, PreservesAll}
 
+/**
+  * A base trait for `Annotation`s that describe a `FirrtlNode`.
+  * Usually, we would like to emit these descriptions in some way.
+  */
 sealed trait DescriptionAnnotation extends Annotation {
   val named: Named
   val description: String
-
 }
 
+/**
+  * A docstring description (a comment).
+  * @param named the object being described
+  * @param description the docstring describing the object
+  */
 case class DocStringAnnotation(named: Named, description: String) extends DescriptionAnnotation {
   def update(renames: RenameMap): Seq[DocStringAnnotation] = {
     renames.get(named) match {
@@ -21,6 +29,12 @@ case class DocStringAnnotation(named: Named, description: String) extends Descri
     }
   }
 }
+
+/**
+  * An Verilog-style attribute.
+  * @param named the object being given an attribute
+  * @param description the attribute
+  */
 case class AttributeAnnotation(named: Named, description: String) extends DescriptionAnnotation {
   def update(renames: RenameMap): Seq[AttributeAnnotation] = {
     renames.get(named) match {
@@ -30,20 +44,40 @@ case class AttributeAnnotation(named: Named, description: String) extends Descri
   }
 }
 
+/**
+  * Base trait for an object that has associated descriptions
+  */
 private sealed trait HasDescription {
   def descriptions: Seq[Description]
 }
 
+/**
+  * Base trait for a description that gives some information about a `FirrtlNode`.
+  * Usually, we would like to emit these descriptions in some way.
+  */
 sealed trait Description extends FirrtlNode
 
+/**
+  * A docstring description (a comment)
+  * @param string a comment
+  */
 case class DocString(string: StringLit) extends Description {
   def serialize: String = "@[" + string.serialize + "]"
 }
 
+/**
+  * A Verilog-style attribute.
+  * @param string the attribute
+  */
 case class Attribute(string: StringLit) extends Description {
   def serialize: String = "@[" + string.serialize + "]"
 }
 
+/**
+  * A statement with descriptions
+  * @param descriptions
+  * @param stmt the encapsulated statement
+  */
 private case class DescribedStmt(descriptions: Seq[Description], stmt: Statement) extends Statement with HasDescription {
   def serialize: String = s"${descriptions.map(_.serialize).mkString("\n")}\n${stmt.serialize}"
   def mapStmt(f: Statement => Statement): Statement = f(stmt)
@@ -58,6 +92,12 @@ private case class DescribedStmt(descriptions: Seq[Description], stmt: Statement
   def foreachInfo(f: Info => Unit): Unit = stmt.foreachInfo(f)
 }
 
+/**
+  * A module with descriptions
+  * @param descriptions list of descriptions for the module
+  * @param portDescriptions list of descriptions for the module's ports
+  * @param mod the encapsulated module
+  */
 private case class DescribedMod(descriptions: Seq[Description],
   portDescriptions: Map[String, Seq[Description]],
   mod: DefModule) extends DefModule with HasDescription {

--- a/src/main/scala/firrtl/AddDescriptionNodes.scala
+++ b/src/main/scala/firrtl/AddDescriptionNodes.scala
@@ -12,8 +12,8 @@ import firrtl.options.{Dependency, PreservesAll}
   * Usually, we would like to emit these descriptions in some way.
   */
 sealed trait DescriptionAnnotation extends Annotation {
-  val named: Named
-  val description: String
+  def named: Named
+  def description: String
 }
 
 /**
@@ -185,14 +185,14 @@ class AddDescriptionNodes extends Transform with DependencyAPIMigration with Pre
     * @return List of `Description`s with some descriptions merged
     */
   def mergeDescriptions(descs: Seq[Description]): Seq[Description] = {
-    val (docs: Seq[DocString], nodocs) = descs.partition(_ match {
+    val (docs: Seq[DocString], nodocs) = descs.partition {
       case _: DocString => true
       case _ => false
-    })
-    val (attrs: Seq[Attribute], rest) = nodocs.partition(_ match {
+    }
+    val (attrs: Seq[Attribute], rest) = nodocs.partition {
       case _: Attribute => true
       case _ => false
-    })
+    }
 
     val doc = if (docs.nonEmpty) {
       Seq(DocString(StringLit.unescape(docs.map(_.string.string).mkString("\n\n"))))

--- a/src/main/scala/firrtl/AddDescriptionNodes.scala
+++ b/src/main/scala/firrtl/AddDescriptionNodes.scala
@@ -209,17 +209,29 @@ class AddDescriptionNodes extends Transform with DependencyAPIMigration with Pre
   }
 
   def collectMaps(annos: Seq[Annotation]): (Map[String, Seq[Description]], Map[String, Map[String, Seq[Description]]]) = {
-    val modMap: Map[String, Seq[Description]] = annos.collect {
+    val modList: Map[String, Seq[Description]] = annos.collect {
       case DocStringAnnotation(ModuleName(m, _), desc) => (m, DocString(StringLit.unescape(desc)))
       case AttributeAnnotation(ModuleName(m, _), desc) => (m, Attribute(StringLit.unescape(desc)))
-    }.groupBy(_._1).mapValues(_.map(_._2)).mapValues(mergeDescriptions)
+    }
 
-    val compMap = annos.collect {
+    // map field 1 (module name) -> field 2 (a list of Descriptions)
+    val modMap = modList.groupBy(_._1).mapValues(_.map(_._2))
+      // and then merge like descriptions (e.g. multiple docstrings into one big docstring)
+      .mapValues(mergeDescriptions)
+
+    val compList = annos.collect {
       case DocStringAnnotation(ComponentName(c, ModuleName(m, _)), desc) =>
         (m, c, DocString(StringLit.unescape(desc)))
       case AttributeAnnotation(ComponentName(c, ModuleName(m, _)), desc) =>
         (m, c, Attribute(StringLit.unescape(desc)))
-    }.groupBy(_._1).mapValues(_.groupBy(_._2).mapValues(_.map(_._3)).mapValues(mergeDescriptions))
+    }
+
+    // map field 1 (name) -> a map that we build
+    val compMap = compList.groupBy(_._1).mapValues(
+      // map field 2 (component name) -> field 3 (a list of Descriptions)
+      _.groupBy(_._2).mapValues(_.map(_._3))
+      // and then merge like descriptions (e.g. multiple docstrings into one big docstring)
+      .mapValues(mergeDescriptions))
 
     (modMap, compMap)
   }

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -860,11 +860,6 @@ class VerilogEmitter extends SeqTransform with Emitter {
     private def combine_all_descriptions(ds: Seq[SimpleDescription]): Seq[SimpleDescription] = {
       val docStrings = ds collect { case d: DocString => d }
       val attrs = ds collect { case d: Attribute => d }
-      val ifdefs = ds collect { case d: Ifdef => d }
-
-      if (ifdefs.length > 1) {
-        throw new EmitterException("Multiple conflicting ifdefs")
-      }
 
       val doc = docStrings.foldLeft[SimpleDescription](EmptyDescription) { (_, _) match {
         case (EmptyDescription, d) => d
@@ -880,7 +875,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
         case _ => throw new EmitterException("attrs should only contain Attributes or EmptyDescription")
       }}
 
-      Seq(doc, attr) ++ ifdefs
+      Seq(doc, attr)
     }
 
     def description_has_ifdef(d: Description): Boolean = d match {

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -804,7 +804,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
     }
 
     def build_attribute(attrs: String): Seq[Seq[String]] = {
-      Seq(Seq("(* ") ++ attrs.split(",") ++ Seq(" *)"))
+      Seq(Seq("(* ") ++ Seq(attrs) ++ Seq(" *)"))
     }
 
     // Turn ports into Seq[String] and add to portdefs

--- a/src/test/scala/firrtlTests/VerilogEmitterTests.scala
+++ b/src/test/scala/firrtlTests/VerilogEmitterTests.scala
@@ -739,8 +739,8 @@ class VerilogDescriptionEmitterSpec extends FirrtlFlatSpec {
     // We don't use executeTest because we care about the spacing in the result
     val modName = ModuleName("Test", CircuitName("Test"))
     val annos = Seq(
-      DescriptionAnnotation(ComponentName("a", modName), "multi\nline", DocStringDescription),
-      DescriptionAnnotation(ComponentName("b", modName), "single line", DocStringDescription))
+      DocStringAnnotation(ComponentName("a", modName), "multi\nline"),
+      DocStringAnnotation(ComponentName("b", modName), "single line"))
     val finalState = compiler.compileAndEmit(CircuitState(parse(input), ChirrtlForm, annos), Seq.empty)
     val output = finalState.getEmittedCircuit.value
     for (c <- check) {
@@ -782,9 +782,9 @@ class VerilogDescriptionEmitterSpec extends FirrtlFlatSpec {
     // We don't use executeTest because we care about the spacing in the result
     val modName = ModuleName("Test", CircuitName("Test"))
     val annos = Seq(
-      DescriptionAnnotation(ComponentName("d", modName), "multi\nline", DocStringDescription),
-      DescriptionAnnotation(ComponentName("e", modName), "multi\nline", DocStringDescription),
-      DescriptionAnnotation(ComponentName("f", modName), "single line", DocStringDescription))
+      DocStringAnnotation(ComponentName("d", modName), "multi\nline"),
+      DocStringAnnotation(ComponentName("e", modName), "multi\nline"),
+      DocStringAnnotation(ComponentName("f", modName), "single line"))
     val finalState = compiler.compileAndEmit(CircuitState(parse(input), ChirrtlForm, annos), Seq.empty)
     val output = finalState.getEmittedCircuit.value
     for (c <- check) {
@@ -819,7 +819,7 @@ class VerilogDescriptionEmitterSpec extends FirrtlFlatSpec {
     )
     // We don't use executeTest because we care about the spacing in the result
     val modName = ModuleName("Test", CircuitName("Test"))
-    val annos = Seq(DescriptionAnnotation(modName, "multi\nline", DocStringDescription))
+    val annos = Seq(DocStringAnnotation(modName, "multi\nline"))
     val finalState = compiler.compileAndEmit(CircuitState(parse(input), ChirrtlForm, annos), Seq.empty)
     val output = finalState.getEmittedCircuit.value
     for (c <- check) {
@@ -877,16 +877,16 @@ class VerilogDescriptionEmitterSpec extends FirrtlFlatSpec {
         s"module ${m.name}()"
     }
     val annos = Seq(
-      DescriptionAnnotation(modName, "line1", DocStringDescription),
-      DescriptionAnnotation(modName, "line2", DocStringDescription),
-      DescriptionAnnotation(modName, "parallel_case", AttributeDescription),
-      DescriptionAnnotation(ComponentName("a", modName), "line3", DocStringDescription),
-      DescriptionAnnotation(ComponentName("a", modName), "line4", DocStringDescription),
-      DescriptionAnnotation(ComponentName("d", modName), "line5", DocStringDescription),
-      DescriptionAnnotation(ComponentName("d", modName), "line6", DocStringDescription),
-      DescriptionAnnotation(ComponentName("a", modName), "full_case", AttributeDescription),
-      DescriptionAnnotation(ComponentName("d", modName), "parallel_case", AttributeDescription),
-      DescriptionAnnotation(ComponentName("d", modName), "mark_debug", AttributeDescription)
+      DocStringAnnotation(modName, "line1"),
+      DocStringAnnotation(modName, "line2"),
+      AttributeAnnotation(modName, "parallel_case"),
+      DocStringAnnotation(ComponentName("a", modName), "line3"),
+      DocStringAnnotation(ComponentName("a", modName), "line4"),
+      DocStringAnnotation(ComponentName("d", modName), "line5"),
+      DocStringAnnotation(ComponentName("d", modName), "line6"),
+      AttributeAnnotation(ComponentName("a", modName), "full_case"),
+      AttributeAnnotation(ComponentName("d", modName), "parallel_case"),
+      AttributeAnnotation(ComponentName("d", modName), "mark_debug")
     )
     val writer = new java.io.StringWriter
     val finalState = compiler.compileAndEmit(CircuitState(parse(input), ChirrtlForm, annos), Seq.empty)

--- a/src/test/scala/firrtlTests/VerilogEmitterTests.scala
+++ b/src/test/scala/firrtlTests/VerilogEmitterTests.scala
@@ -859,7 +859,7 @@ class VerilogDescriptionEmitterSpec extends FirrtlFlatSpec {
         |   *
         |   * line6
         |   */
-        |  (* parallel_case *)
+        |  (* parallel_case, mark_debug *)
         |  `ifndef SYNTHESIS
         |  real wire d;
         |  `else
@@ -885,7 +885,8 @@ class VerilogDescriptionEmitterSpec extends FirrtlFlatSpec {
       DescriptionAnnotation(ComponentName("d", modName), "line5", DocStringDescription),
       DescriptionAnnotation(ComponentName("d", modName), "line6", DocStringDescription),
       DescriptionAnnotation(ComponentName("a", modName), "full_case", AttributeDescription),
-      DescriptionAnnotation(ComponentName("d", modName), "parallel_case", AttributeDescription)
+      DescriptionAnnotation(ComponentName("d", modName), "parallel_case", AttributeDescription),
+      DescriptionAnnotation(ComponentName("d", modName), "mark_debug", AttributeDescription)
     )
     val writer = new java.io.StringWriter
     val finalState = compiler.compileAndEmit(CircuitState(parse(input), ChirrtlForm, annos), Seq.empty)

--- a/src/test/scala/firrtlTests/VerilogEmitterTests.scala
+++ b/src/test/scala/firrtlTests/VerilogEmitterTests.scala
@@ -847,11 +847,8 @@ class VerilogDescriptionEmitterSpec extends FirrtlFlatSpec {
         | * line2
         | */
         |(* parallel_case *)
-        |`ifndef SYNTHESIS
-        |real wire Test;
-        |`else
         |module Test(
-        |`endif""".stripMargin,
+        |""".stripMargin,
       """  /* line3
         |   *
         |   * line4
@@ -883,15 +880,12 @@ class VerilogDescriptionEmitterSpec extends FirrtlFlatSpec {
       DescriptionAnnotation(modName, "line1", DocStringDescription),
       DescriptionAnnotation(modName, "line2", DocStringDescription),
       DescriptionAnnotation(modName, "parallel_case", AttributeDescription),
-      DescriptionAnnotation(modName, "SYNTHESIS", IfdefDescription(altFunc)),
       DescriptionAnnotation(ComponentName("a", modName), "line3", DocStringDescription),
       DescriptionAnnotation(ComponentName("a", modName), "line4", DocStringDescription),
       DescriptionAnnotation(ComponentName("d", modName), "line5", DocStringDescription),
       DescriptionAnnotation(ComponentName("d", modName), "line6", DocStringDescription),
       DescriptionAnnotation(ComponentName("a", modName), "full_case", AttributeDescription),
-      DescriptionAnnotation(ComponentName("d", modName), "parallel_case", AttributeDescription),
-      DescriptionAnnotation(ComponentName("b", modName), "SYNTHESIS", IfdefDescription(altFunc)),
-      DescriptionAnnotation(ComponentName("d", modName), "SYNTHESIS", IfdefDescription(altFunc))
+      DescriptionAnnotation(ComponentName("d", modName), "parallel_case", AttributeDescription)
     )
     val writer = new java.io.StringWriter
     val finalState = compiler.compileAndEmit(CircuitState(parse(input), ChirrtlForm, annos), Seq.empty)

--- a/src/test/scala/firrtlTests/VerilogEmitterTests.scala
+++ b/src/test/scala/firrtlTests/VerilogEmitterTests.scala
@@ -860,35 +860,22 @@ class VerilogDescriptionEmitterSpec extends FirrtlFlatSpec {
         |   * line6
         |   */
         |  (* parallel_case, mark_debug *)
-        |  `ifndef SYNTHESIS
-        |  real wire d;
-        |  `else
-        |  wire  d = 
-        |  `endif""".stripMargin
+        |  wire  d = """.stripMargin
     )
     // We don't use executeTest because we care about the spacing in the result
     val modName = ModuleName("Test", CircuitName("Test"))
-    def altFunc(alternative: ir.FirrtlNode): String = alternative match {
-      case ir.Port(_, name, dir, _) =>
-        s"real ${dir.serialize} $name"
-      case d: ir.IsDeclaration=>
-        s"real wire ${d.name};"
-      case m: ir.DefModule =>
-        s"module ${m.name}()"
-    }
     val annos = Seq(
       DocStringAnnotation(modName, "line1"),
       DocStringAnnotation(modName, "line2"),
       AttributeAnnotation(modName, "parallel_case"),
       DocStringAnnotation(ComponentName("a", modName), "line3"),
       DocStringAnnotation(ComponentName("a", modName), "line4"),
+      AttributeAnnotation(ComponentName("a", modName), "full_case"),
       DocStringAnnotation(ComponentName("d", modName), "line5"),
       DocStringAnnotation(ComponentName("d", modName), "line6"),
-      AttributeAnnotation(ComponentName("a", modName), "full_case"),
       AttributeAnnotation(ComponentName("d", modName), "parallel_case"),
       AttributeAnnotation(ComponentName("d", modName), "mark_debug")
     )
-    val writer = new java.io.StringWriter
     val finalState = compiler.compileAndEmit(CircuitState(parse(input), ChirrtlForm, annos), Seq.empty)
     val output = finalState.getEmittedCircuit.value
     for (c <- check) {


### PR DESCRIPTION
This pull request rebases great work #1172 by @grebe to master.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- new feature/API

#### API Impact
- break:
convert `DescriptionAnnotation` into `sealed trait`
- add:
`DocStringAnnotation`, `AttributeAnnotation`

#### Backend Code Generation Impact
None

#### Desired Merge Strategy
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
Verilog can have both attributes and doc string now.
 
### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you mark as `Please Merge`?
