### PR TITLE
verification: emit mesage as Verilog comment

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -458,7 +458,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
 
   def addFormalStatement(formals: mutable.Map[Expression, ArrayBuffer[Seq[Any]]],
                                  clk: Expression, en: Expression,
-                                 stmt: Seq[Any], info: Info): Unit = {
+                                 stmt: Seq[Any], info: Info, msg: StringLit): Unit = {
     throw EmitterException("Cannot emit verification statements in Verilog" +
       "(2001). Use the SystemVerilog emitter instead.")
   }
@@ -827,8 +827,8 @@ class VerilogEmitter extends SeqTransform with Emitter {
       lines += Seq("`endif // SYNTHESIS")
     }
 
-    def addFormal(clk: Expression, en: Expression, stmt: Seq[Any], info: Info) = {
-      addFormalStatement(formals, clk, en, stmt, info)
+    def addFormal(clk: Expression, en: Expression, stmt: Seq[Any], info: Info, msg: StringLit): Unit = {
+      addFormalStatement(formals, clk, en, stmt, info, msg)
     }
 
     def formalStatement(op: Formal.Value, cond: Expression): Seq[Any] = {
@@ -939,7 +939,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
         case sx: Print =>
           simulate(sx.clk, sx.en, printf(sx.string, sx.args), Some("PRINTF_COND"), sx.info)
         case sx: Verification =>
-          addFormal(sx.clk, sx.en, formalStatement(sx.op, sx.pred), sx.info)
+          addFormal(sx.clk, sx.en, formalStatement(sx.op, sx.pred), sx.info, sx.msg)
         // If we are emitting an Attach, it must not have been removable in VerilogPrep
         case sx: Attach =>
           // For Synthesis
@@ -1258,8 +1258,9 @@ class SystemVerilogEmitter extends VerilogEmitter {
 
   override def addFormalStatement(formals: mutable.Map[Expression, ArrayBuffer[Seq[Any]]],
                                   clk: Expression, en: Expression,
-                                  stmt: Seq[Any], info: Info): Unit = {
+                                  stmt: Seq[Any], info: Info, msg: StringLit): Unit = {
     val lines = formals.getOrElseUpdate(clk, ArrayBuffer[Seq[Any]]())
+    lines += Seq("// ", msg.serialize)
     lines += Seq("if (", en, ") begin")
     lines += Seq(tab, stmt, info)
     lines += Seq("end")

--- a/src/test/scala/firrtlTests/formal/VerificationSpec.scala
+++ b/src/test/scala/firrtlTests/formal/VerificationSpec.scala
@@ -1,3 +1,5 @@
+// See LICENSE for license details.
+
 package firrtlTests.formal
 
 import firrtl.{SystemVerilogCompiler}
@@ -38,12 +40,15 @@ class VerificationSpec extends FirrtlFlatSpec {
         |  wire outputEquals0xAA = out == 8'haa;
         |  assign out = in;
         |  always @(posedge clock) begin
+        |    // assume input is 0xAA
         |    if (1'h1) begin
         |      assume(inputEquals0xAA);
         |    end
+        |    // assert that output equals input
         |    if (1'h1) begin
         |      assert(areEqual);
         |    end
+        |    // cover output is 0xAA
         |    if (1'h1) begin
         |      cover(outputEquals0xAA);
         |    end


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- backend comment generation

#### API Impact
- no API impact

#### Backend Code Generation Impact
- this adds the message included with a verification statement as a Verilog comment to the Verilog code

#### Desired Merge Strategy

- squash

#### Release Notes
-

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
