### PR TITLE
fix reduction op bug ConstantPropagation

### DIFF
--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -764,6 +764,15 @@ object Utils extends LazyLogging {
       .toSeq
       .foldLeft(Seq[String]()){ case (seq, id) => seq :+ name.splitAt(id)._1 }
   }
+
+  /** Returns the value masked with the width.
+    *
+    * This supports truncating negative values as well as values that are too
+    * wide for the width
+    */
+  def maskBigInt(value: BigInt, width: Int): BigInt = {
+    value & ((BigInt(1) << width) - 1)
+  }
 }
 
 object MemoizedHash {

--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -160,7 +160,12 @@ class ConstantPropagation extends Transform with DependencyAPIMigration with Res
         case IntWidth(b) => b
       }
 
-      val v: Seq[Boolean] = s"%${w}s".format(a.value.toString(2)).map(_ == '1')
+      val maskedValue = if (a.value.signum < 0) {
+        a.value & ((BigInt(1) << w.toInt) - 1)
+      } else {
+        a.value
+      }
+      val v: Seq[Boolean] = s"%${w}s".format(maskedValue.toString(2)).map(_ == '1')
 
       (BigInt(0) until w).zip(v).foldLeft(identityValue) {
         case (acc, (_, x)) => reduce(acc, x)

--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -160,7 +160,7 @@ class ConstantPropagation extends Transform with DependencyAPIMigration with Res
         case IntWidth(b) => b
       }
 
-      val maskedValue = a.value & ((BigInt(1) << w.toInt) - 1)
+      val maskedValue = Utils.maskBigInt(a.value, w.toInt)
       val v: Seq[Boolean] = s"%${w}s".format(maskedValue.toString(2)).map(_ == '1')
 
       (BigInt(0) until w).zip(v).foldLeft(identityValue) {

--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -160,11 +160,7 @@ class ConstantPropagation extends Transform with DependencyAPIMigration with Res
         case IntWidth(b) => b
       }
 
-      val maskedValue = if (a.value.signum < 0) {
-        a.value & ((BigInt(1) << w.toInt) - 1)
-      } else {
-        a.value
-      }
+      val maskedValue = a.value & ((BigInt(1) << w.toInt) - 1)
       val v: Seq[Boolean] = s"%${w}s".format(maskedValue.toString(2)).map(_ == '1')
 
       (BigInt(0) until w).zip(v).foldLeft(identityValue) {

--- a/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+++ b/src/test/scala/firrtlTests/ConstantPropagationTests.scala
@@ -1609,9 +1609,9 @@ class ConstantPropagationEquivalenceSpec extends FirrtlFlatSpec {
     val input =
       s"""circuit ConstPropReductionTester :
          |  module ConstPropReductionTester :
-         |    output out1 : UInt<2>
-         |    output out2 : UInt<2>
-         |    output out3 : UInt<2>
+         |    output out1 : UInt<1>
+         |    output out2 : UInt<1>
+         |    output out3 : UInt<1>
          |    out1 <= xorr(SInt<2>(-1))
          |    out2 <= andr(SInt<2>(-1))
          |    out3 <= orr(SInt<2>(-1))""".stripMargin

--- a/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+++ b/src/test/scala/firrtlTests/ConstantPropagationTests.scala
@@ -1604,4 +1604,17 @@ class ConstantPropagationEquivalenceSpec extends FirrtlFlatSpec {
          |    out <= head_temp""".stripMargin
     firrtlEquivalenceTest(input, transforms)
   }
+
+  "reduction of literals" should "be propagated" in {
+    val input =
+      s"""circuit ConstPropReductionTester :
+         |  module ConstPropReductionTester :
+         |    output out1 : UInt<2>
+         |    output out2 : UInt<2>
+         |    output out3 : UInt<2>
+         |    out1 <= xorr(SInt<2>(-1))
+         |    out2 <= andr(SInt<2>(-1))
+         |    out3 <= orr(SInt<2>(-1))""".stripMargin
+    firrtlEquivalenceTest(input, transforms)
+  }
 }


### PR DESCRIPTION
Another bug caught by the fuzzer. Bitwise reductions of negative literals is incorrect:
```
circuit ConstPropReductionTester :
  module ConstPropReductionTester :
    output out1 : UInt<1>
    output out2 : UInt<1>
    output out3 : UInt<1>
    out1 <= xorr(SInt<2>(-1))
    out2 <= andr(SInt<2>(-1))
    out3 <= orr(SInt<2>(-1))
```

The optimized verilog emitter produces
```
module ConstPropReductionTester_custom(
  output  out1,
  output  out2,
  output  out3
);
  assign out1 = 1'h1;
  assign out2 = 1'h0;
  assign out3 = 1'h1;
endmodule
```

while the minimum verilog emitter produces
```
module ConstPropReductionTester_ref(
  output  out1,
  output  out2,
  output  out3
);
  assign out1 = ^-2'sh1;
  assign out2 = &-2'sh1;
  assign out3 = |-2'sh1;
endmodule
```

This is due to the `BigInt(-5).toString(2)` method returning '-101' instead of the two's complement representation that `SimplifyReductionOp` expects. This PR updates `SimplifyReductionOp` to mask negative values before calling `.toString(2)` on them.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->
- bug fix

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
none

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
none

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
- squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
