### PR TITLE
[1.3.x] RemoveIntervals: fixup kinds of refs to replaced nodes

### DIFF
--- a/src/main/scala/firrtl/passes/RemoveIntervals.scala
+++ b/src/main/scala/firrtl/passes/RemoveIntervals.scala
@@ -51,7 +51,7 @@ class RemoveIntervals extends Pass with PreservesAll[Transform] {
     val wiredCircuit = alignedCircuit map makeWireModule
     val replacedCircuit = wiredCircuit map replaceModuleInterval(errors)
     errors.trigger()
-    InferTypes.run(replacedCircuit)
+    ResolveKinds.run(InferTypes.run(replacedCircuit))
   }
 
   /* Replace interval types */

--- a/src/test/scala/firrtlTests/interval/IntervalSpec.scala
+++ b/src/test/scala/firrtlTests/interval/IntervalSpec.scala
@@ -532,12 +532,15 @@ class IntervalSpec extends FirrtlFlatSpec {
   "RemoveIntervals" should "fixup kinds of replaced nodes" in {
     val passes = Seq(ToWorkingIR, new ResolveAndCheck, new RemoveIntervals)
     val input =
-      s"""circuit Unit :
-         |  module Unit :
+      s"""circuit Foo :
+         |  module Foo :
          |    input in: Interval[2, 3].3
          |    output out: Interval[2, 3].3
          |    node temp = in
          |    out <= temp
+         |  module Bar :
+         |    node temp = UInt<1>("h0")
+         |    node bar = temp
          |    """.stripMargin
       val removed = compile(input, passes)
       removed should be (ResolveKinds.run(removed))


### PR DESCRIPTION
1.3.x version of https://github.com/freechipsproject/firrtl/pull/1689

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->
- bug fix

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
none

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
none

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
- Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
fix bug in RemoveIntervals where refs to replaced nodes did not have the correct kind


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
