### PR TITLE
delete usages of toSet for determinism

### DIFF
--- a/src/main/scala/firrtl/options/DependencyManager.scala
+++ b/src/main/scala/firrtl/options/DependencyManager.scala
@@ -167,7 +167,12 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
         blacklist = _currentState,
 
         /* Explore all invalidated transforms **EXCEPT** the current transform! */
-        extractor = (p: B) => v.filter(p.invalidates).map(oToD(_)).toSet - oToD(p)))
+        extractor = (p: B) => {
+          val filtered = new LinkedHashSet[Dependency[B]]
+          filtered ++= v.filter(p.invalidates).map(oToD(_))
+          filtered -= oToD(p)
+          filtered
+        }))
       .reverse
   }
 

--- a/src/main/scala/firrtl/options/DependencyManager.scala
+++ b/src/main/scala/firrtl/options/DependencyManager.scala
@@ -172,8 +172,8 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
           filtered ++= v.filter(p.invalidates).map(oToD(_))
           filtered -= oToD(p)
           filtered
-        }))
-      .reverse
+        })
+    ).reverse
   }
 
   /** Wrap a possible [[CyclicException]] thrown by a thunk in a [[DependencyManagerException]] */

--- a/src/main/scala/firrtl/options/Phase.scala
+++ b/src/main/scala/firrtl/options/Phase.scala
@@ -125,14 +125,14 @@ trait DependencyAPI[A <: DependencyAPI[A]] { this: TransformLike[_] =>
     * $seqNote
     */
   def prerequisites: Seq[Dependency[A]] = Seq.empty
-  private[options] lazy val _prerequisites: LinkedHashSet[Dependency[A]] = new LinkedHashSet() ++ prerequisites.toSet
+  private[options] lazy val _prerequisites: LinkedHashSet[Dependency[A]] = new LinkedHashSet() ++ prerequisites
 
   /** All transforms that, if a prerequisite of *another* transform, will run before this transform.
     * $seqNote
     */
   def optionalPrerequisites: Seq[Dependency[A]] = Seq.empty
   private[options] lazy val _optionalPrerequisites: LinkedHashSet[Dependency[A]] =
-    new LinkedHashSet() ++ optionalPrerequisites.toSet
+    new LinkedHashSet() ++ optionalPrerequisites
 
   /** All transforms that must run ''after'' this transform
     *
@@ -171,7 +171,7 @@ trait DependencyAPI[A <: DependencyAPI[A]] { this: TransformLike[_] =>
     */
   def optionalPrerequisiteOf: Seq[Dependency[A]] = dependents
   private[options] lazy val _optionalPrerequisiteOf: LinkedHashSet[Dependency[A]] =
-    new LinkedHashSet() ++ optionalPrerequisiteOf.toSet
+    new LinkedHashSet() ++ optionalPrerequisiteOf
 
   /** A function that, given *another* transform (parameter `a`) will return true if this transform invalidates/undos the
     * effects of the *other* transform (parameter `a`).


### PR DESCRIPTION
While working on https://github.com/freechipsproject/firrtl/pull/1665 I noticed that between different runs the results of `LoweringCompilersSpec` would change. Getting rid of these `.toSet` calls fixes the issue.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->
- bug fix

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
none

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
none

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
- Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
fix determinism bug in transform ordering

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
