### PR TITLE
Enable flow from assert to print + stop

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -16,7 +16,7 @@ import Utils._
 import MemPortUtils.{memPortField, memType}
 import firrtl.options.{Dependency, HasShellOptions, PhaseException, ShellOption, Unserializable}
 import firrtl.stage.{RunFirrtlTransformAnnotation, TransformManager}
-import firrtl.transforms.formal.RemoveVerificationStatements
+import firrtl.transforms.formal.{RemoveVerificationStatements, ConvertAsserts}
 // Datastructures
 import scala.collection.mutable.ArrayBuffer
 
@@ -182,6 +182,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
   def outputForm = LowForm
 
   override def prerequisites =
+    Dependency(ConvertAsserts) +:
     Dependency[RemoveVerificationStatements] +:
     Dependency[LegalizeAndReductionsTransform] +:
     firrtl.stage.Forms.LowFormOptimized
@@ -1240,6 +1241,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
 class MinimumVerilogEmitter extends VerilogEmitter with Emitter {
 
   override def prerequisites =
+    Dependency(ConvertAsserts) +:
     Dependency[RemoveVerificationStatements] +:
     Dependency[LegalizeAndReductionsTransform] +:
     firrtl.stage.Forms.LowFormMinimumOptimized

--- a/src/main/scala/firrtl/transforms/formal/ConvertAsserts.scala
+++ b/src/main/scala/firrtl/transforms/formal/ConvertAsserts.scala
@@ -1,0 +1,39 @@
+// See LICENSE for license details.
+
+package firrtl.transforms.formal
+
+import firrtl._
+import firrtl.ir._
+import firrtl.options.Dependency
+
+/** Convert Asserts
+  *
+  * Replaces all Assert nodes with a gated print-and-stop. This effectively
+  * emulates the assert for IEEE 1364 Verilog.
+  */
+object ConvertAsserts extends Transform with DependencyAPIMigration {
+  override def prerequisites = Nil
+  override def optionalPrerequisites = Nil
+  override def optionalPrerequisiteOf = Seq(
+    Dependency[VerilogEmitter],
+    Dependency[MinimumVerilogEmitter],
+    Dependency[RemoveVerificationStatements])
+
+  override def invalidates(a: Transform): Boolean = false
+
+  def convertAsserts(stmt: Statement): Statement = stmt match {
+    case Verification(Formal.Assert, i, clk, pred, en, msg) =>
+      val nPred = DoPrim(PrimOps.Not, Seq(pred), Nil, pred.tpe)
+      val gatedNPred = DoPrim(PrimOps.And, Seq(nPred, en), Nil, pred.tpe)
+      val stop = Stop(i, 1, clk, gatedNPred)
+      msg match {
+        case StringLit("") => stop
+        case _ => Block(Print(i, msg, Nil, clk, gatedNPred), stop)
+      }
+    case s => s.mapStmt(convertAsserts)
+  }
+
+  def execute(state: CircuitState): CircuitState = {
+    state.copy(circuit = state.circuit.mapModule(m => m.mapStmt(convertAsserts)))
+  }
+}

--- a/src/main/scala/firrtl/transforms/formal/RemoveVerificationStatements.scala
+++ b/src/main/scala/firrtl/transforms/formal/RemoveVerificationStatements.scala
@@ -19,7 +19,7 @@ class RemoveVerificationStatements extends Transform
   with PreservesAll[Transform] {
 
   override def prerequisites: Seq[TransformDependency] = Seq.empty
-  override def optionalPrerequisites: Seq[TransformDependency] = Seq.empty
+  override def optionalPrerequisites: Seq[TransformDependency] = Seq(Dependency(ConvertAsserts))
   override def optionalPrerequisiteOf: Seq[TransformDependency] =
     Seq( Dependency[VerilogEmitter],
       Dependency[MinimumVerilogEmitter])

--- a/src/test/scala/firrtlTests/CustomTransformSpec.scala
+++ b/src/test/scala/firrtlTests/CustomTransformSpec.scala
@@ -10,7 +10,7 @@ import firrtl.stage.{FirrtlSourceAnnotation, FirrtlStage, Forms, RunFirrtlTransf
 import firrtl.options.Dependency
 import firrtl.transforms.{IdentityTransform, LegalizeAndReductionsTransform}
 import firrtl.testutils._
-import firrtl.transforms.formal.RemoveVerificationStatements
+import firrtl.transforms.formal.{RemoveVerificationStatements, ConvertAsserts}
 
 import scala.reflect.runtime
 
@@ -174,9 +174,11 @@ class CustomTransformSpec extends FirrtlFlatSpec {
 
     Seq( (Seq(Dependency[LowFirrtlEmitter]),             Seq(low.last)      ),
          (Seq(Dependency[LegalizeAndReductionsTransform],
+           Dependency(ConvertAsserts),
            Dependency[RemoveVerificationStatements],
            Dependency[MinimumVerilogEmitter]),           Seq(lowMinOpt.last)),
          (Seq(Dependency[LegalizeAndReductionsTransform],
+           Dependency(ConvertAsserts),
            Dependency[RemoveVerificationStatements],
            Dependency[VerilogEmitter]),                  Seq(lowOpt.last)    ),
          (Seq(Dependency[LegalizeAndReductionsTransform],

--- a/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
+++ b/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
@@ -354,6 +354,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
     val tm = (new TransformManager(Seq(Dependency[firrtl.MinimumVerilogEmitter], Dependency[Transforms.LowToLow])))
     val patches = Seq(
       Add(63, Seq(
+        Dependency(firrtl.transforms.formal.ConvertAsserts),
         Dependency[firrtl.transforms.formal.RemoveVerificationStatements],
         Dependency[firrtl.transforms.LegalizeAndReductionsTransform]))
     )
@@ -367,6 +368,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
     val tm = (new TransformManager(Seq(Dependency[firrtl.VerilogEmitter], Dependency[Transforms.LowToLow])))
     val patches = Seq(
       Add(70, Seq(
+        Dependency(firrtl.transforms.formal.ConvertAsserts),
         Dependency[firrtl.transforms.formal.RemoveVerificationStatements],
         Dependency[firrtl.transforms.LegalizeAndReductionsTransform]))
     )

--- a/src/test/scala/firrtlTests/formal/ConvertAssertsSpec.scala
+++ b/src/test/scala/firrtlTests/formal/ConvertAssertsSpec.scala
@@ -1,0 +1,47 @@
+// See LICENSE for license details.
+
+package firrtlTests.formal
+
+import firrtl._
+import firrtl.testutils.FirrtlFlatSpec
+import firrtl.transforms.formal.ConvertAsserts
+
+class ConvertAssertsSpec extends FirrtlFlatSpec {
+  val preamble =
+      """circuit DUT:
+        |  module DUT:
+        |    input clock: Clock
+        |    input reset: UInt<1>
+        |    input x: UInt<8>
+        |    output y: UInt<8>
+        |    y <= x
+        |    node ne5 = neq(x, UInt(5))
+        |""".stripMargin
+
+  "assert nodes" should "be converted to predicated prints and stops" in {
+    val input = preamble +
+      """    assert(clock, ne5, not(reset), "x should not equal 5")
+        |""".stripMargin
+
+    val ref = preamble +
+      """    printf(clock, and(not(ne5), not(reset)), "x should not equal 5")
+        |    stop(clock, and(not(ne5), not(reset)), 1)
+        |""".stripMargin
+
+    val outputCS = ConvertAsserts.execute(CircuitState(parse(input), Nil))
+    (parse(outputCS.circuit.serialize)) should be (parse(ref))
+  }
+
+  "assert nodes with no message" should "omit printed messages" in {
+    val input = preamble +
+      """    assert(clock, ne5, not(reset), "")
+        |""".stripMargin
+
+    val ref = preamble +
+      """    stop(clock, and(not(ne5), not(reset)), 1)
+        |""".stripMargin
+
+    val outputCS = ConvertAsserts.execute(CircuitState(parse(input), Nil))
+    (parse(outputCS.circuit.serialize)) should be (parse(ref))
+  }
+}


### PR DESCRIPTION
**Type of improvement:** enhancement
**API impact:** none
**Backend code-generation impact:** allows code using the new `assert` statement from #1653 to map to the same conditional print-and-stop. This allows us to maintain the flow of sending Chisel assertions to `$display`/`$finish` blocks that will work in IEEE 1364 Verilog.
**Desired merge strategy:** rebase
**Release notes:**
The assert statement added in #1653 can be mapped to conditional prints and stops when targeting Verilog to aid compatibility with strict IEEE 1364 tools.

There is another question remaining: currently, nonzero-argument `Stop`s turn into `$fatal`, which is not part of IEEE 1364 Verilog. I can extend the Verilog emitter to use `$finish` for Verilog and `$fatal` for SystemVerilog to be stricter, if we feel that's warranted.

This depends on the ordering specified in #1724 (as does the current Chisel 3.3 + FIRRTL 1.3 flow).

The print / stop conditions leave in an unsplit expression, which is guaranteed to always be fine because it exclusively uses 1-bit boolean ops. I may add a comment to note that this doesn't invalidate `SplitExpressions` and specifically note that that case does not violate the postcondition of `SplitExpressions` as a comment in `SplitExpressions.scala`.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?