### PR TITLE
Change ProtoBuf generated directory

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,8 +65,7 @@ lazy val protobufSettings = Seq(
   sourceDirectory in ProtobufConfig := baseDirectory.value / "src" / "main" / "proto",
   protobufRunProtoc in ProtobufConfig := (args =>
     com.github.os72.protocjar.Protoc.runProtoc("-v351" +: args.toArray)
-  ),
-  javaSource in ProtobufConfig := (sourceManaged in Compile).value
+  )
 )
 
 lazy val assemblySettings = Seq(


### PR DESCRIPTION
Changed from target/<scala-version>/src_managed/main/firrtl/ to
target/<scala-version>/src_managed/main/compiled_protobuf/firrtl/
The protobuf generation clears its target directory so it would clear
the generated ANTLR-generated files.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [NA] Did you add at least one test demonstrating the PR?
- [NA] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - bug fix   

#### API Impact

None, unless someone was depending on the target directory for Protobuf source generation

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

None

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged

#### Release Notes

Improved SBT build

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
