### PR TITLE
Integrate new transforms with firrtl.stage.Forms

### DIFF
--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -313,7 +313,7 @@ trait Transform extends TransformLike[CircuitState] with DependencyAPI[Transform
   }
 
   override def optionalPrerequisites: Seq[Dependency[Transform]] = inputForm match {
-    case L => Forms.LowFormOptimized
+    case L => Forms.LowFormOptimized ++ Forms.AssertsRemoved
     case _ => Seq.empty
   }
 

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -7,16 +7,15 @@ import java.io.Writer
 import scala.collection.mutable
 import firrtl.ir._
 import firrtl.passes._
-import firrtl.transforms.{FixAddingNegativeLiterals, LegalizeAndReductionsTransform}
+import firrtl.transforms.FixAddingNegativeLiterals
 import firrtl.annotations._
 import firrtl.traversals.Foreachers._
 import firrtl.PrimOps._
 import firrtl.WrappedExpression._
 import Utils._
 import MemPortUtils.{memPortField, memType}
-import firrtl.options.{Dependency, HasShellOptions, PhaseException, ShellOption, Unserializable}
+import firrtl.options.{HasShellOptions, PhaseException, ShellOption, Unserializable}
 import firrtl.stage.{RunFirrtlTransformAnnotation, TransformManager}
-import firrtl.transforms.formal.{RemoveVerificationStatements, ConvertAsserts}
 // Datastructures
 import scala.collection.mutable.ArrayBuffer
 
@@ -181,10 +180,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
   def inputForm = LowForm
   def outputForm = LowForm
 
-  override def prerequisites =
-    Dependency(ConvertAsserts) +:
-    Dependency[RemoveVerificationStatements] +:
-    Dependency[LegalizeAndReductionsTransform] +:
+  override def prerequisites = firrtl.stage.Forms.AssertsRemoved ++
     firrtl.stage.Forms.LowFormOptimized
 
   override def optionalPrerequisiteOf = Seq.empty
