### PR TITLE
Fix Fuzzer for 2.11

### DIFF
--- a/fuzzer/src/main/scala/firrtl/ExprGenParams.scala
+++ b/fuzzer/src/main/scala/firrtl/ExprGenParams.scala
@@ -70,7 +70,7 @@ sealed trait ExprGenParams {
         case SIntType(IntWidth(width)) if width == BigInt(1) => ExprGen.ReferenceGen.boolSIntGen[ExprGenParams, G].get
         case SIntType(IntWidth(width)) => ExprGen.ReferenceGen.sintGen[ExprGenParams, G].get(width)
       }
-      unboundRefs <- StateGen.inspect { ExprState[ExprGenParams].unboundRefs(_) }
+      unboundRefs <- StateGen.inspect { ExprState[ExprGenParams].unboundRefs }
     } yield {
       val outputPort = Port(
         NoInfo,

--- a/fuzzer/src/main/scala/firrtl/FirrtlCompileTests.scala
+++ b/fuzzer/src/main/scala/firrtl/FirrtlCompileTests.scala
@@ -32,7 +32,7 @@ trait SourceOfRandomnessGen[A] {
 
 object SourceOfRandomnessGen {
   implicit def sourceOfRandomnessGenGenMonadInstance(implicit r: SourceOfRandomness): GenMonad[SourceOfRandomnessGen] = new GenMonad[SourceOfRandomnessGen] {
-    import scala.collection.JavaConverters.seqAsJavaList
+    import scala.collection.JavaConverters.seqAsJavaListConverter
     type G[T] = SourceOfRandomnessGen[T]
     def flatMap[A, B](a: G[A])(f: A => G[B]): G[B] = a.flatMap(f)
     def map[A, B](a: G[A])(f: A => B): G[B] = a.map(f)
@@ -40,8 +40,8 @@ object SourceOfRandomnessGen {
       r.nextLong(min, max).toInt // use r.nextLong instead of r.nextInt because r.nextInt is exclusive of max
     }
     def oneOf[T](items: T*): G[T] = {
-      val arr = seqAsJavaList(items)
-      const(arr).map(r.choose(_))
+      val arr = seqAsJavaListConverter(items)
+      const(arr.asJava).map(r.choose(_))
     }
     def const[T](c: T): G[T] = SourceOfRandomnessGen(c)
     def widen[A, B >: A](ga: G[A]): G[B] = ga.widen[B]


### PR DESCRIPTION
This fixes two issues with the Fuzzer when running '+publishLocal':

- Avoid foo(_) pattern due to weaker 2.11 type inference
- Use seqAsJavaListConverter instead of seqAsJavaList (a 2.12
  addition)

Specifically, this is fixing:

```
[error] /home/chisel/repo/firrtl/fuzzer/src/main/scala/firrtl/ExprGenParams.scala:73:78: missing parameter type for expanded function ((x$1) => ExprState[ExprGenParams].unboundRefs(x$1))
[error]       unboundRefs <- StateGen.inspect { ExprState[ExprGenParams].unboundRefs(_) }
[error]                                                                              ^
[error] /home/chisel/repo/firrtl/fuzzer/src/main/scala/firrtl/FirrtlCompileTests.scala:35:12: value seqAsJavaList is not a member of object scala.collection.JavaConverters
[error]     import scala.collection.JavaConverters.seqAsJavaList
[error]            ^
[error] /home/chisel/repo/firrtl/fuzzer/src/main/scala/firrtl/FirrtlCompileTests.scala:43:17: not found: value seqAsJavaList
[error]       val arr = seqAsJavaList(items)
[error]                 ^
```

I was doing the changes for `seqAsJavaList` purely by looking at the API doc, so this may not be right.

Note: A test exercising this should be added as `sbt +publishLocal` for FIRRTL master is currently a part of Chisel CI.

### Contributor Checklist

- [n/a] Did you add Scaladoc to every public function/method?
- [n/a] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR? (Tested with https://github.com/freechipsproject/firrtl/pull/1772.)
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

None.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
None.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
