### PR TITLE
Deprecate PreservesAll Trait, Remove Usages

### DIFF
--- a/src/main/scala/firrtl/AddDescriptionNodes.scala
+++ b/src/main/scala/firrtl/AddDescriptionNodes.scala
@@ -5,7 +5,7 @@ package firrtl
 import firrtl.ir._
 import firrtl.annotations._
 import firrtl.Mappers._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 
 /**
   * A base trait for `Annotation`s that describe a `FirrtlNode`.
@@ -122,7 +122,7 @@ private case class DescribedMod(descriptions: Seq[Description],
   * @note should only be used by VerilogEmitter, described nodes will
   *       break other transforms.
   */
-class AddDescriptionNodes extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+class AddDescriptionNodes extends Transform with DependencyAPIMigration {
 
   override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
     Seq( Dependency[firrtl.transforms.BlackBoxSourceHelper],
@@ -140,6 +140,8 @@ class AddDescriptionNodes extends Transform with DependencyAPIMigration with Pre
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Transform) = false
 
   def onStmt(compMap: Map[String, Seq[Description]])(stmt: Statement): Statement = {
     val s = stmt.map(onStmt(compMap))

--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -13,7 +13,7 @@ import firrtl.annotations._
 import firrtl.ir.Circuit
 import firrtl.Utils.throwInternalError
 import firrtl.annotations.transforms.{EliminateTargetPaths, ResolvePaths}
-import firrtl.options.{DependencyAPI, Dependency, PreservesAll, StageUtils, TransformLike}
+import firrtl.options.{DependencyAPI, Dependency, StageUtils, TransformLike}
 import firrtl.stage.Forms
 
 /** Container of all annotations for a Firrtl compiler */
@@ -420,7 +420,10 @@ trait ResolvedAnnotationPaths {
 }
 
 /** Defines old API for Emission. Deprecated */
-trait Emitter extends Transform with PreservesAll[Transform] {
+trait Emitter extends Transform {
+
+  override def invalidates(a: Transform) = false
+
   @deprecated("Use emission annotations instead", "firrtl 1.0")
   def emit(state: CircuitState, writer: Writer): Unit
 

--- a/src/main/scala/firrtl/analyses/GetNamespace.scala
+++ b/src/main/scala/firrtl/analyses/GetNamespace.scala
@@ -4,7 +4,6 @@ package firrtl.analyses
 
 import firrtl.annotations.NoTargetAnnotation
 import firrtl.{CircuitState, DependencyAPIMigration, Namespace, Transform}
-import firrtl.options.PreservesAll
 import firrtl.stage.Forms
 
 case class ModuleNamespaceAnnotation(namespace: Namespace) extends NoTargetAnnotation
@@ -13,10 +12,11 @@ case class ModuleNamespaceAnnotation(namespace: Namespace) extends NoTargetAnnot
   *
   * namespace is used by RenameModules to get unique names
   */
-class GetNamespace extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+class GetNamespace extends Transform with DependencyAPIMigration {
   override def prerequisites = Forms.LowForm
   override def optionalPrerequisites = Seq.empty
   override def optionalPrerequisiteOf = Forms.LowEmitters
+  override def invalidates(a: Transform) = false
 
   def execute(state: CircuitState): CircuitState = {
     val namespace = Namespace(state.circuit)

--- a/src/main/scala/firrtl/annotations/transforms/EliminateTargetPaths.scala
+++ b/src/main/scala/firrtl/annotations/transforms/EliminateTargetPaths.scala
@@ -10,7 +10,6 @@ import firrtl.annotations.analysis.DuplicationHelper
 import firrtl.annotations._
 import firrtl.ir._
 import firrtl.{AnnotationSeq, CircuitState, DependencyAPIMigration, FirrtlInternalException, RenameMap, Transform}
-import firrtl.options.PreservesAll
 import firrtl.stage.Forms
 import firrtl.transforms.DedupedResult
 
@@ -102,12 +101,13 @@ object EliminateTargetPaths {
   * B/x -> (B/x, B_/x) // where x is any reference in B
   * C/x -> (C/x, C_/x) // where x is any reference in C
   */
-class EliminateTargetPaths extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+class EliminateTargetPaths extends Transform with DependencyAPIMigration {
   import EliminateTargetPaths._
 
   override def prerequisites = Forms.MinimalHighForm
   override def optionalPrerequisites = Seq.empty
   override def optionalPrerequisiteOf = Seq.empty
+  override def invalidates(a: Transform) = false
 
   /** Replaces old ofModules with new ofModules by calling dupMap methods
     * Updates oldUsedOfModules, newUsedOfModules

--- a/src/main/scala/firrtl/checks/CheckResets.scala
+++ b/src/main/scala/firrtl/checks/CheckResets.scala
@@ -3,7 +3,7 @@
 package firrtl.checks
 
 import firrtl._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 import firrtl.passes.{Errors, PassException}
 import firrtl.ir._
 import firrtl.Utils.isCast
@@ -28,7 +28,7 @@ object CheckResets {
 // Must run after ExpandWhens
 // Requires
 //   - static single connections of ground types
-class CheckResets extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+class CheckResets extends Transform with DependencyAPIMigration {
 
   override def prerequisites =
     Seq( Dependency(passes.LowerTypes),
@@ -38,6 +38,8 @@ class CheckResets extends Transform with DependencyAPIMigration with PreservesAl
   override def optionalPrerequisites = Seq(Dependency[firrtl.transforms.CheckCombLoops])
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Transform) = false
 
   import CheckResets._
 

--- a/src/main/scala/firrtl/options/Phase.scala
+++ b/src/main/scala/firrtl/options/Phase.scala
@@ -184,6 +184,8 @@ trait DependencyAPI[A <: DependencyAPI[A]] { this: TransformLike[_] =>
 /** A trait indicating that no invalidations occur, i.e., all previous transforms are preserved
   * @tparam A some [[TransformLike]]
   */
+@deprecated("Use an explicit `override def invalidates` returning false. This will be removed in FIRRTL 1.5.",
+            "FIRRTL 1.4")
 trait PreservesAll[A <: DependencyAPI[A]] { this: DependencyAPI[A] =>
 
   override final def invalidates(a: A): Boolean = false

--- a/src/main/scala/firrtl/options/phases/AddDefaults.scala
+++ b/src/main/scala/firrtl/options/phases/AddDefaults.scala
@@ -3,18 +3,20 @@
 package firrtl.options.phases
 
 import firrtl.AnnotationSeq
-import firrtl.options.{Dependency, Phase, PreservesAll, TargetDirAnnotation}
+import firrtl.options.{Dependency, Phase, TargetDirAnnotation}
 
 /** Add default annotations for a [[Stage]]
   *
   * This currently only adds a [[TargetDirAnnotation]]. This isn't necessary for a [[StageOptionsView]], but downstream
   * tools may expect a [[TargetDirAnnotation]] to exist.
   */
-class AddDefaults extends Phase with PreservesAll[Phase] {
+class AddDefaults extends Phase {
 
   override def prerequisites = Seq(Dependency[GetIncludes], Dependency[ConvertLegacyAnnotations])
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Phase) = false
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = {
     val td = annotations.collectFirst{ case a: TargetDirAnnotation => a}.isEmpty

--- a/src/main/scala/firrtl/options/phases/Checks.scala
+++ b/src/main/scala/firrtl/options/phases/Checks.scala
@@ -4,17 +4,19 @@ package firrtl.options.phases
 
 import firrtl.AnnotationSeq
 import firrtl.annotations.Annotation
-import firrtl.options.{OptionsException, OutputAnnotationFileAnnotation, Phase, PreservesAll, TargetDirAnnotation}
+import firrtl.options.{OptionsException, OutputAnnotationFileAnnotation, Phase, TargetDirAnnotation}
 import firrtl.options.Dependency
 
 /** [[firrtl.options.Phase Phase]] that validates an [[AnnotationSeq]]. If successful, views of this [[AnnotationSeq]]
   * as [[StageOptions]] are guaranteed to succeed.
   */
-class Checks extends Phase with PreservesAll[Phase] {
+class Checks extends Phase {
 
   override def prerequisites = Seq(Dependency[GetIncludes], Dependency[ConvertLegacyAnnotations], Dependency[AddDefaults])
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Phase) = false
 
   /** Validate an [[AnnotationSeq]] for [[StageOptions]]
     * @throws OptionsException if annotations are invalid

--- a/src/main/scala/firrtl/options/phases/ConvertLegacyAnnotations.scala
+++ b/src/main/scala/firrtl/options/phases/ConvertLegacyAnnotations.scala
@@ -4,14 +4,16 @@ package firrtl.options.phases
 
 import firrtl.AnnotationSeq
 import firrtl.annotations.LegacyAnnotation
-import firrtl.options.{Dependency, Phase, PreservesAll}
+import firrtl.options.{Dependency, Phase}
 
 /** Convert any [[firrtl.annotations.LegacyAnnotation LegacyAnnotation]]s to non-legacy variants */
-class ConvertLegacyAnnotations extends Phase with PreservesAll[Phase] {
+class ConvertLegacyAnnotations extends Phase {
 
   override def prerequisites = Seq(Dependency[GetIncludes])
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Phase) = false
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = LegacyAnnotation.convertLegacyAnnos(annotations)
 

--- a/src/main/scala/firrtl/options/phases/DeletedWrapper.scala
+++ b/src/main/scala/firrtl/options/phases/DeletedWrapper.scala
@@ -4,7 +4,7 @@ package firrtl.options.phases
 
 import firrtl.AnnotationSeq
 import firrtl.annotations.DeletedAnnotation
-import firrtl.options.{Phase, PreservesAll, Translator}
+import firrtl.options.{Phase, Translator}
 
 import scala.collection.mutable
 
@@ -12,12 +12,13 @@ import scala.collection.mutable
   * wrapped [[firrtl.options.Phase Phase]] will be added as [[firrtl.annotations.DeletedAnnotation DeletedAnnotation]]s.
   * @param p a [[firrtl.options.Phase Phase]] to wrap
   */
-class DeletedWrapper(p: Phase) extends Phase with Translator[AnnotationSeq, (AnnotationSeq, AnnotationSeq)]
-    with PreservesAll[Phase] {
+class DeletedWrapper(p: Phase) extends Phase with Translator[AnnotationSeq, (AnnotationSeq, AnnotationSeq)] {
 
   override def prerequisites = Seq.empty
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Phase) = false
 
   override lazy val name: String = p.name
 

--- a/src/main/scala/firrtl/options/phases/GetIncludes.scala
+++ b/src/main/scala/firrtl/options/phases/GetIncludes.scala
@@ -7,7 +7,7 @@ import net.jcazevedo.moultingyaml._
 import firrtl.AnnotationSeq
 import firrtl.annotations.{AnnotationFileNotFoundException, JsonProtocol, LegacyAnnotation}
 import firrtl.annotations.AnnotationYamlProtocol._
-import firrtl.options.{InputAnnotationFileAnnotation, Phase, PreservesAll, StageUtils}
+import firrtl.options.{InputAnnotationFileAnnotation, Phase, StageUtils}
 import firrtl.FileUtils
 
 import java.io.File
@@ -16,11 +16,13 @@ import scala.collection.mutable
 import scala.util.{Try, Failure}
 
 /** Recursively expand all [[InputAnnotationFileAnnotation]]s in an [[AnnotationSeq]] */
-class GetIncludes extends Phase with PreservesAll[Phase] {
+class GetIncludes extends Phase {
 
   override def prerequisites = Seq.empty
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Phase) = false
 
   /** Read all [[annotations.Annotation]] from a file in JSON or YAML format
     * @param filename a JSON or YAML file of [[annotations.Annotation]]

--- a/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
+++ b/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
@@ -4,7 +4,7 @@ package firrtl.options.phases
 
 import firrtl.AnnotationSeq
 import firrtl.annotations.{DeletedAnnotation, JsonProtocol}
-import firrtl.options.{Phase, PreservesAll, StageOptions, Unserializable, Viewer}
+import firrtl.options.{Phase, StageOptions, Unserializable, Viewer}
 import firrtl.options.Dependency
 
 import java.io.PrintWriter
@@ -12,7 +12,7 @@ import java.io.PrintWriter
 /** [[firrtl.options.Phase Phase]] that writes an [[AnnotationSeq]] to a file. A file is written if and only if a
   * [[StageOptions]] view has a non-empty [[StageOptions.annotationFileOut annotationFileOut]].
   */
-class WriteOutputAnnotations extends Phase with PreservesAll[Phase] {
+class WriteOutputAnnotations extends Phase {
 
   override def prerequisites =
     Seq( Dependency[GetIncludes],
@@ -21,6 +21,8 @@ class WriteOutputAnnotations extends Phase with PreservesAll[Phase] {
          Dependency[Checks] )
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Phase) = false
 
   /** Write the input [[AnnotationSeq]] to a fie. */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/passes/CInferMDir.scala
+++ b/src/main/scala/firrtl/passes/CInferMDir.scala
@@ -5,12 +5,14 @@ package firrtl.passes
 import firrtl._
 import firrtl.ir._
 import firrtl.Mappers._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 import Utils.throwInternalError
 
-object CInferMDir extends Pass with PreservesAll[Transform] {
+object CInferMDir extends Pass {
 
   override def prerequisites = firrtl.stage.Forms.ChirrtlForm :+ Dependency(CInferTypes)
+
+  override def invalidates(a: Transform) = false
 
   type MPortDirMap = collection.mutable.LinkedHashMap[String, MPortDir]
 

--- a/src/main/scala/firrtl/passes/CheckChirrtl.scala
+++ b/src/main/scala/firrtl/passes/CheckChirrtl.scala
@@ -4,14 +4,16 @@ package firrtl.passes
 
 import firrtl.Transform
 import firrtl.ir._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 
-object CheckChirrtl extends Pass with CheckHighFormLike with PreservesAll[Transform] {
+object CheckChirrtl extends Pass with CheckHighFormLike {
 
   override val optionalPrerequisiteOf = firrtl.stage.Forms.ChirrtlForm ++
     Seq( Dependency(CInferTypes),
          Dependency(CInferMDir),
          Dependency(RemoveCHIRRTL) )
+
+  override def invalidates(a: Transform) = false
 
   def errorOnChirrtl(info: Info, mname: String, s: Statement): Option[PassException] = None
 }

--- a/src/main/scala/firrtl/passes/CheckFlows.scala
+++ b/src/main/scala/firrtl/passes/CheckFlows.scala
@@ -6,9 +6,9 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.traversals.Foreachers._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 
-object CheckFlows extends Pass with PreservesAll[Transform] {
+object CheckFlows extends Pass {
 
   override def prerequisites = Dependency(passes.ResolveFlows) +: firrtl.stage.Forms.WorkingIR
 
@@ -17,6 +17,8 @@ object CheckFlows extends Pass with PreservesAll[Transform] {
          Dependency[passes.TrimIntervals],
          Dependency[passes.InferWidths],
          Dependency[transforms.InferResets] )
+
+  override def invalidates(a: Transform) = false
 
   type FlowMap = collection.mutable.HashMap[String, Flow]
 

--- a/src/main/scala/firrtl/passes/CheckHighForm.scala
+++ b/src/main/scala/firrtl/passes/CheckHighForm.scala
@@ -7,7 +7,7 @@ import firrtl.ir._
 import firrtl.PrimOps._
 import firrtl.Utils._
 import firrtl.traversals.Foreachers._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 
 trait CheckHighFormLike { this: Pass =>
   type NameSet = collection.mutable.HashSet[String]
@@ -280,7 +280,7 @@ trait CheckHighFormLike { this: Pass =>
   }
 }
 
-object CheckHighForm extends Pass with CheckHighFormLike with PreservesAll[Transform] {
+object CheckHighForm extends Pass with CheckHighFormLike {
 
   override def prerequisites = firrtl.stage.Forms.WorkingIR
 
@@ -291,6 +291,8 @@ object CheckHighForm extends Pass with CheckHighFormLike with PreservesAll[Trans
          Dependency(passes.ResolveFlows),
          Dependency[passes.InferWidths],
          Dependency[transforms.InferResets] )
+
+  override def invalidates(a: Transform) = false
 
   class IllegalChirrtlMemException(info: Info, mname: String, name: String) extends PassException(
     s"$info: [module $mname] Memory $name has not been properly lowered from Chirrtl IR.")

--- a/src/main/scala/firrtl/passes/CheckInitialization.scala
+++ b/src/main/scala/firrtl/passes/CheckInitialization.scala
@@ -6,7 +6,6 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.traversals.Foreachers._
-import firrtl.options.PreservesAll
 
 import annotation.tailrec
 
@@ -15,9 +14,11 @@ import annotation.tailrec
   * @note This pass looks for [[firrtl.WVoid]]s left behind by [[ExpandWhens]]
   * @note Assumes single connection (ie. no last connect semantics)
   */
-object CheckInitialization extends Pass with PreservesAll[Transform] {
+object CheckInitialization extends Pass {
 
   override def prerequisites = firrtl.stage.Forms.Resolved
+
+  override def invalidates(a: Transform) = false
 
   private case class VoidExpr(stmt: Statement, voidDeps: Seq[Expression])
 

--- a/src/main/scala/firrtl/passes/CheckTypes.scala
+++ b/src/main/scala/firrtl/passes/CheckTypes.scala
@@ -9,9 +9,9 @@ import firrtl.Utils._
 import firrtl.traversals.Foreachers._
 import firrtl.WrappedType._
 import firrtl.constraint.{Constraint, IsKnown}
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 
-object CheckTypes extends Pass with PreservesAll[Transform] {
+object CheckTypes extends Pass {
 
   override def prerequisites = Dependency(InferTypes) +: firrtl.stage.Forms.WorkingIR
 
@@ -21,6 +21,8 @@ object CheckTypes extends Pass with PreservesAll[Transform] {
          Dependency(passes.CheckFlows),
          Dependency[passes.InferWidths],
          Dependency(passes.CheckWidths) )
+
+  override def invalidates(a: Transform) = false
 
   // Custom Exceptions
   class SubfieldNotInBundle(info: Info, mname: String, name: String) extends PassException(

--- a/src/main/scala/firrtl/passes/CheckWidths.scala
+++ b/src/main/scala/firrtl/passes/CheckWidths.scala
@@ -9,13 +9,15 @@ import firrtl.traversals.Foreachers._
 import firrtl.Utils._
 import firrtl.constraint.IsKnown
 import firrtl.annotations.{CircuitTarget, ModuleTarget, Target, TargetToken}
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 
-object CheckWidths extends Pass with PreservesAll[Transform] {
+object CheckWidths extends Pass {
 
   override def prerequisites = Dependency[passes.InferWidths] +: firrtl.stage.Forms.WorkingIR
 
   override def optionalPrerequisiteOf = Seq(Dependency[transforms.InferResets])
+
+  override def invalidates(a: Transform) = false
 
   /** The maximum allowed width for any circuit element */
   val MaxWidth = 1000000

--- a/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
+++ b/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
@@ -5,9 +5,9 @@ package firrtl.passes
 import firrtl._
 import firrtl.ir._
 import firrtl.Mappers._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 
-object CommonSubexpressionElimination extends Pass with PreservesAll[Transform] {
+object CommonSubexpressionElimination extends Pass {
 
   override def prerequisites = firrtl.stage.Forms.LowForm ++
     Seq( Dependency(firrtl.passes.RemoveValidIf),
@@ -19,6 +19,8 @@ object CommonSubexpressionElimination extends Pass with PreservesAll[Transform] 
   override def optionalPrerequisiteOf =
     Seq( Dependency[SystemVerilogEmitter],
          Dependency[VerilogEmitter] )
+
+  override def invalidates(a: Transform) = false
 
   private def cse(s: Statement): Statement = {
     val expressions = collection.mutable.HashMap[MemoizedHash[Expression], String]()

--- a/src/main/scala/firrtl/passes/ConvertFixedToSInt.scala
+++ b/src/main/scala/firrtl/passes/ConvertFixedToSInt.scala
@@ -8,11 +8,11 @@ import firrtl.ir._
 import firrtl._
 import firrtl.Mappers._
 import firrtl.Utils.{sub_type, module_type, field_type, max, throwInternalError}
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 
 /** Replaces FixedType with SIntType, and correctly aligns all binary points
   */
-object ConvertFixedToSInt extends Pass with PreservesAll[Transform] {
+object ConvertFixedToSInt extends Pass {
 
   override def prerequisites =
     Seq( Dependency(PullMuxes),
@@ -21,6 +21,8 @@ object ConvertFixedToSInt extends Pass with PreservesAll[Transform] {
          Dependency(RemoveAccesses),
          Dependency[ExpandWhensAndCheck],
          Dependency[RemoveIntervals] ) ++ firrtl.stage.Forms.Deduped
+
+  override def invalidates(a: Transform) = false
 
   def alignArg(e: Expression, point: BigInt): Expression = e.tpe match {
     case FixedType(IntWidth(w), IntWidth(p)) => // assert(point >= p)

--- a/src/main/scala/firrtl/passes/InferBinaryPoints.scala
+++ b/src/main/scala/firrtl/passes/InferBinaryPoints.scala
@@ -8,9 +8,9 @@ import firrtl.Mappers._
 import firrtl.annotations.{CircuitTarget, ModuleTarget, ReferenceTarget, Target}
 import firrtl.constraint.ConstraintSolver
 import firrtl.Transform
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 
-class InferBinaryPoints extends Pass with PreservesAll[Transform] {
+class InferBinaryPoints extends Pass {
 
   override def prerequisites =
     Seq( Dependency(ResolveKinds),
@@ -19,6 +19,8 @@ class InferBinaryPoints extends Pass with PreservesAll[Transform] {
          Dependency(ResolveFlows) )
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Transform) = false
 
   private val constraintSolver = new ConstraintSolver()
 

--- a/src/main/scala/firrtl/passes/InferTypes.scala
+++ b/src/main/scala/firrtl/passes/InferTypes.scala
@@ -6,11 +6,12 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 
-object InferTypes extends Pass with PreservesAll[Transform] {
+object InferTypes extends Pass {
 
   override def prerequisites = Dependency(ResolveKinds) +: firrtl.stage.Forms.WorkingIR
+  override def invalidates(a: Transform) = false
 
   @deprecated("This should never have been public", "1.3.2")
   type TypeMap = collection.mutable.LinkedHashMap[String, Type]
@@ -91,9 +92,10 @@ object InferTypes extends Pass with PreservesAll[Transform] {
   }
 }
 
-object CInferTypes extends Pass with PreservesAll[Transform] {
+object CInferTypes extends Pass {
 
   override def prerequisites = firrtl.stage.Forms.ChirrtlForm
+  override def invalidates(a: Transform) = false
 
   @deprecated("This should never have been public", "1.3.2")
   type TypeMap = collection.mutable.LinkedHashMap[String, Type]

--- a/src/main/scala/firrtl/passes/InferWidths.scala
+++ b/src/main/scala/firrtl/passes/InferWidths.scala
@@ -10,7 +10,7 @@ import firrtl._
 import firrtl.annotations._
 import firrtl.constraint.{ConstraintSolver, IsMax}
 import firrtl.ir._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 
 object InferWidths {
   def apply(): InferWidths = new InferWidths()
@@ -62,8 +62,7 @@ case class WidthGeqConstraintAnnotation(loc: ReferenceTarget, exp: ReferenceTarg
   */
 class InferWidths extends Transform
     with ResolvedAnnotationPaths
-    with DependencyAPIMigration
-    with PreservesAll[Transform] {
+    with DependencyAPIMigration {
 
   override def prerequisites =
     Seq( Dependency(passes.ResolveKinds),
@@ -72,6 +71,7 @@ class InferWidths extends Transform
          Dependency(passes.ResolveFlows),
          Dependency[passes.InferBinaryPoints],
          Dependency[passes.TrimIntervals] ) ++ firrtl.stage.Forms.WorkingIR
+  override def invalidates(a: Transform) = false
 
   private val constraintSolver = new ConstraintSolver()
 

--- a/src/main/scala/firrtl/passes/Legalize.scala
+++ b/src/main/scala/firrtl/passes/Legalize.scala
@@ -3,20 +3,22 @@ package firrtl.passes
 import firrtl.PrimOps._
 import firrtl.Utils.{BoolType, error, zero}
 import firrtl.ir._
-import firrtl.options.{PreservesAll, Dependency}
+import firrtl.options.Dependency
 import firrtl.transforms.ConstantPropagation
 import firrtl.{Transform, bitWidth}
 import firrtl.Mappers._
 
 // Replace shr by amount >= arg width with 0 for UInts and MSB for SInts
 // TODO replace UInt with zero-width wire instead
-object Legalize extends Pass with PreservesAll[Transform] {
+object Legalize extends Pass {
 
   override def prerequisites = firrtl.stage.Forms.MidForm :+ Dependency(LowerTypes)
 
   override def optionalPrerequisites = Seq.empty
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Transform) = false
 
   private def legalizeShiftRight(e: DoPrim): Expression = {
     require(e.op == Shr)

--- a/src/main/scala/firrtl/passes/PullMuxes.scala
+++ b/src/main/scala/firrtl/passes/PullMuxes.scala
@@ -2,12 +2,13 @@ package firrtl.passes
 
 import firrtl.ir._
 import firrtl.Mappers._
-import firrtl.options.PreservesAll
 import firrtl.{Transform, WSubAccess, WSubField, WSubIndex}
 
-object PullMuxes extends Pass with PreservesAll[Transform] {
+object PullMuxes extends Pass {
 
   override def prerequisites = firrtl.stage.Forms.Deduped
+
+  override def invalidates(a: Transform) = false
 
   def run(c: Circuit): Circuit = {
      def pull_muxes_e(e: Expression): Expression = e map pull_muxes_e match {

--- a/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
+++ b/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
@@ -8,17 +8,19 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 
 case class MPort(name: String, clk: Expression)
 case class MPorts(readers: ArrayBuffer[MPort], writers: ArrayBuffer[MPort], readwriters: ArrayBuffer[MPort])
 case class DataRef(exp: Expression, male: String, female: String, mask: String, rdwrite: Boolean)
 
-object RemoveCHIRRTL extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+object RemoveCHIRRTL extends Transform with DependencyAPIMigration {
 
   override def prerequisites = firrtl.stage.Forms.ChirrtlForm ++
     Seq( Dependency(passes.CInferTypes),
          Dependency(passes.CInferMDir) )
+
+  override def invalidates(a: Transform) = false
 
   val ut = UnknownType
   type MPortMap = collection.mutable.LinkedHashMap[String, MPorts]

--- a/src/main/scala/firrtl/passes/RemoveEmpty.scala
+++ b/src/main/scala/firrtl/passes/RemoveEmpty.scala
@@ -4,14 +4,14 @@ package firrtl
 package passes
 
 import firrtl.ir._
-import firrtl.options.PreservesAll
 import firrtl.stage.Forms
 
-object RemoveEmpty extends Pass with DependencyAPIMigration with PreservesAll[Transform] {
+object RemoveEmpty extends Pass with DependencyAPIMigration {
 
   override def prerequisites = Seq.empty
   override def optionalPrerequisites = Forms.LowFormOptimized
   override def optionalPrerequisiteOf = Forms.ChirrtlEmitters
+  override def invalidates(a: Transform) = false
 
   private def onModule(m: DefModule): DefModule = {
     m match {

--- a/src/main/scala/firrtl/passes/ReplaceAccesses.scala
+++ b/src/main/scala/firrtl/passes/ReplaceAccesses.scala
@@ -6,14 +6,16 @@ import firrtl.Transform
 import firrtl.ir._
 import firrtl.{WSubAccess, WSubIndex}
 import firrtl.Mappers._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 
 /** Replaces constant [[firrtl.WSubAccess]] with [[firrtl.WSubIndex]]
   * TODO Fold in to High Firrtl Const Prop
   */
-object ReplaceAccesses extends Pass with PreservesAll[Transform] {
+object ReplaceAccesses extends Pass {
 
   override def prerequisites = firrtl.stage.Forms.Deduped :+ Dependency(PullMuxes)
+
+  override def invalidates(a: Transform) = false
 
   def run(c: Circuit): Circuit = {
     def onStmt(s: Statement): Statement = s map onStmt map onExp

--- a/src/main/scala/firrtl/passes/ResolveFlows.scala
+++ b/src/main/scala/firrtl/passes/ResolveFlows.scala
@@ -5,14 +5,16 @@ package firrtl.passes
 import firrtl._
 import firrtl.ir._
 import firrtl.Mappers._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 
-object ResolveFlows extends Pass with PreservesAll[Transform] {
+object ResolveFlows extends Pass {
 
   override def prerequisites =
     Seq( Dependency(passes.ResolveKinds),
          Dependency(passes.InferTypes),
          Dependency(passes.Uniquify) ) ++ firrtl.stage.Forms.WorkingIR
+
+  override def invalidates(a: Transform) = false
 
   def resolve_e(g: Flow)(e: Expression): Expression = e match {
     case ex: WRef => ex copy (flow = g)

--- a/src/main/scala/firrtl/passes/ResolveKinds.scala
+++ b/src/main/scala/firrtl/passes/ResolveKinds.scala
@@ -6,11 +6,12 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.traversals.Foreachers._
-import firrtl.options.PreservesAll
 
-object ResolveKinds extends Pass with PreservesAll[Transform] {
+object ResolveKinds extends Pass {
 
   override def prerequisites = firrtl.stage.Forms.WorkingIR
+
+  override def invalidates(a: Transform) = false
 
   type KindMap = collection.mutable.HashMap[String, Kind]
 
@@ -45,4 +46,3 @@ object ResolveKinds extends Pass with PreservesAll[Transform] {
   def run(c: Circuit): Circuit =
     c copy (modules = c.modules map resolve_kinds)
 }
-

--- a/src/main/scala/firrtl/passes/ToWorkingIR.scala
+++ b/src/main/scala/firrtl/passes/ToWorkingIR.scala
@@ -1,10 +1,10 @@
 package firrtl.passes
 
 import firrtl.ir._
-import firrtl.options.PreservesAll
 import firrtl.Transform
 
-object ToWorkingIR extends Pass with PreservesAll[Transform] {
+object ToWorkingIR extends Pass {
   override def prerequisites = firrtl.stage.Forms.MinimalHighForm
+  override def invalidates(a: Transform) = false
   def run(c:Circuit): Circuit = c
 }

--- a/src/main/scala/firrtl/passes/TrimIntervals.scala
+++ b/src/main/scala/firrtl/passes/TrimIntervals.scala
@@ -6,7 +6,7 @@ import firrtl.PrimOps._
 import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.constraint.{IsFloor, IsKnown, IsMul}
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 import firrtl.Transform
 
 /** Replaces IntervalType with SIntType, three AST walks:
@@ -20,7 +20,7 @@ import firrtl.Transform
   *      c. replace with SIntType
   * 3) Run InferTypes
   */
-class TrimIntervals extends Pass with PreservesAll[Transform] {
+class TrimIntervals extends Pass {
 
   override def prerequisites =
     Seq( Dependency(ResolveKinds),
@@ -30,6 +30,8 @@ class TrimIntervals extends Pass with PreservesAll[Transform] {
          Dependency[InferBinaryPoints] )
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Transform) = false
 
   def run(c: Circuit): Circuit = {
     // Open -> closed

--- a/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
+++ b/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
@@ -7,7 +7,7 @@ import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.PrimOps.{Bits, Rem}
 import firrtl.Utils._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 
 import scala.collection.mutable
 
@@ -24,7 +24,7 @@ import scala.collection.mutable
  *  This is technically incorrect firrtl, but allows the verilog emitter
  *  to emit correct verilog without needing to add temporary nodes
  */
-object VerilogModulusCleanup extends Pass with PreservesAll[Transform] {
+object VerilogModulusCleanup extends Pass {
 
   override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
     Seq( Dependency[firrtl.transforms.BlackBoxSourceHelper],
@@ -38,6 +38,8 @@ object VerilogModulusCleanup extends Pass with PreservesAll[Transform] {
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Transform) = false
 
   private def onModule(m: Module): Module = {
     val namespace = Namespace(m)

--- a/src/main/scala/firrtl/passes/VerilogPrep.scala
+++ b/src/main/scala/firrtl/passes/VerilogPrep.scala
@@ -3,7 +3,7 @@ package firrtl.passes
 import firrtl.Utils.{create_exps, flow, kind, toWrappedExpression}
 import firrtl.ir._
 import firrtl.Mappers._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 import firrtl._
 
 import scala.collection.mutable
@@ -18,7 +18,7 @@ import scala.collection.mutable
   *
   * @note The result of this pass is NOT legal Firrtl
   */
-object VerilogPrep extends Pass with PreservesAll[Transform] {
+object VerilogPrep extends Pass {
 
   override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
     Seq( Dependency[firrtl.transforms.BlackBoxSourceHelper],
@@ -34,6 +34,8 @@ object VerilogPrep extends Pass with PreservesAll[Transform] {
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Transform) = false
 
   type AttachSourceMap = Map[WrappedExpression, Expression]
 

--- a/src/main/scala/firrtl/passes/ZeroLengthVecs.scala
+++ b/src/main/scala/firrtl/passes/ZeroLengthVecs.scala
@@ -6,7 +6,7 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.PrimOps._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 
 /** Handles dynamic accesses to zero-length vectors.
   *
@@ -15,12 +15,14 @@ import firrtl.options.{Dependency, PreservesAll}
   * @note Removes attaches that become degenerate after zero-length-accessor removal
   * @note Replaces "source" references to elements of zero-length vectors with always-invalid validif
   */
-object ZeroLengthVecs extends Pass with PreservesAll[Transform] {
+object ZeroLengthVecs extends Pass {
   override def prerequisites =
     Seq( Dependency(PullMuxes),
          Dependency(ResolveKinds),
          Dependency(InferTypes),
          Dependency(ExpandConnects) )
+
+  override def invalidates(a: Transform) = false
 
   // Pass in an expression, not just a type, since it's not possible to generate an expression of
   // interval type with the type alone unless you declare a component

--- a/src/main/scala/firrtl/passes/memlib/DecorateMems.scala
+++ b/src/main/scala/firrtl/passes/memlib/DecorateMems.scala
@@ -4,16 +4,14 @@ package firrtl
 package passes
 package memlib
 
-import firrtl.options.PreservesAll
 import firrtl.stage.Forms
 
-class CreateMemoryAnnotations(reader: Option[YamlFileReader]) extends Transform
-    with DependencyAPIMigration
-    with PreservesAll[Transform] {
+class CreateMemoryAnnotations(reader: Option[YamlFileReader]) extends Transform with DependencyAPIMigration {
 
   override def prerequisites = Forms.MidForm
   override def optionalPrerequisites = Seq.empty
   override def optionalPrerequisiteOf = Forms.MidEmitters
+  override def invalidates(a: Transform) = false
 
   def execute(state: CircuitState): CircuitState = reader match {
     case None => state

--- a/src/main/scala/firrtl/passes/memlib/InferReadWrite.scala
+++ b/src/main/scala/firrtl/passes/memlib/InferReadWrite.scala
@@ -8,7 +8,7 @@ import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.PrimOps._
 import firrtl.Utils.{one, zero, BoolType}
-import firrtl.options.{HasShellOptions, PreservesAll, ShellOption}
+import firrtl.options.{HasShellOptions, ShellOption}
 import MemPortUtils.memPortField
 import firrtl.passes.memlib.AnalysisUtils.{Connects, getConnects, getOrigin}
 import WrappedExpression.weq
@@ -146,13 +146,13 @@ object InferReadWritePass extends Pass {
 // To use this transform, circuit name should be annotated with its TransId.
 class InferReadWrite extends Transform
     with DependencyAPIMigration
-    with PreservesAll[Transform]
     with SeqTransformBased
     with HasShellOptions {
 
   override def prerequisites = Forms.MidForm
   override def optionalPrerequisites = Seq.empty
   override def optionalPrerequisiteOf = Forms.MidEmitters
+  override def invalidates(a: Transform) = false
 
   val options = Seq(
     new ShellOption[Unit](

--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemMacros.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemMacros.scala
@@ -10,7 +10,6 @@ import firrtl.Mappers._
 import MemPortUtils.{MemPortMap, Modules}
 import MemTransformUtils._
 import firrtl.annotations._
-import firrtl.options.PreservesAll
 import firrtl.stage.Forms
 import wiring._
 
@@ -26,11 +25,12 @@ object ReplaceMemMacros {
   * This will not generate wmask ports if not needed.
   * Creates the minimum # of black boxes needed by the design.
   */
-class ReplaceMemMacros(writer: ConfWriter) extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+class ReplaceMemMacros(writer: ConfWriter) extends Transform with DependencyAPIMigration {
 
   override def prerequisites = Forms.MidForm
   override def optionalPrerequisites = Seq.empty
   override def optionalPrerequisiteOf = Forms.MidEmitters
+  override def invalidates(a: Transform) = false
 
   /** Return true if mask granularity is per bit, false if per byte or unspecified
     */

--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
@@ -5,7 +5,7 @@ package memlib
 
 import firrtl._
 import firrtl.annotations._
-import firrtl.options.{HasShellOptions, PreservesAll, ShellOption}
+import firrtl.options.{HasShellOptions, ShellOption}
 import Utils.error
 import java.io.{File, CharArrayWriter, PrintWriter}
 import wiring._
@@ -103,11 +103,12 @@ class SimpleTransform(p: Pass, form: CircuitForm) extends Transform {
 class SimpleMidTransform(p: Pass) extends SimpleTransform(p, MidForm)
 
 // SimpleRun instead of PassBased because of the arguments to passSeq
-class ReplSeqMem extends Transform with HasShellOptions with DependencyAPIMigration with PreservesAll[Transform] {
+class ReplSeqMem extends Transform with HasShellOptions with DependencyAPIMigration {
 
   override def prerequisites = Forms.MidForm
   override def optionalPrerequisites = Seq.empty
   override def optionalPrerequisiteOf = Forms.MidEmitters
+  override def invalidates(a: Transform) = false
 
   val options = Seq(
     new ShellOption[String](

--- a/src/main/scala/firrtl/passes/memlib/ResolveMemoryReference.scala
+++ b/src/main/scala/firrtl/passes/memlib/ResolveMemoryReference.scala
@@ -6,7 +6,6 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.annotations._
-import firrtl.options.PreservesAll
 import firrtl.stage.Forms
 
 /** A component, e.g. register etc. Must be declared only once under the TopAnnotation */
@@ -16,11 +15,12 @@ case class NoDedupMemAnnotation(target: ComponentName) extends SingleTargetAnnot
 
 /** Resolves annotation ref to memories that exactly match (except name) another memory
  */
-class ResolveMemoryReference extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+class ResolveMemoryReference extends Transform with DependencyAPIMigration {
 
   override def prerequisites = Forms.MidForm
   override def optionalPrerequisites = Seq.empty
   override def optionalPrerequisiteOf = Forms.MidEmitters
+  override def invalidates(a: Transform) = false
 
   /** Helper class for determining when two memories are equivalent while igoring
     * irrelevant details like name and info

--- a/src/main/scala/firrtl/stage/FirrtlStage.scala
+++ b/src/main/scala/firrtl/stage/FirrtlStage.scala
@@ -3,13 +3,15 @@
 package firrtl.stage
 
 import firrtl.AnnotationSeq
-import firrtl.options.{Dependency, Phase, PhaseManager, PreservesAll, Shell, Stage, StageMain}
+import firrtl.options.{Dependency, Phase, PhaseManager, Shell, Stage, StageMain}
 import firrtl.options.phases.DeletedWrapper
 import firrtl.stage.phases.CatchExceptions
 
 class FirrtlPhase
-    extends PhaseManager(targets=Seq(Dependency[firrtl.stage.phases.Compiler], Dependency[firrtl.stage.phases.WriteEmitted]))
-    with PreservesAll[Phase] {
+    extends PhaseManager(targets=Seq(Dependency[firrtl.stage.phases.Compiler],
+                                     Dependency[firrtl.stage.phases.WriteEmitted])) {
+
+  override def invalidates(a: Phase) = false
 
   override val wrappers = Seq(CatchExceptions(_: Phase), DeletedWrapper(_: Phase))
 

--- a/src/main/scala/firrtl/stage/phases/AddCircuit.scala
+++ b/src/main/scala/firrtl/stage/phases/AddCircuit.scala
@@ -5,7 +5,7 @@ package firrtl.stage.phases
 import firrtl.stage._
 
 import firrtl.{AnnotationSeq, Parser}
-import firrtl.options.{Dependency, Phase, PhasePrerequisiteException, PreservesAll}
+import firrtl.options.{Dependency, Phase, PhasePrerequisiteException}
 
 /** [[firrtl.options.Phase Phase]] that expands [[FirrtlFileAnnotation]]/[[FirrtlSourceAnnotation]] into
   * [[FirrtlCircuitAnnotation]]s and deletes the originals. This is part of the preprocessing done on an input
@@ -25,11 +25,13 @@ import firrtl.options.{Dependency, Phase, PhasePrerequisiteException, PreservesA
   * an [[InfoModeAnnotation]].'''.
   * @define infoModeException firrtl.options.PhasePrerequisiteException if no [[InfoModeAnnotation]] is present
   */
-class AddCircuit extends Phase with PreservesAll[Phase] {
+class AddCircuit extends Phase {
 
   override val prerequisites = Seq(Dependency[AddDefaults], Dependency[Checks])
 
   override val optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Phase) = false
 
   /** Extract the info mode from an [[AnnotationSeq]] or use the default info mode if no annotation exists
     * @param annotations some annotations

--- a/src/main/scala/firrtl/stage/phases/AddDefaults.scala
+++ b/src/main/scala/firrtl/stage/phases/AddDefaults.scala
@@ -3,18 +3,20 @@
 package firrtl.stage.phases
 
 import firrtl.AnnotationSeq
-import firrtl.options.{Phase, PreservesAll, TargetDirAnnotation}
+import firrtl.options.{Phase, TargetDirAnnotation}
 import firrtl.transforms.BlackBoxTargetDirAnno
 import firrtl.stage.{CompilerAnnotation, InfoModeAnnotation, FirrtlOptions}
 
 /** [[firrtl.options.Phase Phase]] that adds default [[FirrtlOption]] [[firrtl.annotations.Annotation Annotation]]s.
   * This is a part of the preprocessing done by [[FirrtlStage]].
   */
-class AddDefaults extends Phase with PreservesAll[Phase] {
+class AddDefaults extends Phase {
 
   override def prerequisites = Seq.empty
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Phase) = false
 
   /** Append any missing default annotations to an annotation sequence */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/stage/phases/AddImplicitEmitter.scala
+++ b/src/main/scala/firrtl/stage/phases/AddImplicitEmitter.scala
@@ -4,16 +4,18 @@ package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, EmitAnnotation, EmitCircuitAnnotation}
 import firrtl.stage.{CompilerAnnotation, RunFirrtlTransformAnnotation}
-import firrtl.options.{Dependency, Phase, PreservesAll}
+import firrtl.options.{Dependency, Phase}
 
 /** [[firrtl.options.Phase Phase]] that adds a [[firrtl.EmitCircuitAnnotation EmitCircuitAnnotation]] derived from a
   * [[firrtl.stage.CompilerAnnotation CompilerAnnotation]] if one does not already exist.
   */
-class AddImplicitEmitter extends Phase with PreservesAll[Phase] {
+class AddImplicitEmitter extends Phase {
 
   override def prerequisites = Seq(Dependency[AddDefaults])
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Phase) = false
 
   def transform(annos: AnnotationSeq): AnnotationSeq = {
     val emitter = annos.collectFirst{ case a: EmitAnnotation => a }

--- a/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
+++ b/src/main/scala/firrtl/stage/phases/AddImplicitOutputFile.scala
@@ -3,7 +3,7 @@
 package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, EmitAllModulesAnnotation}
-import firrtl.options.{Dependency, Phase, PreservesAll, Viewer}
+import firrtl.options.{Dependency, Phase, Viewer}
 import firrtl.stage.{FirrtlOptions, OutputFileAnnotation}
 
 /** [[firrtl.options.Phase Phase]] that adds an [[OutputFileAnnotation]] if one does not already exist.
@@ -20,11 +20,13 @@ import firrtl.stage.{FirrtlOptions, OutputFileAnnotation}
   * [[firrtl.stage.FirrtlCircuitAnnotation FirrtlCircuitAnnotation]] will be used to implicitly set the
   * [[OutputFileAnnotation]] (not other [[firrtl.stage.CircuitOption CircuitOption]] subclasses).
   */
-class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
+class AddImplicitOutputFile extends Phase {
 
   override def prerequisites = Seq(Dependency[AddCircuit])
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Phase) = false
 
   /** Add an [[OutputFileAnnotation]] to an [[AnnotationSeq]] */
   def transform(annotations: AnnotationSeq): AnnotationSeq =

--- a/src/main/scala/firrtl/stage/phases/Checks.scala
+++ b/src/main/scala/firrtl/stage/phases/Checks.scala
@@ -6,7 +6,7 @@ import firrtl.stage._
 
 import firrtl.{AnnotationSeq, EmitAllModulesAnnotation, EmitCircuitAnnotation}
 import firrtl.annotations.Annotation
-import firrtl.options.{Dependency, OptionsException, Phase, PreservesAll}
+import firrtl.options.{Dependency, OptionsException, Phase}
 
 /** [[firrtl.options.Phase Phase]] that strictly validates an [[AnnotationSeq]]. The checks applied are intended to be
   * extremeley strict. Nothing is inferred or assumed to take a default value (for default value resolution see
@@ -16,11 +16,13 @@ import firrtl.options.{Dependency, OptionsException, Phase, PreservesAll}
   * certain that other [[firrtl.options.Phase Phase]]s or views will succeed. See [[FirrtlStage]] for a list of
   * [[firrtl.options.Phase Phase]] that commonly run before this.
   */
-class Checks extends Phase with PreservesAll[Phase] {
+class Checks extends Phase {
 
   override val prerequisites = Seq(Dependency[AddDefaults], Dependency[AddImplicitEmitter])
 
   override val optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Phase) = false
 
   /** Determine if annotations are sane
     *

--- a/src/main/scala/firrtl/stage/phases/Compiler.scala
+++ b/src/main/scala/firrtl/stage/phases/Compiler.scala
@@ -3,7 +3,7 @@
 package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, ChirrtlForm, CircuitState, Compiler => FirrtlCompiler, Transform, seqToAnnoSeq}
-import firrtl.options.{Dependency, Phase, PhasePrerequisiteException, PreservesAll, Translator}
+import firrtl.options.{Dependency, Phase, PhasePrerequisiteException, Translator}
 import firrtl.stage.{CompilerAnnotation, FirrtlCircuitAnnotation, Forms, RunFirrtlTransformAnnotation}
 import firrtl.stage.TransformManager.TransformDependency
 
@@ -42,7 +42,7 @@ private [stage] case class Defaults(
   * FirrtlCircuitAnnotation(y). Note: A(b) ''may'' overwrite A(a) if this is a CompilerAnnotation.
   * FirrtlCircuitAnnotation(z) has no annotations, so it only gets the default A(a).
   */
-class Compiler extends Phase with Translator[AnnotationSeq, Seq[CompilerRun]] with PreservesAll[Phase] {
+class Compiler extends Phase with Translator[AnnotationSeq, Seq[CompilerRun]] {
 
   override def prerequisites =
     Seq(Dependency[AddDefaults],
@@ -52,6 +52,8 @@ class Compiler extends Phase with Translator[AnnotationSeq, Seq[CompilerRun]] wi
         Dependency[AddImplicitOutputFile])
 
   override def optionalPrerequisiteOf = Seq(Dependency[WriteEmitted])
+
+  override def invalidates(a: Phase) = false
 
   /** Convert an [[AnnotationSeq]] into a sequence of compiler runs. */
   protected def aToB(a: AnnotationSeq): Seq[CompilerRun] = {

--- a/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
+++ b/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
@@ -8,7 +8,7 @@ import firrtl.{AnnotationSeq, EmitAllModulesAnnotation, EmitCircuitAnnotation, F
 import firrtl.annotations.NoTargetAnnotation
 import firrtl.FileUtils
 import firrtl.proto.FromProto
-import firrtl.options.{InputAnnotationFileAnnotation, OptionsException, Phase, PreservesAll, StageOptions, StageUtils}
+import firrtl.options.{InputAnnotationFileAnnotation, OptionsException, Phase, StageOptions, StageUtils}
 import firrtl.options.Viewer
 import firrtl.options.Dependency
 
@@ -122,11 +122,13 @@ object DriverCompatibility {
     * @param annos input annotations
     * @return output annotations
     */
-  class AddImplicitAnnotationFile extends Phase with PreservesAll[Phase] {
+  class AddImplicitAnnotationFile extends Phase {
 
     override def prerequisites = Seq(Dependency[AddImplicitFirrtlFile])
 
     override def optionalPrerequisiteOf = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
+
+    override def invalidates(a: Phase) = false
 
     /** Try to add an [[firrtl.options.InputAnnotationFileAnnotation InputAnnotationFileAnnotation]] implicitly specified by
       * an [[AnnotationSeq]]. */
@@ -161,12 +163,13 @@ object DriverCompatibility {
     * @param annotations input annotations
     * @return
     */
-  class AddImplicitFirrtlFile extends Phase with PreservesAll[Phase] {
+  class AddImplicitFirrtlFile extends Phase {
 
     override def prerequisites = Seq.empty
 
     override def optionalPrerequisiteOf = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
 
+    override def invalidates(a: Phase) = false
 
     /** Try to add a [[FirrtlFileAnnotation]] implicitly specified by an [[AnnotationSeq]]. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {
@@ -193,11 +196,13 @@ object DriverCompatibility {
     */
   @deprecated("""AddImplicitEmitter should only be used to build Driver compatibility wrappers. Switch to Stage.""",
               "1.2")
-  class AddImplicitEmitter extends Phase with PreservesAll[Phase] {
+  class AddImplicitEmitter extends Phase {
 
     override def prerequisites = Seq.empty
 
     override def optionalPrerequisiteOf = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
+
+    override def invalidates(a: Phase) = false
 
     /** Add one [[EmitAnnotation]] foreach [[CompilerAnnotation]]. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {
@@ -219,11 +224,13 @@ object DriverCompatibility {
     */
   @deprecated("""AddImplicitOutputFile should only be used to build Driver compatibility wrappers. Switch to Stage.""",
               "1.2")
-  class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
+  class AddImplicitOutputFile extends Phase {
 
     override def prerequisites = Seq(Dependency[AddImplicitFirrtlFile])
 
     override def optionalPrerequisiteOf = Seq(Dependency[FirrtlPhase], Dependency[FirrtlStage])
+
+    override def invalidates(a: Phase) = false
 
     /** Add an [[OutputFileAnnotation]] derived from a [[TopNameAnnotation]] if needed. */
     def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
+++ b/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
@@ -3,7 +3,7 @@
 package firrtl.stage.phases
 
 import firrtl.{AnnotationSeq, EmittedModuleAnnotation, EmittedCircuitAnnotation}
-import firrtl.options.{Phase, PreservesAll, StageOptions, Viewer}
+import firrtl.options.{Phase, StageOptions, Viewer}
 import firrtl.stage.FirrtlOptions
 
 import java.io.PrintWriter
@@ -24,11 +24,13 @@ import java.io.PrintWriter
   *
   * Any annotations written to files will be deleted.
   */
-class WriteEmitted extends Phase with PreservesAll[Phase] {
+class WriteEmitted extends Phase {
 
   override def prerequisites = Seq.empty
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Phase) = false
 
   /** Write any [[EmittedAnnotation]]s in an [[AnnotationSeq]] to files. Written [[EmittedAnnotation]]s are deleted. */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -6,7 +6,6 @@ import java.io.{File, FileNotFoundException, FileInputStream, FileOutputStream, 
 
 import firrtl._
 import firrtl.annotations._
-import firrtl.options.PreservesAll
 
 import scala.collection.immutable.ListSet
 
@@ -55,7 +54,7 @@ class BlackBoxNotFoundException(fileName: String, message: String) extends Firrt
   * will set the directory where the Verilog will be written.  This annotation is typically be
   * set by the execution harness, or directly in the tests
   */
-class BlackBoxSourceHelper extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+class BlackBoxSourceHelper extends Transform with DependencyAPIMigration {
   import BlackBoxSourceHelper._
   private val DefaultTargetDir = new File(".")
 
@@ -64,6 +63,8 @@ class BlackBoxSourceHelper extends Transform with DependencyAPIMigration with Pr
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Transform) = false
 
   /** Collect BlackBoxHelperAnnos and and find the target dir if specified
     * @param annos a list of generic annotations for this transform

--- a/src/main/scala/firrtl/transforms/CheckCombLoops.scala
+++ b/src/main/scala/firrtl/transforms/CheckCombLoops.scala
@@ -12,7 +12,7 @@ import firrtl.annotations._
 import firrtl.Utils.throwInternalError
 import firrtl.graph._
 import firrtl.analyses.InstanceGraph
-import firrtl.options.{Dependency, PreservesAll, RegisteredTransform, ShellOption}
+import firrtl.options.{Dependency, RegisteredTransform, ShellOption}
 
 /**
   * A case class that represents a net in the circuit. This is necessary since combinational loop
@@ -100,8 +100,7 @@ case class CombinationalPath(sink: ReferenceTarget, sources: Seq[ReferenceTarget
   */
 class CheckCombLoops extends Transform
     with RegisteredTransform
-    with DependencyAPIMigration
-    with PreservesAll[Transform] {
+    with DependencyAPIMigration {
 
   override def prerequisites = firrtl.stage.Forms.MidForm ++
     Seq( Dependency(passes.LowerTypes),
@@ -111,6 +110,8 @@ class CheckCombLoops extends Transform
   override def optionalPrerequisites = Seq.empty
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Transform) = false
 
   import CheckCombLoops._
 

--- a/src/main/scala/firrtl/transforms/CombineCats.scala
+++ b/src/main/scala/firrtl/transforms/CombineCats.scala
@@ -7,7 +7,6 @@ import firrtl.Mappers._
 import firrtl.PrimOps._
 import firrtl.WrappedExpression._
 import firrtl.annotations.NoTargetAnnotation
-import firrtl.options.PreservesAll
 import firrtl.options.Dependency
 
 import scala.collection.mutable
@@ -53,7 +52,7 @@ object CombineCats {
   * Use [[MaxCatLenAnnotation]] to limit the number of elements that can be concatenated.
   * The default maximum number of elements is 10.
   */
-class CombineCats extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+class CombineCats extends Transform with DependencyAPIMigration {
 
   override def prerequisites = firrtl.stage.Forms.LowForm ++
     Seq( Dependency(passes.RemoveValidIf),
@@ -66,6 +65,8 @@ class CombineCats extends Transform with DependencyAPIMigration with PreservesAl
   override def optionalPrerequisiteOf = Seq(
     Dependency[SystemVerilogEmitter],
     Dependency[VerilogEmitter] )
+
+  override def invalidates(a: Transform) = false
 
   val defaultMaxCatLen = 10
 

--- a/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
+++ b/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
@@ -10,7 +10,7 @@ import firrtl.analyses.InstanceGraph
 import firrtl.Mappers._
 import firrtl.Utils.{throwInternalError, kind}
 import firrtl.MemoizedHash._
-import firrtl.options.{Dependency, PreservesAll, RegisteredTransform, ShellOption}
+import firrtl.options.{Dependency, RegisteredTransform, ShellOption}
 
 import collection.mutable
 
@@ -32,8 +32,7 @@ import collection.mutable
 class DeadCodeElimination extends Transform
     with ResolvedAnnotationPaths
     with RegisteredTransform
-    with DependencyAPIMigration
-    with PreservesAll[Transform] {
+    with DependencyAPIMigration {
 
   override def prerequisites = firrtl.stage.Forms.LowForm ++
     Seq( Dependency(firrtl.passes.RemoveValidIf),
@@ -53,6 +52,8 @@ class DeadCodeElimination extends Transform
          Dependency[firrtl.transforms.VerilogRename],
          Dependency(passes.VerilogPrep),
          Dependency[firrtl.AddDescriptionNodes] )
+
+  override def invalidates(a: Transform) = false
 
   val options = Seq(
     new ShellOption[Unit](

--- a/src/main/scala/firrtl/transforms/Dedup.scala
+++ b/src/main/scala/firrtl/transforms/Dedup.scala
@@ -11,7 +11,7 @@ import firrtl.passes.{InferTypes, MemPortUtils}
 import firrtl.Utils.throwInternalError
 import firrtl.annotations.transforms.DupedResult
 import firrtl.annotations.TargetToken.{OfModule, Instance}
-import firrtl.options.{HasShellOptions, PreservesAll, ShellOption}
+import firrtl.options.{HasShellOptions, ShellOption}
 import logger.LazyLogging
 
 // Datastructures
@@ -73,11 +73,13 @@ case class DedupedResult(original: ModuleTarget, duplicate: Option[IsModule], in
   * This transform will also emit [[DedupedResult]] for deduped modules that
   * only have one instance.
   */
-class DedupModules extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+class DedupModules extends Transform with DependencyAPIMigration {
 
   override def prerequisites = firrtl.stage.Forms.Resolved
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Transform) = false
 
   /** Deduplicate a Circuit
     * @param state Input Firrtl AST

--- a/src/main/scala/firrtl/transforms/FixAddingNegativeLiteralsTransform.scala
+++ b/src/main/scala/firrtl/transforms/FixAddingNegativeLiteralsTransform.scala
@@ -5,7 +5,7 @@ package firrtl.transforms
 import firrtl.{CircuitState, DependencyAPIMigration, Namespace, PrimOps, Transform, Utils, WRef}
 import firrtl.ir._
 import firrtl.Mappers._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 import firrtl.PrimOps.{Add, AsSInt, Sub, Tail}
 import firrtl.stage.Forms
 
@@ -107,13 +107,15 @@ object FixAddingNegativeLiterals {
   * the literal and thus not all expressions in the add are the same. This is fixed here when we directly
   * subtract the literal instead.
   */
-class FixAddingNegativeLiterals extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+class FixAddingNegativeLiterals extends Transform with DependencyAPIMigration {
 
   override def prerequisites = Forms.LowFormMinimumOptimized :+ Dependency[BlackBoxSourceHelper]
 
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Transform) = false
 
   def execute(state: CircuitState): CircuitState = {
     val modulesx = state.circuit.modules.map(FixAddingNegativeLiterals.fixupModule)

--- a/src/main/scala/firrtl/transforms/Flatten.scala
+++ b/src/main/scala/firrtl/transforms/Flatten.scala
@@ -7,7 +7,6 @@ import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.annotations._
 import scala.collection.mutable
-import firrtl.options.PreservesAll
 import firrtl.passes.{InlineInstances,PassException}
 import firrtl.stage.Forms
 
@@ -24,11 +23,12 @@ case class FlattenAnnotation(target: Named) extends SingleTargetAnnotation[Named
   * @note Flattening a module means inlining all its fully-defined child instances
   * @note Instances of extmodules are not (and cannot be) inlined
   */
-class Flatten extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+class Flatten extends Transform with DependencyAPIMigration {
 
    override def prerequisites = Forms.LowForm
    override def optionalPrerequisites = Seq.empty
    override def optionalPrerequisiteOf = Forms.LowEmitters
+  override def invalidates(a: Transform) = false
 
    val inlineTransform = new InlineInstances
 

--- a/src/main/scala/firrtl/transforms/InlineBitExtractions.scala
+++ b/src/main/scala/firrtl/transforms/InlineBitExtractions.scala
@@ -5,7 +5,7 @@ package transforms
 
 import firrtl.ir._
 import firrtl.Mappers._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 import firrtl.PrimOps.{Bits, Head, Tail, Shr}
 import firrtl.Utils.{isBitExtract, isTemp}
 import firrtl.WrappedExpression._
@@ -94,7 +94,7 @@ object InlineBitExtractionsTransform {
 }
 
 /** Inline nodes that are simple bits */
-class InlineBitExtractionsTransform extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+class InlineBitExtractionsTransform extends Transform with DependencyAPIMigration {
 
   override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
     Seq( Dependency[BlackBoxSourceHelper],
@@ -104,6 +104,8 @@ class InlineBitExtractionsTransform extends Transform with DependencyAPIMigratio
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Transform) = false
 
   def execute(state: CircuitState): CircuitState = {
     val modulesx = state.circuit.modules.map(InlineBitExtractionsTransform.onMod(_))

--- a/src/main/scala/firrtl/transforms/LegalizeClocks.scala
+++ b/src/main/scala/firrtl/transforms/LegalizeClocks.scala
@@ -3,7 +3,7 @@ package transforms
 
 import firrtl.ir._
 import firrtl.Mappers._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 import firrtl.Utils.isCast
 
 // Fixup otherwise legal Verilog that lint tools and other tools don't like
@@ -59,7 +59,7 @@ object LegalizeClocksTransform {
 }
 
 /** Ensure Clocks to be emitted are legal Verilog */
-class LegalizeClocksTransform extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+class LegalizeClocksTransform extends Transform with DependencyAPIMigration {
 
   override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
     Seq( Dependency[BlackBoxSourceHelper],
@@ -71,6 +71,8 @@ class LegalizeClocksTransform extends Transform with DependencyAPIMigration with
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Transform) = false
 
   def execute(state: CircuitState): CircuitState = {
     val modulesx = state.circuit.modules.map(LegalizeClocksTransform.onMod(_))

--- a/src/main/scala/firrtl/transforms/LegalizeReductions.scala
+++ b/src/main/scala/firrtl/transforms/LegalizeReductions.scala
@@ -3,7 +3,7 @@ package transforms
 
 import firrtl.ir._
 import firrtl.Mappers._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 import firrtl.Utils.BoolType
 
 
@@ -31,7 +31,7 @@ object LegalizeAndReductionsTransform {
   * Workaround a bug in Verilator v4.026 - v4.032 (inclusive).
   * For context, see https://github.com/verilator/verilator/issues/2300
   */
-class LegalizeAndReductionsTransform extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+class LegalizeAndReductionsTransform extends Transform with DependencyAPIMigration {
 
   override def prerequisites =
     firrtl.stage.Forms.WorkingIR ++
@@ -41,6 +41,8 @@ class LegalizeAndReductionsTransform extends Transform with DependencyAPIMigrati
   override def optionalPrerequisites = Nil
 
   override def optionalPrerequisiteOf = Nil
+
+  override def invalidates(a: Transform) = false
 
   def execute(state: CircuitState): CircuitState = {
     val modulesx = state.circuit.modules.map(LegalizeAndReductionsTransform.onMod(_))

--- a/src/main/scala/firrtl/transforms/PropagatePresetAnnotations.scala
+++ b/src/main/scala/firrtl/transforms/PropagatePresetAnnotations.scala
@@ -6,7 +6,7 @@ package transforms
 import firrtl.PrimOps._
 import firrtl.annotations._
 import firrtl.ir.{AsyncResetType, _}
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 
 import scala.collection.mutable
 
@@ -36,7 +36,7 @@ object PropagatePresetAnnotations {
   *
   * @note This pass must run before InlineCastsTransform
   */
-class PropagatePresetAnnotations extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+class PropagatePresetAnnotations extends Transform with DependencyAPIMigration {
 
   override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
     Seq( Dependency[BlackBoxSourceHelper],
@@ -47,6 +47,7 @@ class PropagatePresetAnnotations extends Transform with DependencyAPIMigration w
 
   override def optionalPrerequisiteOf = Seq.empty
 
+  override def invalidates(a: Transform) = false
 
   import PropagatePresetAnnotations._
 

--- a/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
+++ b/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
@@ -10,7 +10,7 @@ import firrtl.ir
 import firrtl.passes.{Uniquify, PassException}
 import firrtl.Utils.v_keywords
 import firrtl.Mappers._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 
 import scala.collection.mutable
 
@@ -231,7 +231,7 @@ class RemoveKeywordCollisions(keywords: Set[String]) extends Transform with Depe
 }
 
 /** Transform that removes collisions with Verilog keywords */
-class VerilogRename extends RemoveKeywordCollisions(v_keywords) with PreservesAll[Transform] {
+class VerilogRename extends RemoveKeywordCollisions(v_keywords) {
 
   override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
     Seq( Dependency[BlackBoxSourceHelper],
@@ -246,5 +246,7 @@ class VerilogRename extends RemoveKeywordCollisions(v_keywords) with PreservesAl
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Transform) = false
 
 }

--- a/src/main/scala/firrtl/transforms/RemoveWires.scala
+++ b/src/main/scala/firrtl/transforms/RemoveWires.scala
@@ -9,7 +9,7 @@ import firrtl.Mappers._
 import firrtl.traversals.Foreachers._
 import firrtl.WrappedExpression._
 import firrtl.graph.{MutableDiGraph, CyclicException}
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 
 import scala.collection.mutable
 import scala.util.{Try, Success, Failure}
@@ -20,7 +20,7 @@ import scala.util.{Try, Success, Failure}
   *  wires have multiple connections that may be impossible to order in a
   *  flow-foward way
   */
-class RemoveWires extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+class RemoveWires extends Transform with DependencyAPIMigration {
 
   override def prerequisites = firrtl.stage.Forms.MidForm ++
     Seq( Dependency(passes.LowerTypes),
@@ -31,6 +31,8 @@ class RemoveWires extends Transform with DependencyAPIMigration with PreservesAl
   override def optionalPrerequisites = Seq(Dependency[checks.CheckResets])
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Transform) = false
 
   // Extract all expressions that are references to a Node, Wire, or Reg
   // Since we are operating on LowForm, they can only be WRefs

--- a/src/main/scala/firrtl/transforms/RenameModules.scala
+++ b/src/main/scala/firrtl/transforms/RenameModules.scala
@@ -5,7 +5,6 @@ package firrtl.transforms
 import firrtl.analyses.{InstanceGraph, ModuleNamespaceAnnotation}
 import firrtl.ir._
 import firrtl._
-import firrtl.options.PreservesAll
 import firrtl.stage.Forms
 
 import scala.collection.mutable
@@ -14,11 +13,12 @@ import scala.collection.mutable
   *
   * using namespace created by [[analyses.GetNamespace]], create unique names for modules
   */
-class RenameModules extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+class RenameModules extends Transform with DependencyAPIMigration {
 
   override def prerequisites = Forms.LowForm
   override def optionalPrerequisites = Seq.empty
   override def optionalPrerequisiteOf = Forms.LowEmitters
+  override def invalidates(a: Transform) = false
 
   def collectNameMapping(namespace: Namespace, moduleNameMap: mutable.HashMap[String, String])(mod: DefModule): Unit = {
     val newName = namespace.newName(mod.name)

--- a/src/main/scala/firrtl/transforms/ReplaceTruncatingArithmetic.scala
+++ b/src/main/scala/firrtl/transforms/ReplaceTruncatingArithmetic.scala
@@ -7,7 +7,7 @@ import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.PrimOps._
 import firrtl.WrappedExpression._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 
 import scala.collection.mutable
 
@@ -77,7 +77,7 @@ object ReplaceTruncatingArithmetic {
   * @note This replaces some FIRRTL primops with ops that are not actually legal FIRRTL. They are
   * useful for emission to languages that support non-expanding arithmetic (like Verilog)
   */
-class ReplaceTruncatingArithmetic extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+class ReplaceTruncatingArithmetic extends Transform with DependencyAPIMigration {
 
   override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
     Seq( Dependency[BlackBoxSourceHelper],
@@ -86,6 +86,8 @@ class ReplaceTruncatingArithmetic extends Transform with DependencyAPIMigration 
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 
   override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Transform) = false
 
   def execute(state: CircuitState): CircuitState = {
     val modulesx = state.circuit.modules.map(ReplaceTruncatingArithmetic.onMod(_))

--- a/src/main/scala/firrtl/transforms/SimplifyMems.scala
+++ b/src/main/scala/firrtl/transforms/SimplifyMems.scala
@@ -9,7 +9,6 @@ import firrtl.annotations._
 import firrtl.passes._
 import firrtl.passes.memlib._
 import firrtl.stage.Forms
-import firrtl.options.PreservesAll
 import scala.collection.mutable
 
 import AnalysisUtils._
@@ -19,11 +18,12 @@ import ResolveMaskGranularity._
 /**
   * Lowers memories without splitting them, but without the complexity of ReplaceMemMacros
   */
-class SimplifyMems extends Transform with DependencyAPIMigration with PreservesAll[Transform] {
+class SimplifyMems extends Transform with DependencyAPIMigration {
 
   override def prerequisites = Forms.MidForm
   override def optionalPrerequisites = Seq.empty
   override def optionalPrerequisiteOf = Forms.MidEmitters
+  override def invalidates(a: Transform) = false
 
   def onModule(c: Circuit, renames: RenameMap)(m: DefModule): DefModule = {
     val moduleNS = Namespace(m)

--- a/src/main/scala/logger/phases/AddDefaults.scala
+++ b/src/main/scala/logger/phases/AddDefaults.scala
@@ -3,15 +3,16 @@
 package logger.phases
 
 import firrtl.AnnotationSeq
-import firrtl.options.{Phase, PreservesAll}
+import firrtl.options.Phase
 
 import logger.{LoggerOption, LogLevelAnnotation}
 
 /** Add default logger [[Annotation]]s */
-private [logger] class AddDefaults extends Phase with PreservesAll[Phase] {
+private [logger] class AddDefaults extends Phase {
 
   override def prerequisites = Seq.empty
   override def optionalPrerequisiteOf = Seq.empty
+  override def invalidates(a: Phase) = false
 
   /** Add missing default [[Logger]] [[Annotation]]s to an [[AnnotationSeq]]
     * @param annotations input annotations

--- a/src/main/scala/logger/phases/Checks.scala
+++ b/src/main/scala/logger/phases/Checks.scala
@@ -4,7 +4,7 @@ package logger.phases
 
 import firrtl.AnnotationSeq
 import firrtl.annotations.Annotation
-import firrtl.options.{Dependency, Phase, PreservesAll}
+import firrtl.options.{Dependency, Phase}
 
 import logger.{LogLevelAnnotation, LogFileAnnotation, LoggerException}
 
@@ -12,10 +12,11 @@ import scala.collection.mutable
 
 /** Check that an [[firrtl.AnnotationSeq AnnotationSeq]] has all necessary [[firrtl.annotations.Annotation Annotation]]s
   * for a [[Logger]] */
-object Checks extends Phase with PreservesAll[Phase] {
+object Checks extends Phase {
 
   override def prerequisites = Seq(Dependency[AddDefaults])
   override def optionalPrerequisiteOf = Seq.empty
+  override def invalidates(a: Phase) = false
 
   /** Ensure that an [[firrtl.AnnotationSeq AnnotationSeq]] has necessary [[Logger]] [[firrtl.annotations.Annotation
     * Annotation]]s

--- a/src/test/scala/firrtl/testutils/FirrtlSpec.scala
+++ b/src/test/scala/firrtl/testutils/FirrtlSpec.scala
@@ -13,7 +13,7 @@ import org.scalatestplus.scalacheck._
 import firrtl._
 import firrtl.ir._
 import firrtl.Parser.UseInfo
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.Dependency
 import firrtl.stage.{FirrtlFileAnnotation, InfoModeAnnotation, RunFirrtlTransformAnnotation}
 import firrtl.analyses.{GetNamespace, ModuleNamespaceAnnotation}
 import firrtl.annotations._
@@ -33,9 +33,10 @@ class CheckLowForm extends SeqTransform {
 
 case class RenameTopAnnotation(newTopName: String) extends NoTargetAnnotation
 
-object RenameTop extends Transform with PreservesAll[Transform] {
+object RenameTop extends Transform {
   def inputForm = UnknownForm
   def outputForm = UnknownForm
+  override def invalidates(a: Transform) = false
 
   override val optionalPrerequisites = Seq(Dependency[RenameModules])
 

--- a/src/test/scala/firrtlTests/InferReadWriteSpec.scala
+++ b/src/test/scala/firrtlTests/InferReadWriteSpec.scala
@@ -4,7 +4,6 @@ package firrtlTests
 
 import firrtl._
 import firrtl.ir._
-import firrtl.options.PreservesAll
 import firrtl.passes._
 import firrtl.stage.Forms
 import firrtl.testutils._
@@ -14,10 +13,11 @@ class InferReadWriteSpec extends SimpleTransformSpec {
   class InferReadWriteCheckException extends PassException(
     "Readwrite ports are not found!")
 
-  object InferReadWriteCheck extends Pass with PreservesAll[Transform] {
+  object InferReadWriteCheck extends Pass {
     override def prerequisites = Forms.MidForm
     override def optionalPrerequisites = Seq.empty
     override def optionalPrerequisiteOf = Forms.MidEmitters
+    override def invalidates(a: Transform) = false
 
     def findReadWrite(s: Statement): Boolean = s match {
       case s: DefMemory if s.readLatency > 0 && s.readwriters.size == 1 =>

--- a/src/test/scala/firrtlTests/options/PhaseManagerSpec.scala
+++ b/src/test/scala/firrtlTests/options/PhaseManagerSpec.scala
@@ -4,7 +4,7 @@ package firrtlTests.options
 
 
 import firrtl.AnnotationSeq
-import firrtl.options.{DependencyManagerException, Phase, PhaseManager, PreservesAll, Dependency}
+import firrtl.options.{DependencyManagerException, Phase, PhaseManager, Dependency}
 
 import java.io.{File, PrintWriter}
 
@@ -14,6 +14,10 @@ import org.scalatest.matchers.should.Matchers
 
 trait IdentityPhase extends Phase {
   def transform(annotations: AnnotationSeq): AnnotationSeq = annotations
+}
+
+trait PreservesAll { this: Phase =>
+  override def invalidates(phase: Phase) = false
 }
 
 /** Default [[Phase]] that has no prerequisites and invalidates nothing */
@@ -68,11 +72,11 @@ class G extends IdentityPhase {
   }
 }
 
-class CyclicA extends IdentityPhase with PreservesAll[Phase] {
+class CyclicA extends IdentityPhase with PreservesAll {
   override def prerequisites = Seq(Dependency[CyclicB])
 }
 
-class CyclicB extends IdentityPhase with PreservesAll[Phase] {
+class CyclicB extends IdentityPhase with PreservesAll {
   override def prerequisites = Seq(Dependency[CyclicA])
 }
 
@@ -236,22 +240,22 @@ object UnrelatedFixture {
   }
 
   class B0 extends IdentityPhase with InvalidatesB8Dep
-  class B1 extends IdentityPhase with PreservesAll[Phase]
-  class B2 extends IdentityPhase with PreservesAll[Phase]
-  class B3 extends IdentityPhase with PreservesAll[Phase]
-  class B4 extends IdentityPhase with PreservesAll[Phase]
-  class B5 extends IdentityPhase with PreservesAll[Phase]
-  class B6 extends IdentityPhase with PreservesAll[Phase]
-  class B7 extends IdentityPhase with PreservesAll[Phase]
+  class B1 extends IdentityPhase with PreservesAll
+  class B2 extends IdentityPhase with PreservesAll
+  class B3 extends IdentityPhase with PreservesAll
+  class B4 extends IdentityPhase with PreservesAll
+  class B5 extends IdentityPhase with PreservesAll
+  class B6 extends IdentityPhase with PreservesAll
+  class B7 extends IdentityPhase with PreservesAll
 
-  class B8 extends IdentityPhase with PreservesAll[Phase]
-  class B9 extends IdentityPhase with PreservesAll[Phase]
-  class B10 extends IdentityPhase with PreservesAll[Phase]
-  class B11 extends IdentityPhase with PreservesAll[Phase]
-  class B12 extends IdentityPhase with PreservesAll[Phase]
-  class B13 extends IdentityPhase with PreservesAll[Phase]
-  class B14 extends IdentityPhase with PreservesAll[Phase]
-  class B15 extends IdentityPhase with PreservesAll[Phase]
+  class B8 extends IdentityPhase with PreservesAll
+  class B9 extends IdentityPhase with PreservesAll
+  class B10 extends IdentityPhase with PreservesAll
+  class B11 extends IdentityPhase with PreservesAll
+  class B12 extends IdentityPhase with PreservesAll
+  class B13 extends IdentityPhase with PreservesAll
+  class B14 extends IdentityPhase with PreservesAll
+  class B15 extends IdentityPhase with PreservesAll
 
   class B6Sub extends B6 {
     override def prerequisites = Seq(Dependency[B6])
@@ -300,29 +304,29 @@ object UnrelatedFixture {
 
 object CustomAfterOptimizationFixture {
 
-  class Root extends IdentityPhase with PreservesAll[Phase]
+  class Root extends IdentityPhase with PreservesAll
 
-  class OptMinimum extends IdentityPhase with PreservesAll[Phase] {
+  class OptMinimum extends IdentityPhase with PreservesAll {
     override def prerequisites = Seq(Dependency[Root])
     override def optionalPrerequisiteOf = Seq(Dependency[AfterOpt])
   }
 
-  class OptFull extends IdentityPhase with PreservesAll[Phase] {
+  class OptFull extends IdentityPhase with PreservesAll {
     override def prerequisites = Seq(Dependency[Root], Dependency[OptMinimum])
     override def optionalPrerequisiteOf = Seq(Dependency[AfterOpt])
   }
 
-  class AfterOpt extends IdentityPhase with PreservesAll[Phase]
+  class AfterOpt extends IdentityPhase with PreservesAll
 
-  class DoneMinimum extends IdentityPhase with PreservesAll[Phase] {
+  class DoneMinimum extends IdentityPhase with PreservesAll {
     override def prerequisites = Seq(Dependency[OptMinimum])
   }
 
-  class DoneFull extends IdentityPhase with PreservesAll[Phase] {
+  class DoneFull extends IdentityPhase with PreservesAll {
     override def prerequisites = Seq(Dependency[OptFull])
   }
 
-  class Custom extends IdentityPhase with PreservesAll[Phase] {
+  class Custom extends IdentityPhase with PreservesAll {
     override def prerequisites = Seq(Dependency[Root], Dependency[AfterOpt])
     override def optionalPrerequisiteOf = Seq(Dependency[DoneMinimum], Dependency[DoneFull])
   }
@@ -333,23 +337,23 @@ object OptionalPrerequisitesFixture {
 
   class Root extends IdentityPhase
 
-  class OptMinimum extends IdentityPhase with PreservesAll[Phase] {
+  class OptMinimum extends IdentityPhase with PreservesAll {
     override def prerequisites = Seq(Dependency[Root])
   }
 
-  class OptFull extends IdentityPhase with PreservesAll[Phase] {
+  class OptFull extends IdentityPhase with PreservesAll {
     override def prerequisites = Seq(Dependency[Root], Dependency[OptMinimum])
   }
 
-  class DoneMinimum extends IdentityPhase with PreservesAll[Phase] {
+  class DoneMinimum extends IdentityPhase with PreservesAll {
     override def prerequisites = Seq(Dependency[OptMinimum])
   }
 
-  class DoneFull extends IdentityPhase with PreservesAll[Phase] {
+  class DoneFull extends IdentityPhase with PreservesAll {
     override def prerequisites = Seq(Dependency[OptFull])
   }
 
-  class Custom extends IdentityPhase with PreservesAll[Phase] {
+  class Custom extends IdentityPhase with PreservesAll {
     override def prerequisites = Seq(Dependency[Root])
     override def optionalPrerequisites = Seq(Dependency[OptMinimum], Dependency[OptFull])
     override def optionalPrerequisiteOf = Seq(Dependency[DoneMinimum], Dependency[DoneFull])
@@ -359,7 +363,7 @@ object OptionalPrerequisitesFixture {
 
 object OrderingFixture {
 
-  class A extends IdentityPhase with PreservesAll[Phase]
+  class A extends IdentityPhase with PreservesAll
 
   class B extends IdentityPhase {
     override def invalidates(phase: Phase): Boolean = phase match {

--- a/src/test/scala/firrtlTests/stage/phases/CompilerSpec.scala
+++ b/src/test/scala/firrtlTests/stage/phases/CompilerSpec.scala
@@ -6,7 +6,7 @@ package firrtlTests.stage.phases
 import scala.collection.mutable
 
 import firrtl.{Compiler => _, _}
-import firrtl.options.{Phase, PreservesAll}
+import firrtl.options.Phase
 import firrtl.stage.{CompilerAnnotation, FirrtlCircuitAnnotation, Forms, RunFirrtlTransformAnnotation}
 import firrtl.stage.phases.Compiler
 import org.scalatest.flatspec.AnyFlatSpec
@@ -160,10 +160,11 @@ object CompilerSpec {
 
   private[CompilerSpec] val globalState: mutable.Queue[Class[_ <: Transform]] = mutable.Queue.empty[Class[_ <: Transform]]
 
-  class LoggingTransform extends Transform with PreservesAll[Transform] {
+  class LoggingTransform extends Transform {
     override def inputForm = UnknownForm
     override def outputForm = UnknownForm
     override def prerequisites = Forms.HighForm
+    override def invalidates(a: Transform) = false
     def execute(c: CircuitState): CircuitState = {
       globalState += this.getClass
       c


### PR DESCRIPTION
Might as well rip this band-aid off now...

This deprecates the `PreservesAll[A]` trait. This was intended to be a way to easily specify (and pattern match against a type) that a transform invalidated nothing. However, this created problems for backwards compatibility. 

This PR also removes all usages of `Preservesall[A]`.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->
- API deprecation

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

This deprecates the `PreservesAll[A]` trait. This also introduces backwards incompatibilities by removing the `PreservesAll` trait from all classes it's mixed into.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
- Rebase

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Deprecate PreservesAll trait

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
