### PR TITLE
Fix dshlw in checktypes

### DIFF
--- a/src/main/scala/firrtl/passes/CheckTypes.scala
+++ b/src/main/scala/firrtl/passes/CheckTypes.scala
@@ -195,7 +195,7 @@ object CheckTypes extends Pass {
       e.op match {
         case AsUInt | AsSInt | AsClock | AsFixedPoint | AsAsyncReset | AsInterval =>
           // All types are ok
-        case Dshl | Dshr =>
+        case Dshl | Dshr | Dshlw =>
           checkAllTypes(Seq(e.args.head), okUInt=true, okSInt=true,  okClock=false, okFix=true,  okAsync=false, okInterval=true)
           checkAllTypes(Seq(e.args(1)),   okUInt=true, okSInt=false, okClock=false, okFix=false, okAsync=false, okInterval=false)
         case Add | Sub | Mul | Lt | Leq | Gt | Geq | Eq | Neq =>


### PR DESCRIPTION
Fixes Problems with CheckTypes when left shifting an Interval
Dshlw can be encountered in CheckTypes and it has similar argument types to Dshl
Added a test that only passes with new CheckTypes

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [na] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

Bug fix. Dsptools fails in IntervalSpec due to CheckTypes error

#### API Impact

Should have no impact on existing API

#### Backend Code Generation Impact

No change to backend verilog

#### Desired Merge Strategy
Squash

#### Release Notes
Fixed problem where left shifting and Interval could generated firrtl error

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
