### PR TITLE
Fix performance regression in DedupModules

### DIFF
--- a/src/main/scala/firrtl/transforms/Dedup.scala
+++ b/src/main/scala/firrtl/transforms/Dedup.scala
@@ -165,7 +165,7 @@ class DedupModules extends Transform with DependencyAPIMigration with PreservesA
     }.toMap
 
     // get the ordered set of instances a module, includes new Deduped modules
-    val getChildrenInstances = (mod: String) => {
+    val getChildrenInstances = {
       val childrenMap = instanceGraph.getChildrenInstances
       val newModsMap: Map[String, mutable.LinkedHashSet[WDefInstance]] = dedupMap.map {
         case (name, m: Module) =>
@@ -175,7 +175,7 @@ class DedupModules extends Transform with DependencyAPIMigration with PreservesA
         case (name, m: DefModule) =>
           m.name -> mutable.LinkedHashSet.empty[WDefInstance]
       }.toMap
-      childrenMap.get(mod).getOrElse(newModsMap(mod))
+      (mod: String) => childrenMap.get(mod).getOrElse(newModsMap(mod))
     }
 
     val instanceNameMap: Map[OfModule, Map[Instance, Instance]] = {


### PR DESCRIPTION
Fix a performance bug in DedupModules introduced in #1539. Stop
recalculating the same expensive datastructures for each module,
potentially multiple times.

The correctness is easy to see. I hoisted a couple of datastructures out of the returned function.

### Benchmarking results

Times in seconds. This change is still benchmarking but results for small were promising.

|  Design | Before 1539 | 1539 | This PR |
| --- | --- | --- | --- |
| small | 39.4 ± 1.2 | 44.1 ± 0.8 | 37.7 ± 1.9 |
| medium | 86.9 ± 1.1 | 148.2 ± 2.0 | 90.7 ± 3.3 |


### Contributor Checklist

- [N/A] Did you add Scaladoc to every public function/method?
- [N/A] Did you update the FIRRTL spec to include every new feature/behavior?
- [N/A] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
 - performance improvement 

#### API Impact

None

#### Backend Code Generation Impact

None

#### Desired Merge Strategy

 - Squash: The PR will be squashed and merged (choose this if you have no preference.

#### Release Notes
Fix performance regression in DedupModules

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you mark as `Please Merge`?
