### PR TITLE
Update negative literal emission

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -7,7 +7,7 @@ import java.io.Writer
 import scala.collection.mutable
 import firrtl.ir._
 import firrtl.passes._
-import firrtl.transforms.LegalizeAndReductionsTransform
+import firrtl.transforms.{FixAddingNegativeLiterals, LegalizeAndReductionsTransform}
 import firrtl.annotations._
 import firrtl.traversals.Foreachers._
 import firrtl.PrimOps._
@@ -286,6 +286,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
      case SIntLiteral(value, IntWidth(width)) =>
        val stringLiteral = value.toString(16)
        w write (stringLiteral.head match {
+         case '-' if value == FixAddingNegativeLiterals.minNegValue(width) => s"$width'sh${stringLiteral.tail}"
          case '-' => s"-$width'sh${stringLiteral.tail}"
          case _ => s"$width'sh${stringLiteral}"
        })

--- a/src/test/scala/firrtlTests/AsyncResetSpec.scala
+++ b/src/test/scala/firrtlTests/AsyncResetSpec.scala
@@ -278,7 +278,7 @@ class AsyncResetSpec extends FirrtlFlatSpec {
         |z <= r""".stripMargin
       )
     fixedResult should containLine ("always @(posedge clock or posedge reset) begin")
-    fixedResult should containLine ("r <= -2'sh2;")
+    fixedResult should containLine ("r <= 2'sh2;")
 
     val intervalResult = compileBody(s"""
         |input clock : Clock

--- a/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+++ b/src/test/scala/firrtlTests/ConstantPropagationTests.scala
@@ -1604,4 +1604,14 @@ class ConstantPropagationEquivalenceSpec extends FirrtlFlatSpec {
          |    out <= head_temp""".stripMargin
     firrtlEquivalenceTest(input, transforms)
   }
+
+   "addition of negative literals" should "be propagated" in {
+     val input =
+       s"""circuit AddTester :
+          |  module AddTester :
+          |    output ref : SInt<2>
+          |    ref <= add(SInt<1>("h-1"), SInt<1>("h-1"))
+          |""".stripMargin
+     firrtlEquivalenceTest(input, transforms)
+   }
 }


### PR DESCRIPTION
fixes https://github.com/freechipsproject/firrtl/issues/1755

This changes the way verilog is emitted for minimum value negative literals. in the example
```
module AddTester_ref(
  output [1:0] out
);
  assign out = -1'sh1 - 2'sh1;
endmodule
```
`-1'sh1` evaluates to `2'sh1` since `1'sh1` is already -1. This PR updates the emitter to not prepend the unary `-` to the emitted literal, since the hex value is already correct.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [n/a] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->
- bug fix

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
none

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
instead of `-1'h1`, `-2'h2`, `-3'h4`, ... emits `1'h1`, `2'h2`, `3h4`, ...

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
- Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
