### PR TITLE
Added empty annotation to AnnotationSeq

### DIFF
--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -18,10 +18,13 @@ import firrtl.stage.Forms
 
 /** Container of all annotations for a Firrtl compiler */
 class AnnotationSeq private (private[firrtl] val underlying: List[Annotation]) {
-  def toSeq: Seq[Annotation] = underlying.toSeq
+  def toSeq: Seq[Annotation] = underlying.toSeq  
 }
 object AnnotationSeq {
   def apply(xs: Seq[Annotation]): AnnotationSeq = new AnnotationSeq(xs.toList)
+
+  // Empty Annotation list for integration, debug and testing
+  val empty = Seq.empty[Annotation]
 }
 
 /** Current State of the Circuit


### PR DESCRIPTION
Oftentimes, you don't wanna specify any annotation, but you need to use the code, which requires `AnnotationSeq` on input.
An example is a Verilog emitter with the following call:

```scala
class Emiter() {

  private lazy val stage = new chisel3.stage.ChiselStage

  def emit(path: String, ann: AnnotationSeq, form: Form): Object = form match {
    case Verilog => stage.execute((Array("-td", path, "-X", "verilog")), ann)
    case High    => stage.execute((Array("-td", path, "-X", "high")), ann)
    case Low     => stage.execute((Array("-td", path, "-X", "low")), ann)
    case _       => new Exception("Unsuppored output format")
  }
}
```

To call this, one needs to do the following: 
```scala
object Emit extends App {
  val emiter = new Emiter {}
  emiter.emit("out", AnnotationSeq(Seq.empty[Annotation]), Verilog)
}
```
Which can be considerably simplified with the following call: `emiter.emit("out", AnnotationSeq.empty, Verilog)`

So this PR Adds `AnnotationSeq.empty` 
