### PR TITLE
WiringTransform: fix non-determinism

### DIFF
--- a/src/main/scala/firrtl/passes/wiring/Wiring.scala
+++ b/src/main/scala/firrtl/passes/wiring/Wiring.scala
@@ -81,7 +81,7 @@ class Wiring(wiSeq: Seq[WiringInfo]) extends Pass {
         case (a, (c, m)) => a ++ Map(m -> (Seq(c) ++ a.getOrElse(m, Nil)) ) }
 
     // Determine "ownership" of sources to sinks via minimum distance
-    val owners = sinksToSources(sinks, source, iGraph)
+    val owners = sinksToSourcesSeq(sinks, source, iGraph)
 
     // Determine port and pending modifications for all sink--source
     // ownership pairs

--- a/src/main/scala/firrtl/passes/wiring/Wiring.scala
+++ b/src/main/scala/firrtl/passes/wiring/Wiring.scala
@@ -87,18 +87,22 @@ class Wiring(wiSeq: Seq[WiringInfo]) extends Pass {
     // ownership pairs
     val meta = new mutable.HashMap[String, Modifications]
       .withDefaultValue(Modifications())
+
+    // only make something a wire if it isn't an output or input already
+    def makeWire(m: Modifications, portName: String): Modifications =
+      m.copy(addPortOrWire = Some(m.addPortOrWire.getOrElse((portName, DecWire))))
+    def makeWireC(m: Modifications, portName: String, c: (String, String)): Modifications =
+      m.copy(addPortOrWire = Some(m.addPortOrWire.getOrElse((portName, DecWire))), cons = (m.cons :+ c).distinct )
+
     owners.foreach { case (sink, source) =>
       val lca = iGraph.lowestCommonAncestor(sink, source)
 
       // Compute metadata along Sink to LCA paths.
-      sink.drop(lca.size - 1).sliding(2).toList.reverse.map {
+      sink.drop(lca.size - 1).sliding(2).toList.reverse.foreach {
         case Seq(WDefInstance(_,_,pm,_), WDefInstance(_,ci,cm,_)) =>
           val to = s"$ci.${portNames(cm)}"
           val from = s"${portNames(pm)}"
-          meta(pm) = meta(pm).copy(
-            addPortOrWire = Some((portNames(pm), DecWire)),
-            cons = (meta(pm).cons :+( (to, from) )).distinct
-          )
+          meta(pm) = makeWireC(meta(pm), portNames(pm), (to, from))
           meta(cm) = meta(cm).copy(
             addPortOrWire = Some((portNames(cm), DecInput))
           )
@@ -106,17 +110,12 @@ class Wiring(wiSeq: Seq[WiringInfo]) extends Pass {
         case Seq(WDefInstance(_,_,pm,_)) =>
           // Case where the source is also the LCA
           if (source.drop(lca.size).isEmpty) {
-            meta(pm) = meta(pm).copy (
-              addPortOrWire = Some((portNames(pm), DecWire))
-            )
+            meta(pm) = makeWire(meta(pm), portNames(pm))
           } else {
             val WDefInstance(_,ci,cm,_) = source.drop(lca.size).head
             val to = s"${portNames(pm)}"
             val from = s"$ci.${portNames(cm)}"
-            meta(pm) = meta(pm).copy(
-              addPortOrWire = Some((portNames(pm), DecWire)),
-              cons = (meta(pm).cons :+( (to, from) )).distinct
-            )
+            meta(pm) = makeWireC(meta(pm), portNames(pm), (to, from))
           }
       }
 

--- a/src/test/scala/firrtlTests/WiringTests.scala
+++ b/src/test/scala/firrtlTests/WiringTests.scala
@@ -83,9 +83,9 @@ class WiringTests extends FirrtlFlatSpec {
          |    x.clock <= clock
          |    inst d of D
          |    d.clock <= clock
-         |    d.r <= r
-         |    r <= b.r
          |    x.pin <= r
+         |    r <= b.r
+         |    d.r <= r
          |  module B :
          |    input clock: Clock
          |    output r: UInt<5>
@@ -169,9 +169,9 @@ class WiringTests extends FirrtlFlatSpec {
          |    x.clock <= clock
          |    inst d of D
          |    d.clock <= clock
-         |    d.r <= r
-         |    r <= b.r
          |    x.pin <= r
+         |    r <= b.r
+         |    d.r <= r
          |  module B :
          |    input clock: Clock
          |    output r: UInt<5>
@@ -256,9 +256,9 @@ class WiringTests extends FirrtlFlatSpec {
          |    x.clock <= clock
          |    inst d of D
          |    d.clock <= clock
-         |    d.r <= r
-         |    r <= b.r
          |    x.pin <= r
+         |    r <= b.r
+         |    d.r <= r
          |  module B :
          |    input clock: Clock
          |    output r: UInt<5>


### PR DESCRIPTION
While the order of connections does not matter for correctness, we want a stable result.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- non-determinism fix

#### API Impact
- changes the signature of `WiringUtils.sinksToSources` to return a Seq of tuples instead of a map
- this did not have any impact on the code inside the `firrtl` compiler, but an external user might have to add a `toMap`

#### Backend Code Generation Impact

- can change the order in which signals are connected by the `WiringTransform` but now it should be deterministic

#### Desired Merge Strategy
- squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you mark as `Please Merge`?
