### PR TITLE
Add support for ValidIf to ProtoBuf [de]serialization

### DIFF
--- a/src/main/scala/firrtl/proto/FromProto.scala
+++ b/src/main/scala/firrtl/proto/FromProto.scala
@@ -94,6 +94,9 @@ object FromProto {
   def convert(mux: Firrtl.Expression.Mux): ir.Mux =
     ir.Mux(convert(mux.getCondition), convert(mux.getTValue), convert(mux.getFValue), ir.UnknownType)
 
+  def convert(validif: Firrtl.Expression.ValidIf): ir.ValidIf =
+    ir.ValidIf(convert(validif.getCondition), convert(validif.getValue), ir.UnknownType)
+
   def convert(expr: Firrtl.Expression): ir.Expression = {
     import Firrtl.Expression._
     expr.getExpressionCase.getNumber match {
@@ -106,6 +109,7 @@ object FromProto {
       case FIXED_LITERAL_FIELD_NUMBER => convert(expr.getFixedLiteral)
       case PRIM_OP_FIELD_NUMBER => convert(expr.getPrimOp)
       case MUX_FIELD_NUMBER => convert(expr.getMux)
+      case VALID_IF_FIELD_NUMBER => convert(expr.getValidIf)
     }
   }
 

--- a/src/main/scala/firrtl/proto/ToProto.scala
+++ b/src/main/scala/firrtl/proto/ToProto.scala
@@ -188,6 +188,11 @@ object ToProto {
           .setTValue(convert(tval))
           .setFValue(convert(fval))
         eb.setMux(mb)
+      case ir.ValidIf(cond, value, _) =>
+        val vb = Firrtl.Expression.ValidIf.newBuilder()
+          .setCondition(convert(cond))
+          .setValue(convert(value))
+        eb.setValidIf(vb)
     }
   }
 

--- a/src/test/scala/firrtlTests/ProtoBufSpec.scala
+++ b/src/test/scala/firrtlTests/ProtoBufSpec.scala
@@ -6,6 +6,7 @@ import firrtl.FirrtlProtos.Firrtl
 import firrtl._
 import firrtl.ir._
 import firrtl.testutils._
+import firrtl.Utils.BoolType
 
 class ProtoBufSpec extends FirrtlFlatSpec {
 
@@ -200,5 +201,14 @@ class ProtoBufSpec extends FirrtlFlatSpec {
   it should "support ResetTypes" in {
     val port = ir.Port(ir.NoInfo, "reset", ir.Input, ir.ResetType)
     FromProto.convert(ToProto.convert(port).build) should equal (port)
+  }
+
+  it should "support ValidIf" in {
+    val en = ir.Reference("en", BoolType, PortKind, SourceFlow)
+    val value = ir.Reference("x", UIntType(IntWidth(8)), PortKind, SourceFlow)
+    val vi = ir.ValidIf(en, value, value.tpe)
+    // Deserialized has almost nothing filled in
+    val expected = ir.ValidIf(ir.Reference("en"), ir.Reference("x"), UnknownType)
+    FromProto.convert(ToProto.convert(vi).build) should equal (expected)
   }
 }


### PR DESCRIPTION
h/t @HCoffman for bringing this to our attention

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
  - bug fix   


#### API Impact

Adds support for ValidIf to protobuf serialization, bugfix but also API expansion

#### Backend Code Generation Impact

No change to Verilog

#### Desired Merge Strategy

  - Squash: The PR will be squashed and merged 

#### Release Notes

Add support for `ValidIf` to protobuf [de]serialization

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
