### PR TITLE
Handle splitting of compound expressions in Mux

### DIFF
--- a/src/main/scala/firrtl/passes/SplitExpressions.scala
+++ b/src/main/scala/firrtl/passes/SplitExpressions.scala
@@ -55,6 +55,7 @@ object SplitExpressions extends Pass {
         def onExp(e: Expression): Expression =
           e map onExp match {
             case ex: DoPrim => ex map split
+            case ex: Mux => ex map split
             case ex => ex
          }
 
@@ -65,7 +66,7 @@ object SplitExpressions extends Pass {
              v += x
              v.size match {
                case 1 => v.head
-               case _ => Block(v.toSeq)
+               case _ => Block(v)
              }
         }
       }

--- a/src/test/scala/firrtlTests/UnitTests.scala
+++ b/src/test/scala/firrtlTests/UnitTests.scala
@@ -179,6 +179,31 @@ class UnitTests extends FirrtlFlatSpec {
     executeTest(input, check, passes)
   }
 
+  "Simple compound expressions in muxes" should "be split" in {
+    val passes = Seq(
+      ToWorkingIR,
+      ResolveKinds,
+      InferTypes,
+      ResolveFlows,
+      new InferWidths,
+      SplitExpressions
+    )
+    val input =
+      """circuit Top :
+        |  module Top :
+        |    input cond : UInt<1>
+        |    input a : UInt<32>
+        |    input b : UInt<32>
+        |    input c : UInt<64>
+        |    output d : UInt<32>
+        |    d <= mux(cond, cat(a, b), c)""".stripMargin
+    val check = Seq(
+      "node _GEN_0 = cat(a, b)",
+      "d <= mux(cond, _GEN_0, c)"
+    )
+    executeTest(input, check, passes)
+  }
+
   "Smaller widths" should "be explicitly padded" in {
     val passes = Seq(
       ToWorkingIR,


### PR DESCRIPTION
SplitExpressions technically handles Muxes in the call to split(), but
split() is only called on a DoPrim and Muxes are not DoPrims. We therefore
end up with cases where muxes still contain nested expressions after calling
this pass.

This commit fixes the issue.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- bug fix

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

No API changes.

#### Backend Code Generation Impact

Generated verilog should now contain an intermediate signal that breaks up compound expressions in Muxes, similarly to how all other nested non-mux expressions are broken up.

#### Desired Merge Strategy

Squash: The PR will be squashed and merged (choose this if you have no preference. -->

#### Release Notes

Fix bug where compound expressions in Muxes were not being split by the `SplitExpressions` pass.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
