### PR TITLE
ir: use Serializer.serialize where possible

### DIFF
--- a/src/main/scala/firrtl/AddDescriptionNodes.scala
+++ b/src/main/scala/firrtl/AddDescriptionNodes.scala
@@ -79,7 +79,7 @@ case class Attribute(string: StringLit) extends Description {
   * @param stmt the encapsulated statement
   */
 private case class DescribedStmt(descriptions: Seq[Description], stmt: Statement) extends Statement with HasDescription {
-  def serialize: String = s"${descriptions.map(_.serialize).mkString("\n")}\n${stmt.serialize}"
+  override def serialize: String = s"${descriptions.map(_.serialize).mkString("\n")}\n${stmt.serialize}"
   def mapStmt(f: Statement => Statement): Statement = f(stmt)
   def mapExpr(f: Expression => Expression): Statement = this.copy(stmt = stmt.mapExpr(f))
   def mapType(f: Type => Type): Statement = this.copy(stmt = stmt.mapType(f))
@@ -104,7 +104,7 @@ private case class DescribedMod(descriptions: Seq[Description],
   val info = mod.info
   val name = mod.name
   val ports = mod.ports
-  def serialize: String = s"${descriptions.map(_.serialize).mkString("\n")}\n${mod.serialize}"
+  override def serialize: String = s"${descriptions.map(_.serialize).mkString("\n")}\n${mod.serialize}"
   def mapStmt(f: Statement => Statement): DefModule = this.copy(mod = mod.mapStmt(f))
   def mapPort(f: Port => Port): DefModule = this.copy(mod = mod.mapPort(f))
   def mapString(f: String => String): DefModule = this.copy(mod = mod.mapString(f))

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -167,7 +167,7 @@ case class VRandom(width: BigInt) extends Expression {
   def tpe = UIntType(IntWidth(width))
   def nWords = (width + 31) / 32
   def realWidth = nWords * 32
-  def serialize: String = "RANDOM"
+  override def serialize: String = "RANDOM"
   def mapExpr(f: Expression => Expression): Expression = this
   def mapType(f: Type => Type): Expression = this
   def mapWidth(f: Width => Width): Expression = this

--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -234,6 +234,7 @@ object Utils extends LazyLogging {
   def isTemp(str: String): Boolean = str.head == '_'
 
   /** Indent the results of [[ir.FirrtlNode.serialize]] */
+  @deprecated("Use ther new firrt.ir.Serializer instead.", "FIRRTL 1.4")
   def indent(str: String) = str replaceAllLiterally ("\n", "\n  ")
 
   implicit def toWrappedExpression (x:Expression): WrappedExpression = new WrappedExpression(x)

--- a/src/main/scala/firrtl/WIR.scala
+++ b/src/main/scala/firrtl/WIR.scala
@@ -65,7 +65,6 @@ object WSubAccess {
 
 case object WVoid extends Expression {
   def tpe = UnknownType
-  def serialize: String = "VOID"
   def mapExpr(f: Expression => Expression): Expression = this
   def mapType(f: Type => Type): Expression = this
   def mapWidth(f: Width => Width): Expression = this
@@ -75,7 +74,6 @@ case object WVoid extends Expression {
 }
 case object WInvalid extends Expression {
   def tpe = UnknownType
-  def serialize: String = "INVALID"
   def mapExpr(f: Expression => Expression): Expression = this
   def mapType(f: Type => Type): Expression = this
   def mapWidth(f: Width => Width): Expression = this
@@ -86,7 +84,6 @@ case object WInvalid extends Expression {
 // Useful for splitting then remerging references
 case object EmptyExpression extends Expression {
   def tpe = UnknownType
-  def serialize: String = "EMPTY"
   def mapExpr(f: Expression => Expression): Expression = this
   def mapType(f: Type => Type): Expression = this
   def mapWidth(f: Width => Width): Expression = this
@@ -109,8 +106,6 @@ case class WDefInstanceConnector(
     module: String,
     tpe: Type,
     portCons: Seq[(Expression, Expression)]) extends Statement with IsDeclaration {
-  def serialize: String = s"inst $name of $module with ${tpe.serialize} connected to " +
-                          portCons.map(_._2.serialize).mkString("(", ", ", ")") + info.serialize
   def mapExpr(f: Expression => Expression): Statement =
     this.copy(portCons = portCons map { case (e1, e2) => (f(e1), f(e2)) })
   def mapStmt(f: Statement => Statement): Statement = this
@@ -186,7 +181,7 @@ private[firrtl] case class InfoExpr(info: Info, expr: Expression) extends Expres
   def tpe: Type = expr.tpe
 
   // Members declared in firrtl.ir.FirrtlNode
-  def serialize: String = s"(${expr.serialize}: ${info.serialize})"
+  override def serialize: String = s"(${expr.serialize}: ${info.serialize})"
 }
 
 private[firrtl] object InfoExpr {
@@ -331,8 +326,6 @@ case class CDefMemory(
     size: BigInt,
     seq: Boolean,
     readUnderWrite: ReadUnderWrite.Value = ReadUnderWrite.Undefined) extends Statement with HasInfo {
-  def serialize: String = (if (seq) "smem" else "cmem") +
-    s" $name : ${tpe.serialize} [$size]" + info.serialize
   def mapExpr(f: Expression => Expression): Statement = this
   def mapStmt(f: Statement => Statement): Statement = this
   def mapType(f: Type => Type): Statement = this.copy(tpe = f(tpe))
@@ -350,10 +343,6 @@ case class CDefMPort(info: Info,
     mem: String,
     exps: Seq[Expression],
     direction: MPortDir) extends Statement with HasInfo {
-  def serialize: String = {
-    val dir = direction.serialize
-    s"$dir mport $name = $mem[${exps.head.serialize}], ${exps(1).serialize}" + info.serialize
-  }
   def mapExpr(f: Expression => Expression): Statement = this.copy(exps = exps map f)
   def mapStmt(f: Statement => Statement): Statement = this
   def mapType(f: Type => Type): Statement = this.copy(tpe = f(tpe))

--- a/src/main/scala/firrtl/ir/Serializer.scala
+++ b/src/main/scala/firrtl/ir/Serializer.scala
@@ -46,9 +46,14 @@ object Serializer {
   private def s(node: Info)(implicit b: StringBuilder, indent: Int): Unit = node match {
     case f : FileInfo => b ++= " @[" ; b ++= f.escaped ; b ++= "]"
     case NoInfo => // empty string
-    case MultiInfo(infos) =>
-      val ii = flattenInfo(infos)
-      b ++= " @[" ; sInfo(ii, ", ") ; b ++= "]"
+    case m : MultiInfo =>
+      val infos = m.flatten
+      if(infos.nonEmpty) {
+        val lastId = infos.length - 1
+        b ++= " @["
+        infos.zipWithIndex.foreach { case (f, i) => b ++= f.escaped; if (i < lastId) b += ' ' }
+        b += ']'
+      }
   }
 
   private def s(str: StringLit)(implicit b: StringBuilder, indent: Int): Unit = b ++= str.serialize
@@ -242,17 +247,6 @@ object Serializer {
     while(it.hasNext) {
       s(it.next())
       if(!noFinalSep || it.hasNext) b ++= sep
-    }
-  }
-
-  /** serialize firrtl Info nodes with a custom separator and the option to include the separator at the end */
-  @inline
-  private def sInfo(nodes: Seq[Info], sep: String)
-               (implicit b: StringBuilder, indent: Int): Unit = {
-    val it = nodes.iterator
-    while(it.hasNext) {
-      s(it.next())
-      if(it.hasNext) b ++= sep
     }
   }
 

--- a/src/main/scala/firrtl/ir/Serializer.scala
+++ b/src/main/scala/firrtl/ir/Serializer.scala
@@ -93,6 +93,7 @@ object Serializer {
         newLineAndIndent(1) ; s(alt)(b, indent + 1)
       }
     case EmptyStmt => b ++= "skip"
+    case Block(Seq()) => b ++= "skip"
     case Block(stmts) =>
       val it = stmts.iterator
       while(it.hasNext) {
@@ -196,11 +197,8 @@ object Serializer {
     case Module(info, name, ports, body) =>
       b ++= "module " ; b ++= name ; b ++= " :" ; s(info)
       ports.foreach{ p => newLineAndIndent(1) ;  s(p) }
-      val isEmpty = body == EmptyStmt || body == Block(Seq())
-      if(!isEmpty) {
-        newLineNoIndent() // add a new line between port declaration and body
-        newLineAndIndent(1) ; s(body)(b, indent + 1)
-      }
+      newLineNoIndent() // add a new line between port declaration and body
+      newLineAndIndent(1) ; s(body)(b, indent + 1)
     case ExtModule(info, name, ports, defname, params) =>
       b ++= "extmodule " ; b ++= name ; b ++= " :" ; s(info)
       ports.foreach{ p => newLineAndIndent(1) ; s(p) }

--- a/src/main/scala/firrtl/ir/Serializer.scala
+++ b/src/main/scala/firrtl/ir/Serializer.scala
@@ -245,7 +245,7 @@ object Serializer {
   }
 
   /** serialize firrtl Expression nodes with a custom separator and the option to include the separator at the end */
-  private def s(nodes: Seq[Expression], sep: String, noFinalSep: Boolean = true)
+  private def s(nodes: Iterable[Expression], sep: String, noFinalSep: Boolean = true)
                (implicit b: StringBuilder, indent: Int): Unit = {
     val it = nodes.iterator
     while(it.hasNext) {
@@ -256,7 +256,7 @@ object Serializer {
 
   /** serialize firrtl Field nodes with a custom separator and the option to include the separator at the end */
   @inline
-  private def sField(nodes: Seq[Field], sep: String)
+  private def sField(nodes: Iterable[Field], sep: String)
                (implicit b: StringBuilder, indent: Int): Unit = {
     val it = nodes.iterator
     while(it.hasNext) {
@@ -266,7 +266,7 @@ object Serializer {
   }
 
   /** serialize BigInts with a custom separator */
-  private def s(consts: Seq[BigInt], sep: String)(implicit b: StringBuilder): Unit = {
+  private def s(consts: Iterable[BigInt], sep: String)(implicit b: StringBuilder): Unit = {
     val it = consts.iterator
     while(it.hasNext) {
       b ++= it.next().toString()

--- a/src/main/scala/firrtl/ir/Serializer.scala
+++ b/src/main/scala/firrtl/ir/Serializer.scala
@@ -131,6 +131,9 @@ object Serializer {
     case firrtl.CDefMPort(info, name, _, mem, exps, direction) =>
       b ++= direction.serialize ; b ++= " mport " ; b ++= name ; b ++= " = " ; b ++= mem
       b += '[' ; s(exps.head) ; b ++= "], " ; s(exps(1)) ; s(info)
+    case firrtl.WDefInstanceConnector(info, name, module, tpe, portCons) =>
+      b ++= "inst " ; b ++= name ; b ++= " of " ; b ++= module ; b ++= " with " ; s(tpe) ; b ++= " connected to ("
+      s(portCons.map(_._2), ",  ") ; b += ')' ; s(info)
   }
 
   private def s(node: Width)(implicit b: StringBuilder, indent: Int): Unit = node match {
@@ -214,7 +217,10 @@ object Serializer {
     // Bounds
     case UnknownBound => b += '?'
     case CalcBound(arg) => b ++= "calcb(" ; s(arg) ; b += ')'
-    case other => b ++= other.serialize
+    case VarBound(name) => b ++= name
+    case Open(value) => b ++ "o(" ; b ++= value.toString ; b += ')'
+    case Closed(value) => b ++ "c(" ; b ++= value.toString ; b += ')'
+    case other => other.serialize
   }
 
   /** create a new line with the appropriate indent */

--- a/src/main/scala/firrtl/ir/Serializer.scala
+++ b/src/main/scala/firrtl/ir/Serializer.scala
@@ -73,9 +73,8 @@ object Serializer {
     case SIntLiteral(value, width) =>
       b ++= "SInt" ; s(width) ; b ++= "(\"h" ; b ++= value.toString(16) ; b ++= "\")"
     case FixedLiteral(value, width, point) =>
-      b ++= "Fixed"
-      if(width != UnknownWidth) { b += '<' ; s(width) ; b += '>' }
-      s(point) ; b ++= "(\"h" ; b ++= value.toString(16) ; b ++= "\")"
+      b ++= "Fixed" ; s(width) ; sPoint(point)
+      b ++= "(\"h" ; b ++= value.toString(16) ; b ++= "\")"
     // WIR
     case firrtl.WVoid => b ++= "VOID"
     case firrtl.WInvalid => b ++= "INVALID"
@@ -149,6 +148,13 @@ object Serializer {
     case VarWidth(name) => b += '<'; b ++= name; b += '>'
   }
 
+  private def sPoint(node: Width)(implicit b: StringBuilder, indent: Int): Unit = node match {
+    case IntWidth(width) => b ++= "<<"; b ++= width.toString(); b ++= ">>"
+    case UnknownWidth => // empty string
+    case CalcWidth(arg) => b ++= "calcw("; s(arg); b += ')'
+    case VarWidth(name) => b ++= "<<"; b ++= name; b ++= ">>"
+  }
+
   private def s(node: Orientation)(implicit b: StringBuilder, indent: Int): Unit = node match {
     case Default => // empty string
     case Flip => b ++= "flip "
@@ -162,7 +168,7 @@ object Serializer {
     // Types
     case UIntType(width: Width) => b ++= "UInt"; s(width)
     case SIntType(width: Width) => b ++= "SInt"; s(width)
-    case FixedType(width, point) => b ++= "Fixed"; s(width); s(point)
+    case FixedType(width, point) => b ++= "Fixed"; s(width); sPoint(point)
     case BundleType(fields) => b ++= "{ "; sField(fields, ", "); b += '}'
     case VectorType(tpe, size) => s(tpe); b += '['; b ++= size.toString; b += ']'
     case ClockType => b ++= "Clock"

--- a/src/main/scala/firrtl/passes/memlib/MemIR.scala
+++ b/src/main/scala/firrtl/passes/memlib/MemIR.scala
@@ -39,7 +39,7 @@ case class DefAnnotatedMemory(
     memRef: Option[(String, String)] /* (Module, Mem) */
     //pins: Seq[Pin],
     ) extends Statement with IsDeclaration {
-  def serialize: String = this.toMem.serialize
+  override def serialize: String = this.toMem.serialize
   def mapStmt(f: Statement => Statement): Statement = this
   def mapExpr(f: Expression => Expression): Statement = this
   def mapType(f: Type => Type): Statement = this.copy(dataType = f(dataType))

--- a/src/test/scala/firrtlTests/fixed/FixedSerializationSpec.scala
+++ b/src/test/scala/firrtlTests/fixed/FixedSerializationSpec.scala
@@ -1,0 +1,27 @@
+// See LICENSE for license details.
+
+package firrtlTests
+package fixed
+
+import firrtl.ir
+import org.scalatest.flatspec.AnyFlatSpec
+
+class FixedSerializationSpec extends AnyFlatSpec {
+  behavior of "FixedType"
+
+  it should "serialize correctly" in {
+    assert(ir.FixedType(ir.IntWidth(3), ir.IntWidth(2)).serialize == "Fixed<3><<2>>")
+    assert(ir.FixedType(ir.IntWidth(10), ir.UnknownWidth).serialize == "Fixed<10>")
+    assert(ir.FixedType(ir.UnknownWidth, ir.IntWidth(-4)).serialize == "Fixed<<-4>>")
+    assert(ir.FixedType(ir.UnknownWidth, ir.UnknownWidth).serialize == "Fixed")
+  }
+
+  behavior of "FixedLiteral"
+
+  it should "serialize correctly" in {
+    assert(ir.FixedLiteral(1, ir.IntWidth(3), ir.IntWidth(2)).serialize == "Fixed<3><<2>>(\"h1\")")
+    assert(ir.FixedLiteral(1, ir.IntWidth(10), ir.UnknownWidth).serialize == "Fixed<10>(\"h1\")")
+    assert(ir.FixedLiteral(1, ir.UnknownWidth, ir.IntWidth(-4)).serialize == "Fixed<<-4>>(\"h1\")")
+    assert(ir.FixedLiteral(1, ir.UnknownWidth, ir.UnknownWidth).serialize == "Fixed(\"h1\")")
+  }
+}


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- Did you add at least one test demonstrating the PR?
  - no, but there are many tests that are serializing nodes already
  - some comparison tests were run as part of the PR that added the Serializer
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- code refactoring
- code cleanup (we get more of a single source of truth)

#### API Impact

- `Expression` and `Statement` now implement `serialize`, thus if you want to keep a custom serialize around it needs the `override` keyword

#### Backend Code Generation Impact

- none

#### Desired Merge Strategy

- squash

#### Release Notes

n/a

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
