### PR TITLE
Fix sign extension issue in Emitter

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -398,7 +398,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
          error("Verilog emitter does not support SHIFT_RIGHT >= arg width")
        case Shr if c0 == (bitWidth(a0.tpe)-1) => Seq(a0,"[", bitWidth(a0.tpe) - 1, "]")
        case Shr => Seq(a0,"[", bitWidth(a0.tpe) - 1, ":", c0, "]")
-       case Neg => Seq("-{", cast(a0), "}")
+       case Neg => Seq("-", cast(a0))
        case Cvt => a0.tpe match {
          case (_: UIntType) => Seq("{1'b0,", cast(a0), "}")
          case (_: SIntType) => Seq(cast(a0))

--- a/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+++ b/src/test/scala/firrtlTests/ConstantPropagationTests.scala
@@ -1614,4 +1614,14 @@ class ConstantPropagationEquivalenceSpec extends FirrtlFlatSpec {
           |""".stripMargin
      firrtlEquivalenceTest(input, transforms)
    }
+
+  "propagation of signed expressions" should "have the correct signs" in {
+    val input =
+      s"""circuit SignTester :
+         |  module SignTester :
+         |    output ref : SInt<3>
+         |    ref <= mux(UInt<1>("h0"), SInt<3>("h0"), neg(UInt<2>("h3")))
+         |""".stripMargin
+    firrtlEquivalenceTest(input, transforms)
+  }
 }


### PR DESCRIPTION
fixes https://github.com/freechipsproject/firrtl/issues/1751

Here is what I think is happening based on my interpretation of the verilog spec and the yosys results. I could be completely wrong though.

In the module below, `ref_` is equivalent to `3'sh1`:  `-$signed(2'h3)` evaluates to `2'sh1` and then is sign extended to `3'sh1`.
```verilog
module SignTester_ref(
  output [2:0] ref_
);
  assign ref_ = -$signed(2'h3);
endmodule
```

however in this module, `ref_` is equivalent to `3'sh5`:  in a context-determined expression with width 3, `$signed(2'h3)` would be sign-extended to `3sh7`, but since all operands within `{...}` are self-determined, its width is 2 instead of 3. And since the result of `{...}` is always unsigned the result is zero-extended, so `{$signed(2'h3)}` evaluates to `3'h3`, and when it is negated it becomes `3'sh5` 
```verilog
module SignTester_ref(
  output [2:0] ref_
);
  assign ref_ = -{$signed(2'h3)};
endmodule
```

`DoPrim(Neg, ...)` of a literal is not constant propagated, so in most cases the `verilog` and `mverilog` compilers emit equivalent, incorrect code. However in the case of `Mux`, the true and false cases are wrapped in another `$signed` call.
```verilog
module SignTester_ref(
  output [2:0] ref_
);
  assign ref_ = 1'h0 ? $signed(3'sh0) : $signed(-{$signed(2'h3)});
endmodule
```
In this case `ref_` is equivalent to `3sh'1`, because the argument of `$signed(_)` is self-determined so `{$signed(2'h3)}` does not get zero-extended to `3h'3` and instead evaluates to `2h'3`, which is -1 when converted to a signed number. so the operand of `-` evaluates to `2sh'3` which then gives `2sh'1`. so the outer `$signed` recieves `2'h1` and evaluates to `3'h1` since it is a context-determined expression and `ref_` has width 3.

This PR changes the emission of `Neg(a0)` from `-{a0}` to `-a0`, which allows `a0` to be sign-extended in context-determined expressions rather than always zero-extending.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->
- bug fix

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
none

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
instead of emitting `-{a0}` for the firrtl expression `neg(a0)`, emit `-a0`

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
- Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
