### PR TITLE
Remove overlapping inputForm=LowForm tests

### DIFF
--- a/src/test/scala/firrtlTests/CustomTransformSpec.scala
+++ b/src/test/scala/firrtlTests/CustomTransformSpec.scala
@@ -6,11 +6,11 @@ import firrtl.ir.Circuit
 import firrtl._
 import firrtl.passes.Pass
 import firrtl.ir._
-import firrtl.stage.{FirrtlSourceAnnotation, FirrtlStage, Forms, RunFirrtlTransformAnnotation}
+import firrtl.stage.{FirrtlSourceAnnotation, FirrtlStage, RunFirrtlTransformAnnotation}
 import firrtl.options.Dependency
 import firrtl.transforms.{IdentityTransform, LegalizeAndReductionsTransform}
 import firrtl.testutils._
-import firrtl.transforms.formal.{RemoveVerificationStatements, ConvertAsserts}
+import firrtl.transforms.formal.ConvertAsserts
 
 import scala.reflect.runtime
 
@@ -150,40 +150,29 @@ class CustomTransformSpec extends FirrtlFlatSpec {
 
   they should "run right before the emitter* when inputForm=LowForm" in {
 
-    val custom = Dependency[IdentityLowForm]
+    val locationMap = Map(
+      Dependency[LowFirrtlEmitter]      -> Dependency[LowFirrtlEmitter],
+      Dependency[MinimumVerilogEmitter] -> Dependency(ConvertAsserts),
+      Dependency[VerilogEmitter]        -> Dependency(ConvertAsserts),
+      Dependency[SystemVerilogEmitter]  -> Dependency[LegalizeAndReductionsTransform]
+    )
 
-    def testOrder(after: Seq[Dependency[Transform]], before: Seq[Dependency[Transform]]): Unit = {
-      val expectedSlice: Seq[Dependency[Transform]] = before ++: custom +: after
-
-      info(expectedSlice.map(_.getSimpleName).mkString(" -> ") + " ok!")
-
-      val compiler = new firrtl.stage.transforms.Compiler(custom +: after)
-      info("Transform Order: \n" + compiler.prettyPrint("    "))
-
-
-      compiler
+    Seq(
+      Dependency[LowFirrtlEmitter],
+      Dependency[MinimumVerilogEmitter],
+      Dependency[VerilogEmitter],
+      Dependency[SystemVerilogEmitter]
+    ).foreach { emitter =>
+      val custom = Dependency[IdentityLowForm]
+      val tm = new firrtl.stage.transforms.Compiler(custom :: emitter :: Nil)
+      info(s"when using ${emitter.getObject.name}")
+      tm
         .flattenedTransformOrder
-        .map(Dependency.fromTransform(_))
-        .containsSlice(expectedSlice) should be (true)
+        .map(Dependency.fromTransform)
+        .sliding(2)
+        .toList should contain (Seq(custom, locationMap(emitter)))
     }
 
-    val Seq(low, lowMinOpt, lowOpt) =
-      Seq(Forms.LowForm, Forms.LowFormMinimumOptimized, Forms.LowFormOptimized)
-        .map(target => new firrtl.stage.transforms.Compiler(target))
-        .map(_.flattenedTransformOrder.map(Dependency.fromTransform(_)))
-
-    Seq( (Seq(Dependency[LowFirrtlEmitter]),             Seq(low.last)      ),
-         (Seq(Dependency[LegalizeAndReductionsTransform],
-           Dependency(ConvertAsserts),
-           Dependency[RemoveVerificationStatements],
-           Dependency[MinimumVerilogEmitter]),           Seq(lowMinOpt.last)),
-         (Seq(Dependency[LegalizeAndReductionsTransform],
-           Dependency(ConvertAsserts),
-           Dependency[RemoveVerificationStatements],
-           Dependency[VerilogEmitter]),                  Seq(lowOpt.last)    ),
-         (Seq(Dependency[LegalizeAndReductionsTransform],
-           Dependency[SystemVerilogEmitter]),            Seq(lowOpt.last)   )
-    ).foreach((testOrder _).tupled)
   }
 
   they should "work if placed inside an object" in {

--- a/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
+++ b/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
@@ -8,7 +8,6 @@ import firrtl._
 import firrtl.passes
 import firrtl.options.Dependency
 import firrtl.stage.{Forms, TransformManager}
-import firrtl.transforms.IdentityTransform
 
 sealed trait PatchAction { val line: Int }
 
@@ -337,42 +336,6 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
         (new TransformManager(Forms.LowFormOptimized, Forms.ChirrtlForm).flattenedTransformOrder)
     val tm = new TransformManager(Forms.LowFormOptimized :+ Dependency[Transforms.LowToChirrtl])
     compare(expected, tm)
-  }
-
-  it should "schedule inputForm=LowForm after MiddleFirrtlToLowFirrtl for the LowFirrtlEmitter" in {
-    val expected =
-      new TransformManager(Forms.LowForm).flattenedTransformOrder ++
-        Seq(new Transforms.LowToLow, new firrtl.LowFirrtlEmitter)
-    val tm = (new TransformManager(Seq(Dependency[firrtl.LowFirrtlEmitter], Dependency[Transforms.LowToLow])))
-    compare(expected, tm)
-  }
-
-  it should "schedule inputForm=LowForm after MinimumLowFirrtlOptimizations for the MinimalVerilogEmitter" in {
-    val expected =
-      new TransformManager(Forms.LowFormMinimumOptimized).flattenedTransformOrder ++
-        Seq(new Transforms.LowToLow, new firrtl.MinimumVerilogEmitter)
-    val tm = (new TransformManager(Seq(Dependency[firrtl.MinimumVerilogEmitter], Dependency[Transforms.LowToLow])))
-    val patches = Seq(
-      Add(63, Seq(
-        Dependency(firrtl.transforms.formal.ConvertAsserts),
-        Dependency[firrtl.transforms.formal.RemoveVerificationStatements],
-        Dependency[firrtl.transforms.LegalizeAndReductionsTransform]))
-    )
-    compare(expected, tm, patches)
-  }
-
-  it should "schedule inputForm=LowForm after LowFirrtlOptimizations for the VerilogEmitter" in {
-    val expected =
-      new TransformManager(Forms.LowFormOptimized).flattenedTransformOrder ++
-        Seq(new Transforms.LowToLow, new firrtl.VerilogEmitter)
-    val tm = (new TransformManager(Seq(Dependency[firrtl.VerilogEmitter], Dependency[Transforms.LowToLow])))
-    val patches = Seq(
-      Add(70, Seq(
-        Dependency(firrtl.transforms.formal.ConvertAsserts),
-        Dependency[firrtl.transforms.formal.RemoveVerificationStatements],
-        Dependency[firrtl.transforms.LegalizeAndReductionsTransform]))
-    )
-    compare(expected, tm, patches)
   }
 
 }


### PR DESCRIPTION
Remove tests from LoweringCompilerSpec testing the placement of
inputForm=LowForm legacy, custom transforms. This behavior is already
tested in the CustomTransformSpec.
   
Refactor the test used in the CustomTransformSpec to assert that
inputForm=LowForm legacy transforms run right before the emitter (see
note below!). The new test looks only for a list of (customTransform,
emitter) in a sliding, size-2 window of the flattened transform order.
Previously, this was looking for a match before and after the custom
transform. The old implementation necessitate busywork updates of the
test when new transforms are added that changed the transform running
before the custom transform.
    
Note: this test, as written is intentionally wrong. When verification
statements were added, the test was changed to not do what it's
supposed to do. Namely, the test is supposed to ensure that an
inputForm=LowForm transform runs immediately before its emitter.
However, the test is actually checking that the custom transform runs
before transforms that convert and remove verification statements. I'm
intentionally leaving the test broken, but doing the refactor in order
to make this easier to manually backport to the 1.3.x branch.


This should backport to 1.3.x.

### Contributor Checklist

- [n/a] Did you add Scaladoc to every public function/method?
- [n/a] Did you update the FIRRTL spec to include every new feature/behavior?
- [n/a] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
- code cleanup
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

None.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

None.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
