### PR TITLE
Batch renames in LowerTypes

### DIFF
--- a/benchmark/src/main/scala/firrtl/benchmark/hot/TransformBenchmark.scala
+++ b/benchmark/src/main/scala/firrtl/benchmark/hot/TransformBenchmark.scala
@@ -1,0 +1,27 @@
+// See LICENSE for license details.
+
+package firrtl
+package benchmark
+package hot
+
+import firrtl._
+import firrtl.passes.LowerTypes
+import firrtl.stage.TransformManager
+
+import firrtl.benchmark.util._
+
+abstract class TransformBenchmark(factory: () => Transform) extends App {
+  val inputFile = args(0)
+  val warmup = args(1).toInt
+  val runs = args(2).toInt
+
+  val input = filenameToCircuit(inputFile)
+  val inputState = CircuitState(input, ChirrtlForm)
+
+  val manager = new TransformManager(factory().prerequisites)
+  val preState = manager.execute(inputState)
+
+  hot.util.benchmark(warmup, runs)(factory().transform(preState))
+}
+
+object LowerTypesBenchmark extends TransformBenchmark(() => LowerTypes)

--- a/benchmark/src/main/scala/firrtl/benchmark/hot/util/package.scala
+++ b/benchmark/src/main/scala/firrtl/benchmark/hot/util/package.scala
@@ -15,6 +15,7 @@ package object util {
     // Benchmark
     val times: Array[Double] = Array.fill(nRun)(0.0)
     for (i <- 0 until nRun) {
+      System.gc
       val (t, res) = time(f)
       times(i) = t
       println(f"Benchmark run $i took $t%.1f ms")

--- a/src/main/scala/firrtl/passes/LowerTypes.scala
+++ b/src/main/scala/firrtl/passes/LowerTypes.scala
@@ -55,16 +55,16 @@ object LowerTypes extends Transform with DependencyAPIMigration {
       val name = root + loweredName(e)
       renames.rename(root + e.serialize, name)
       Seq(name)
-    case (t: BundleType) => t.fields.flatMap { f =>
-      val subNames = renameExps(renames, WSubField(e, f.name, f.tpe, times(flow(e), f.flip)), root)
+    case (t: BundleType) =>
+      val subNames = t.fields.flatMap { f =>
+        renameExps(renames, WSubField(e, f.name, f.tpe, times(flow(e), f.flip)), root)
+      }
       renames.rename(root + e.serialize, subNames)
       subNames
-    }
-    case (t: VectorType) => (0 until t.size).flatMap { i =>
-      val subNames = renameExps(renames, WSubIndex(e, i, t.tpe,flow(e)), root)
+    case (t: VectorType) =>
+      val subNames = (0 until t.size).flatMap { i => renameExps(renames, WSubIndex(e, i, t.tpe,flow(e)), root) }
       renames.rename(root + e.serialize, subNames)
       subNames
-    }
   }
 
   private def renameMemExps(renames: RenameMap, e: Expression, portAndField: Expression): Seq[String] = e.tpe match {
@@ -224,9 +224,10 @@ object LowerTypes extends Transform with DependencyAPIMigration {
                 val d = WRef(mem.name, sx.dataType)
                 tail match {
                   case None =>
-                    create_exps(mem.name, sx.dataType) foreach { x =>
-                      renames.rename(e.serialize, s"${loweredName(x)}.${port.serialize}.${field.serialize}")
+                    val names = create_exps(mem.name, sx.dataType).map { x =>
+                      s"${loweredName(x)}.${port.serialize}.${field.serialize}"
                     }
+                    renames.rename(e.serialize, names)
                   case Some(_) =>
                     renameMemExps(renames, d, mergeRef(port, field))
                 }


### PR DESCRIPTION
Performance improvement for `LowerTypes`. 

Calling `RenameMap.renames` has the cost of making the renames distinct. This batches calls to `RenameMap.renames` in `LowerTypes` to allow for one `distinct` call. This should have general performance improvements, but especially helps with wide vectors.

E.g., consider the following:

```
circuit Foo:
  module Foo:
    input in: UInt<1>[4096]
```

Without this PR, this takes 2.5 seconds to get through `LowerTypes`. *With this PR it takes 50ms.*

### Contributor Checklist

- [n/a] Did you add Scaladoc to every public function/method?
- [n/a] Did you update the FIRRTL spec to include every new feature/behavior?
- [nope] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
- performance improvement
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

None.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Improve `LowerTypes` performance

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
