### PR TITLE
Build ArrayBuffers in Block.mapStmt

### DIFF
--- a/src/main/scala/firrtl/ir/IR.scala
+++ b/src/main/scala/firrtl/ir/IR.scala
@@ -422,7 +422,21 @@ object Block {
 
 case class Block(stmts: Seq[Statement]) extends Statement {
   def serialize: String = stmts map (_.serialize) mkString "\n"
-  def mapStmt(f: Statement => Statement): Statement = Block(stmts map f)
+  def mapStmt(f: Statement => Statement): Statement = {
+    val res = new scala.collection.mutable.ArrayBuffer[Statement]()
+    var it = stmts.iterator
+    while (it.hasNext) {
+      it.next() match {
+        case EmptyStmt => // flatten out
+        case b: Block =>
+          val prev = it
+          it = b.stmts.iterator ++ prev
+        case other =>
+          res.append(f(other))
+      }
+    }
+    Block(res)
+  }
   def mapExpr(f: Expression => Expression): Statement = this
   def mapType(f: Type => Type): Statement = this
   def mapString(f: String => String): Statement = this


### PR DESCRIPTION
Micro-optimize `Block.mapStmt`, to construct `ArrayBuffer`s and flatten out nested `Block`s and `EmptyStmt`s. This will enable cleaning up awkward concatenations we often do at the end of complex transforms to prevent too much nesting ([for example](https://github.com/freechipsproject/firrtl/blob/14099e1d6b7937206cfc5309cbb0e044afc358d0/src/main/scala/firrtl/passes/ExpandWhens.scala#L48)). Furthermore, it should improve FlameGraphs in a few places. It has the added benefit of just cleaner intermediate FIRRTL circuits since `EmptyStmts` are always removed (although only on the next `mapStmt`).

This will need tweaking when we add 2.13 support, with the main candidate being `VectorBuilder`, but this is the best approach that I could find.

I'll note the benefits are small and should be revisited, but this does seem to speed things up slightly while cleaning up the process of iterating on Blocks.

### Benchmark Results

This change has a very small impact (Scala does a pretty good job of `map` on its datastructures, shocker), so I checked several implementations:

1. The current implementation
2. ArrayBuffer (the winner)
3. ArrayBuffer2 (tried to improve with some specialized code, no real benefit for awkward code)
4. VectorBuilder
5. ListBuffer

I also tried both Java8 and GraalVM Java11. The data appears to show that `ArrayBuffer` helps a little, `ArrayBuffer2` is maybe slightly better but the code was super awkward so probably not worth it. VectorBuilder and ListBuffer were worse (but much more so on OpenJDK8 than on GraalVM).

#### GraalVM Java 11


  | master | ArrayBuffer | ArrayBuffer2 | VectorBuilder | ListBuffer
-- | -- | -- | -- | -- | --
Icache.fir | 3.4 ± 0.2 | 3.4 ± 0 | 3.4 ± 0.1 | 3.4 ± 0.1 | 3.4 ± 0.1
small | 45.1 ± 1.9 | 43.2 ± 1.1 | 43.7 ± 0.8 | 41.6 ± 0.3 | 44.3 ± 2.1
medium | 153.9 ± 2.9 | 152.3 ± 8.2 | 144.8 ± 4.5 | 177.4 ± 9.7 | 141.1 ± 2.2
large | 424.6 ± 3.9 | 404.5 ± 2.1 | 434.1 ± 29.5 | 440.7 ± 19.5 | 432.8 ± 20.1

#### OpenJDK 8

  | master | ArrayBuffer | ArrayBuffer2 | VectorBuilder | ListBuffer
-- | -- | -- | -- | -- | --
Icache.fir | 2.7 ± 0.1 | 2.6 ± 0 | 2.7 ± 0 | 2.7 ± 0 | 2.7 ± 0
small | 48.2 ± 1.3 | 51.1 ± 1 | 50.7 ± 0.7 | 53.9 ± 0.7 | 53.9 ± 3.9
medium | 194 ± 3.4 | 187.1 ± 4.5 | 186.3 ± 5.5 | 233.6 ± 6.5 | 201.4 ± 8.4
large | 540 ± 13 | 535.7 ± 6.3 | 530.2 ± 5.6 | 649.8 ± 0.8 | 591.6 ± 6


#### Sanity Check for Massive Designs (GraalVM Java 11)

Because very large arrays can have issues, I wanted to sanity check that `ArrayBuffer` is actually decent on a couple bigger designs, it does just fine there:

  | master | ArrayBuffer
-- | -- | --
huge | 1275.4 ± 18.8 | 1188.8 ± 29.7
large multi-core | 1995.9 ± 92.6 | 1994.4 ± 72.8



### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [NA] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - performance improvement  
  - code refactoring              

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

No impact on Verilog, intermediate emitted FIRRTL should no longer have skips (or at least have far fewer, log-level trace will still have skips from the previous transform).

#### Desired Merge Strategy

   - Squash: The PR will be squashed and merged (choose this if you have no preference. 

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
