### PR TITLE
Make InferWidths thread safe

### DIFF
--- a/src/main/scala/firrtl/passes/InferWidths.scala
+++ b/src/main/scala/firrtl/passes/InferWidths.scala
@@ -14,7 +14,7 @@ import firrtl.options.Dependency
 
 object InferWidths {
   def apply(): InferWidths = new InferWidths()
-  def run(c: Circuit): Circuit = new InferWidths().run(c)
+  def run(c: Circuit): Circuit = new InferWidths().run(c)(new ConstraintSolver)
   def execute(state: CircuitState): CircuitState = new InferWidths().execute(state)
 }
 
@@ -73,11 +73,13 @@ class InferWidths extends Transform
          Dependency[passes.TrimIntervals] ) ++ firrtl.stage.Forms.WorkingIR
   override def invalidates(a: Transform) = false
 
-  private val constraintSolver = new ConstraintSolver()
-
   val annotationClasses = Seq(classOf[WidthGeqConstraintAnnotation])
 
-  private def addTypeConstraints(r1: ReferenceTarget, r2: ReferenceTarget)(t1: Type, t2: Type): Unit = (t1,t2) match {
+  private def addTypeConstraints
+    (r1: ReferenceTarget, r2: ReferenceTarget)
+    (t1: Type, t2: Type)
+    (implicit constraintSolver: ConstraintSolver)
+      : Unit = (t1,t2) match {
     case (UIntType(w1), UIntType(w2)) => constraintSolver.addGeq(w1, w2, r1.prettyPrint(""), r2.prettyPrint(""))
     case (SIntType(w1), SIntType(w2)) => constraintSolver.addGeq(w1, w2, r1.prettyPrint(""), r2.prettyPrint(""))
     case (ClockType, ClockType) =>
@@ -105,14 +107,16 @@ class InferWidths extends Transform
     case (_, ResetType) => Nil
   }
 
-  private def addExpConstraints(e: Expression): Expression = e map addExpConstraints match {
+  private def addExpConstraints(e: Expression)(implicit constraintSolver: ConstraintSolver)
+      : Expression = e map addExpConstraints match {
     case m@Mux(p, tVal, fVal, t) =>
       constraintSolver.addGeq(getWidth(p), Closed(1), "mux predicate", "1.W")
       m
     case other => other
   }
 
-  private def addStmtConstraints(mt: ModuleTarget)(s: Statement): Statement = s map addExpConstraints match {
+  private def addStmtConstraints(mt: ModuleTarget)(s: Statement)(implicit constraintSolver: ConstraintSolver)
+      : Statement = s map addExpConstraints match {
     case c: Connect =>
       val n = get_size(c.loc.tpe)
       val locs = create_exps(c.loc)
@@ -155,12 +159,12 @@ class InferWidths extends Transform
       c map addStmtConstraints(mt)
     case x => x map addStmtConstraints(mt)
   }
-  private def fixWidth(w: Width): Width = constraintSolver.get(w) match {
+  private def fixWidth(w: Width)(implicit constraintSolver: ConstraintSolver): Width = constraintSolver.get(w) match {
     case Some(Closed(x)) if trim(x).isWhole => IntWidth(x.toBigInt)
     case None => w
     case _ => sys.error("Shouldn't be here")
   }
-  private def fixType(t: Type): Type = t map fixType map fixWidth match {
+  private def fixType(t: Type)(implicit constraintSolver: ConstraintSolver): Type = t map fixType map fixWidth match {
     case IntervalType(l, u, p) =>
       val (lx, ux) = (constraintSolver.get(l), constraintSolver.get(u)) match {
         case (Some(x: Bound), Some(y: Bound)) => (x, y)
@@ -173,12 +177,12 @@ class InferWidths extends Transform
     case FixedType(w, p) => FixedType(w, fixWidth(p))
     case x => x
   }
-  private def fixStmt(s: Statement): Statement = s map fixStmt map fixType
-  private def fixPort(p: Port): Port = {
+  private def fixStmt(s: Statement)(implicit constraintSolver: ConstraintSolver): Statement = s map fixStmt map fixType
+  private def fixPort(p: Port)(implicit constraintSolver: ConstraintSolver): Port = {
     Port(p.info, p.name, p.direction, fixType(p.tpe))
   }
 
-  def run (c: Circuit): Circuit = {
+  def run (c: Circuit)(implicit constraintSolver: ConstraintSolver): Circuit = {
     val ct = CircuitTarget(c.main)
     c.modules foreach ( m => m map addStmtConstraints(ct.module(m.name)))
     constraintSolver.solve()
@@ -190,6 +194,8 @@ class InferWidths extends Transform
   }
 
   def execute(state: CircuitState): CircuitState = {
+    implicit val constraintSolver = new ConstraintSolver()
+
     val circuitName = state.circuit.main
     val typeMap = new collection.mutable.HashMap[ReferenceTarget, Type]
 


### PR DESCRIPTION
Change the class-global, but private ConstraintSolver object inside
InferWidths to instead be constructed on each execute invocation. This
prevents issues with thread safety where running the same InferWidths
object at the same time would cause the ConstraintSolver to get
trampled on.

Fixes #1774.

### Contributor Checklist

- [n/a] Did you add Scaladoc to every public function/method?
- [n/a] Did you update the FIRRTL spec to include every new feature/behavior?
- [no] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix                           
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

None.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Fix thread safety bug in InferWidths

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
