### PR TITLE
WIR/IR merge part 2: more IR factories, update tutorial

### DIFF
--- a/src/main/scala/firrtl/ir/IR.scala
+++ b/src/main/scala/firrtl/ir/IR.scala
@@ -141,7 +141,22 @@ abstract class Expression extends FirrtlNode {
   def foreachWidth(f: Width => Unit): Unit
 }
 
-case class Reference(name: String, tpe: Type, kind: Kind = UnknownKind, flow: Flow = UnknownFlow)
+object Reference {
+  /** Creates a Reference from a Wire */
+  def apply(wire: DefWire): Reference = Reference(wire.name, wire.tpe, WireKind, UnknownFlow)
+  /** Creates a Reference from a Register */
+  def apply(reg: DefRegister): Reference = Reference(reg.name, reg.tpe, RegKind, UnknownFlow)
+  /** Creates a Reference from a Node */
+  def apply(node: DefNode): Reference = Reference(node.name, node.value.tpe, NodeKind, SourceFlow)
+  /** Creates a Reference from a Port */
+  def apply(port: Port): Reference = Reference(port.name, port.tpe, PortKind, UnknownFlow)
+  /** Creates a Reference from a DefInstance */
+  def apply(i: DefInstance): Reference = Reference(i.name, i.tpe, InstanceKind, UnknownFlow)
+  /** Creates a Reference from a DefMemory */
+  def apply(mem: DefMemory): Reference = Reference(mem.name, passes.MemPortUtils.memType(mem), MemKind, UnknownFlow)
+}
+
+case class Reference(name: String, tpe: Type = UnknownType, kind: Kind = UnknownKind, flow: Flow = UnknownFlow)
     extends Expression with HasName {
   def serialize: String = name
   def mapExpr(f: Expression => Expression): Expression = this
@@ -152,7 +167,7 @@ case class Reference(name: String, tpe: Type, kind: Kind = UnknownKind, flow: Fl
   def foreachWidth(f: Width => Unit): Unit = Unit
 }
 
-case class SubField(expr: Expression, name: String, tpe: Type, flow: Flow = UnknownFlow)
+case class SubField(expr: Expression, name: String, tpe: Type = UnknownType, flow: Flow = UnknownFlow)
     extends Expression with HasName {
   def serialize: String = s"${expr.serialize}.$name"
   def mapExpr(f: Expression => Expression): Expression = this.copy(expr = f(expr))
@@ -305,6 +320,10 @@ case class DefRegister(
   def foreachType(f: Type => Unit): Unit = f(tpe)
   def foreachString(f: String => Unit): Unit = f(name)
   def foreachInfo(f: Info => Unit): Unit = f(info)
+}
+
+object DefInstance {
+  def apply(name: String, module: String): DefInstance = DefInstance(NoInfo, name, module)
 }
 
 case class DefInstance(info: Info, name: String, module: String, tpe: Type = UnknownType)


### PR DESCRIPTION
**Type of change:** API addition, documentation
**API impact:** API addition
**Backend code-generation impact:** None
**Desired merge strategy:** Rebase

I added some extra factories to plain IR nodes so that they have as many factory options as the old WIR factories. This makes it a little easier and more compelling to use them.

I also updated the tutorial to reflect the lack of IR/WIR distinction.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [] Did you add text to be included in the Release Notes for this change?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
