### PR TITLE
Remove Left Over References to Gender in Code

### DIFF
--- a/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
+++ b/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
@@ -12,7 +12,7 @@ import firrtl.options.Dependency
 
 case class MPort(name: String, clk: Expression)
 case class MPorts(readers: ArrayBuffer[MPort], writers: ArrayBuffer[MPort], readwriters: ArrayBuffer[MPort])
-case class DataRef(exp: Expression, male: String, female: String, mask: String, rdwrite: Boolean)
+case class DataRef(exp: Expression, source: String, sink: String, mask: String, rdwrite: Boolean)
 
 object RemoveCHIRRTL extends Transform with DependencyAPIMigration {
 
@@ -190,9 +190,9 @@ object RemoveCHIRRTL extends Transform with DependencyAPIMigration {
           case SinkFlow =>
             has_write_mport = true
             if (p.rdwrite) has_readwrite_mport = Some(SubField(p.exp, "wmode", BoolType))
-            SubField(p.exp, p.female, tpe)
+            SubField(p.exp, p.sink, tpe)
           case SourceFlow =>
-            SubField(p.exp, p.male, tpe)
+            SubField(p.exp, p.source, tpe)
         }
         case None => g match {
           case SinkFlow => raddrs get name match {


### PR DESCRIPTION
Now the only reference to male/female is in the `notes` directory.


### Contributor Checklist

- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- code cleanup

#### API Impact

- non of the changes should affect public APIs

#### Backend Code Generation Impact

- none

#### Desired Merge Strategy
- Squash: The PR will be squashed and merged (choose this if you have no preference.


### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you mark as `Please Merge`?