@@ -1254,10 +1250,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
 
 class MinimumVerilogEmitter extends VerilogEmitter with Emitter {
 
-  override def prerequisites =
-    Dependency(ConvertAsserts) +:
-    Dependency[RemoveVerificationStatements] +:
-    Dependency[LegalizeAndReductionsTransform] +:
+  override def prerequisites = firrtl.stage.Forms.AssertsRemoved ++
     firrtl.stage.Forms.LowFormMinimumOptimized
 
   override def transforms = new TransformManager(firrtl.stage.Forms.VerilogMinimumOptimized, prerequisites)
@@ -1268,9 +1261,7 @@ class MinimumVerilogEmitter extends VerilogEmitter with Emitter {
 class SystemVerilogEmitter extends VerilogEmitter {
   override val outputSuffix: String = ".sv"
 
-  override def prerequisites =
-      Dependency[LegalizeAndReductionsTransform] +:
-      firrtl.stage.Forms.LowFormOptimized
+  override def prerequisites = firrtl.stage.Forms.LowFormOptimized
 
   override def addFormalStatement(formals: mutable.Map[Expression, ArrayBuffer[Seq[Any]]],
                                   clk: Expression, en: Expression,

--- a/src/main/scala/firrtl/stage/Forms.scala
+++ b/src/main/scala/firrtl/stage/Forms.scala
@@ -72,7 +72,8 @@ object Forms {
     Seq( Dependency(passes.RemoveValidIf),
          Dependency(passes.PadWidths),
          Dependency(passes.memlib.VerilogMemDelays),
-         Dependency(passes.SplitExpressions) )
+         Dependency(passes.SplitExpressions),
+         Dependency[firrtl.transforms.LegalizeAndReductionsTransform] )
 
   val LowFormOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
     Seq( Dependency[firrtl.transforms.ConstantPropagation],
@@ -94,6 +95,10 @@ object Forms {
          Dependency[firrtl.AddDescriptionNodes] )
 
   val VerilogOptimized: Seq[TransformDependency] = LowFormOptimized ++ VerilogMinimumOptimized
+
+  val AssertsRemoved: Seq[TransformDependency] =
+    Seq( Dependency(firrtl.transforms.formal.ConvertAsserts),
+         Dependency[firrtl.transforms.formal.RemoveVerificationStatements] )
 
   val BackendEmitters =
     Seq( Dependency[VerilogEmitter],

--- a/src/test/scala/firrtlTests/CustomTransformSpec.scala
+++ b/src/test/scala/firrtlTests/CustomTransformSpec.scala
@@ -150,13 +150,6 @@ class CustomTransformSpec extends FirrtlFlatSpec {
 
   they should "run right before the emitter* when inputForm=LowForm" in {
 
-    val locationMap = Map(
-      Dependency[LowFirrtlEmitter]      -> Dependency[LowFirrtlEmitter],
-      Dependency[MinimumVerilogEmitter] -> Dependency(ConvertAsserts),
-      Dependency[VerilogEmitter]        -> Dependency(ConvertAsserts),
-      Dependency[SystemVerilogEmitter]  -> Dependency[LegalizeAndReductionsTransform]
-    )
-
     Seq(
       Dependency[LowFirrtlEmitter],
       Dependency[MinimumVerilogEmitter],
@@ -170,7 +163,7 @@ class CustomTransformSpec extends FirrtlFlatSpec {
         .flattenedTransformOrder
         .map(Dependency.fromTransform)
         .sliding(2)
-        .toList should contain (Seq(custom, locationMap(emitter)))
+        .toList should contain (Seq(custom, emitter))
     }
 
   }

--- a/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
+++ b/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
@@ -192,7 +192,8 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
     val tm = new TransformManager(Forms.LowFormMinimumOptimized, Forms.LowForm)
     val patches = Seq(
       Add(4, Seq(Dependency(firrtl.passes.ResolveFlows))),
-      Add(5, Seq(Dependency(firrtl.passes.ResolveKinds)))
+      Add(6, Seq(Dependency[firrtl.transforms.LegalizeAndReductionsTransform],
+                 Dependency(firrtl.passes.ResolveKinds)))
     )
     compare(legacyTransforms(new MinimumLowFirrtlOptimization), tm, patches)
   }
@@ -204,7 +205,8 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
     val patches = Seq(
       Add(6, Seq(Dependency(firrtl.passes.ResolveFlows))),
       Add(7, Seq(Dependency(firrtl.passes.Legalize))),
-      Add(8, Seq(Dependency(firrtl.passes.ResolveKinds)))
+      Add(8, Seq(Dependency[firrtl.transforms.LegalizeAndReductionsTransform],
+                 Dependency(firrtl.passes.ResolveKinds)))
     )
     compare(legacyTransforms(new LowFirrtlOptimization), tm, patches)
   }


### PR DESCRIPTION
Move new transforms, recently added, into existing or new sets of
transforms (defined in firrtl.stage.Forms).

One transform is a mandatory low FIRRTL optimization:

  - firrtl.transforms.LegalizeAndReductionsTransform

Previously, this was included as a prerequisite of all Verilog
emitters (minimum, normal, and SystemVerilog).

Two transforms associated with converting and removing the new
verification statements are moved into a new set of transforms,
AssertsRemoved:

  - firrtl.transforms.formal.ConvertAsserts
  - firrtl.transforms.formal.RemoveVerificationStatements

Previously, these transforms were directly added as prerequisites to
the minimum Verilog and normal Verilog emitter, but not the
SystemVerilog emitter.

The designation of inputForm=LowForm for legacy, custom transforms is
updated to include assertion removal transforms as part of their
optionalPrerequisites. This has the effect of continuing to cause
inputForm=LowForm transforms to run as late as possible (right before
the low FIRRTL, minimum Verilog, Verilog, or SystemVeriog emitter).

Tests are updated to reflect the new order in both CustomTransformSpec
and LoweringCompilersSpec. This commit also simplifies the test used
in the CustomTransformSpec to assert that inputForm=LowForm legacy
transforms run right before the emitter. The new test looks only for a
list of (customTransform, emitter) in a sliding, size-2 window of the
flattened transform order. Previously, this was looking for a match
before and after the custom transform. The old implementation
necessitate busywork updates of the test when new transforms are added
that changed the transform running before the custom transform.

Depends on #1753.

This should not be backported due to references to 1.4 verification statements.

### Contributor Checklist

- [n/a] Did you add Scaladoc to every public function/method?
- [n/a] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- x ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
- code refactoring
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

This adds `firrtl.stage.Forms.AssertRemoved` to the API.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

None

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
