### PR TITLE
Speed up ExpandWhens for very large designs

### DIFF
--- a/src/main/scala/firrtl/passes/ExpandWhens.scala
+++ b/src/main/scala/firrtl/passes/ExpandWhens.scala
@@ -53,7 +53,10 @@ object ExpandWhens extends Pass {
   }
 
   /** Maps an expression to a declared node name. Used to memoize predicates */
+  @deprecated("This should never have been public", "1.3.2")
   type NodeMap = mutable.HashMap[MemoizedHash[Expression], String]
+
+  private type NodeLookup = mutable.HashMap[WrappedExpression, String]
 
   /** Maps a reference to whatever connects to it. Used to resolve last connect semantics */
   type Netlist = mutable.LinkedHashMap[WrappedExpression, Expression]
@@ -88,10 +91,10 @@ object ExpandWhens extends Pass {
     val simlist = new Simlist
 
     // Memoizes if an expression contains any WVoids inserted in this pass
-    val memoizedVoid = new mutable.HashSet[MemoizedHash[Expression]] += WVoid
+    val memoizedVoid = new mutable.HashSet[WrappedExpression] += WVoid
 
     // Memoizes the node that holds a particular expression, if any
-    val nodes = new NodeMap
+    val nodes = new NodeLookup
 
     // Seq of attaches in order
     lazy val attaches = mutable.ArrayBuffer.empty[Attach]

--- a/src/main/scala/firrtl/passes/ExpandWhens.scala
+++ b/src/main/scala/firrtl/passes/ExpandWhens.scala
@@ -53,7 +53,7 @@ object ExpandWhens extends Pass {
   }
 
   /** Maps an expression to a declared node name. Used to memoize predicates */
-  @deprecated("This should never have been public", "1.3.2")
+  @deprecated("This will be removed in FIRRTL 1.4.0", "FIRRTL 1.3.2")
   type NodeMap = mutable.HashMap[MemoizedHash[Expression], String]
 
   private type NodeLookup = mutable.HashMap[WrappedExpression, String]


### PR DESCRIPTION
Use WrappedExpression instead of MemoizedHash. The benefit of memoizing
the hash pales in comparison to the cost of hashing deeply nested Types
in the AST.

### Performance measurements

This is for full runs of vanilla FIRRTL

  | master | | This PR |  | |
-- | -- | -- | -- | -- | -- |
**design** | **runtime** | **SD** | **runtime** | **SD** | **Speedup**
small | 40.8 | 0.7 | 41.8 | 0.3 | -2.3%
medium | 125.9 | 3.6 | 127.4 | 4.1 | -1.2%
large | 330.1 | 10.9 | 330.4 | 11.9 | -0.1%
BOOM | 735.7 | 115.7 | 460.7 | 10.0 | 37.4%
huge | 1049.6 | 8.4 | 938.6 | 14.9 | 10.6%

There are slight slowdowns for "normal" designs, but `medium` and `large` are within the standard deviation, and `small` is only barely outside of it. 

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [NA] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - performance improvement

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy
  - Squash: The PR will be squashed and merged (choose this if you have no preference.

#### Release Notes

Speed up `ExpandWhens` for very large designs (like BOOM)

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
