### PR TITLE
RemoveIntervals: fixup kinds of refs to replaced nodes

### DIFF
--- a/src/main/scala/firrtl/passes/RemoveIntervals.scala
+++ b/src/main/scala/firrtl/passes/RemoveIntervals.scala
@@ -8,7 +8,7 @@ import firrtl._
 import firrtl.Mappers._
 import Implicits.{bigint2WInt}
 import firrtl.constraint.IsKnown
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 
 import scala.math.BigDecimal.RoundingMode._
 

--- a/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
+++ b/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
@@ -171,7 +171,9 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       Del(13),
       Add(12, Seq(Dependency(firrtl.passes.ResolveFlows),
                   Dependency[firrtl.passes.InferWidths])),
-      Del(14)
+      Del(14),
+      Add(15, Seq(Dependency(firrtl.passes.ResolveKinds),
+                  Dependency(firrtl.passes.InferTypes))),
     )
     compare(legacyTransforms(new HighFirrtlToMiddleFirrtl), tm, patches)
   }
@@ -349,7 +351,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
         Seq(new Transforms.LowToLow, new firrtl.MinimumVerilogEmitter)
     val tm = (new TransformManager(Seq(Dependency[firrtl.MinimumVerilogEmitter], Dependency[Transforms.LowToLow])))
     val patches = Seq(
-      Add(60, Seq(Dependency[firrtl.transforms.LegalizeAndReductionsTransform]))
+      Add(62, Seq(Dependency[firrtl.transforms.LegalizeAndReductionsTransform]))
     )
     compare(expected, tm, patches)
   }
@@ -360,7 +362,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
         Seq(new Transforms.LowToLow, new firrtl.VerilogEmitter)
     val tm = (new TransformManager(Seq(Dependency[firrtl.VerilogEmitter], Dependency[Transforms.LowToLow])))
     val patches = Seq(
-      Add(67, Seq(Dependency[firrtl.transforms.LegalizeAndReductionsTransform]))
+      Add(69, Seq(Dependency[firrtl.transforms.LegalizeAndReductionsTransform]))
     )
     compare(expected, tm, patches)
   }

--- a/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
+++ b/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
@@ -173,7 +173,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
                   Dependency[firrtl.passes.InferWidths])),
       Del(14),
       Add(15, Seq(Dependency(firrtl.passes.ResolveKinds),
-                  Dependency(firrtl.passes.InferTypes))),
+                  Dependency(firrtl.passes.InferTypes)))
     )
     compare(legacyTransforms(new HighFirrtlToMiddleFirrtl), tm, patches)
   }

--- a/src/test/scala/firrtlTests/interval/IntervalSpec.scala
+++ b/src/test/scala/firrtlTests/interval/IntervalSpec.scala
@@ -532,12 +532,15 @@ class IntervalSpec extends FirrtlFlatSpec {
   "RemoveIntervals" should "fixup kinds of replaced nodes" in {
     val passes = Seq(ToWorkingIR, new ResolveAndCheck, new RemoveIntervals)
     val input =
-      s"""circuit Unit :
-         |  module Unit :
+      s"""circuit Foo :
+         |  module Foo :
          |    input in: Interval[2, 3].3
          |    output out: Interval[2, 3].3
          |    node temp = in
          |    out <= temp
+         |  module Bar :
+         |    node temp = UInt<1>("h0")
+         |    node bar = temp
          |    """.stripMargin
       val removed = compile(input, passes)
       removed should be (ResolveKinds.run(removed))

--- a/src/test/scala/firrtlTests/interval/IntervalSpec.scala
+++ b/src/test/scala/firrtlTests/interval/IntervalSpec.scala
@@ -9,14 +9,11 @@ import firrtl.passes.CheckWidths.DisjointSqueeze
 import firrtl.testutils.FirrtlFlatSpec
 
 class IntervalSpec extends FirrtlFlatSpec {
-  private def compile(input: String, passes: Seq[Transform]): Circuit = {
-    passes.foldLeft(Parser.parse(input.split("\n").toIterator)) {
+  private def executeTest(input: String, expected: Seq[String], passes: Seq[Transform]) = {
+    val c = passes.foldLeft(Parser.parse(input.split("\n").toIterator)) {
       (c: Circuit, p: Transform) => 
         p.runTransform(CircuitState(c, UnknownForm, AnnotationSeq(Nil), None)).circuit
     }
-  }
-  private def executeTest(input: String, expected: Seq[String], passes: Seq[Transform]) = {
-    val c = compile(input, passes)
     val lines = c.serialize.split("\n") map normalized
 
     expected foreach { e =>
@@ -527,22 +524,5 @@ class IntervalSpec extends FirrtlFlatSpec {
       """.stripMargin
       compileToVerilog(input)
     }
-  }
-
-  "RemoveIntervals" should "fixup kinds of replaced nodes" in {
-    val passes = Seq(ToWorkingIR, new ResolveAndCheck, new RemoveIntervals)
-    val input =
-      s"""circuit Foo :
-         |  module Foo :
-         |    input in: Interval[2, 3].3
-         |    output out: Interval[2, 3].3
-         |    node temp = in
-         |    out <= temp
-         |  module Bar :
-         |    node temp = UInt<1>("h0")
-         |    node bar = temp
-         |    """.stripMargin
-      val removed = compile(input, passes)
-      removed should be (ResolveKinds.run(removed))
   }
 }


### PR DESCRIPTION
This updates `RemoveIntervals` so that it fixes up `WRef`s to the nodes that it replaced with wires. alternatively we could make `RemoveIntervals` invalidate `ResolveKinds`, but it's simple enough to fix it in `RemoveIntervals` since it needs to traverse through the expressions anyway and I didn't want to mess up `LoweringCompilersSpec`.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
none

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

none

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
- Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
fix bug in RemoveIntervals where refs to replaced nodes did not have the correct kind

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
