### PR TITLE
RemoveWires: improve dependencies and declare ResolveKinds as an invalidation

### DIFF
--- a/src/main/scala/firrtl/transforms/RemoveWires.scala
+++ b/src/main/scala/firrtl/transforms/RemoveWires.scala
@@ -25,6 +25,7 @@ class RemoveWires extends Transform with DependencyAPIMigration {
   override def prerequisites = firrtl.stage.Forms.MidForm ++
     Seq( Dependency(passes.LowerTypes),
          Dependency(passes.Legalize),
+         Dependency(passes.ResolveKinds),
          Dependency(transforms.RemoveReset),
          Dependency[transforms.CheckCombLoops] )
 
@@ -32,7 +33,10 @@ class RemoveWires extends Transform with DependencyAPIMigration {
 
   override def optionalPrerequisiteOf = Seq.empty
 
-  override def invalidates(a: Transform) = false
+  override def invalidates(a: Transform) = a match {
+    case passes.ResolveKinds => true
+    case  _ => false
+  }
 
   // Extract all expressions that are references to a Node, Wire, or Reg
   // Since we are operating on LowForm, they can only be WRefs
@@ -151,13 +155,7 @@ class RemoveWires extends Transform with DependencyAPIMigration {
     }
   }
 
-  /* @todo move ResolveKinds outside */
-  private val cleanup = Seq(
-    passes.ResolveKinds
-  )
 
-  def execute(state: CircuitState): CircuitState = {
-    val result = state.copy(circuit = state.circuit.map(onModule))
-    cleanup.foldLeft(result) { case (in, xform) => xform.execute(in) }
-  }
+  def execute(state: CircuitState): CircuitState =
+    state.copy(circuit = state.circuit.map(onModule))
 }

--- a/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
+++ b/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
@@ -183,7 +183,11 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
 
   it should "replicate the old order" in {
     val tm = new TransformManager(Forms.LowForm, Forms.MidForm)
-    compare(legacyTransforms(new MiddleFirrtlToLowFirrtl), tm)
+    val patches = Seq(
+      // RemoveWires now visibly invalidates ResolveKinds
+      Add(11, Seq(Dependency(firrtl.passes.ResolveKinds)))
+    )
+    compare(legacyTransforms(new MiddleFirrtlToLowFirrtl), tm, patches)
   }
 
   behavior of "MinimumLowFirrtlOptimization"


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- code refactoring

#### API Impact

- the fixup transform is now visible in the dependency manger

#### Backend Code Generation Impact

- none

#### Desired Merge Strategy

- suqash

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you mark as `Please Merge`?
