### PR TITLE
[1.3.x] fix reduction op bug ConstantPropagation (#1746)

### DIFF
--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -774,6 +774,15 @@ object Utils extends LazyLogging {
       .toSeq
       .foldLeft(Seq[String]()){ case (seq, id) => seq :+ name.splitAt(id)._1 }
   }
+
+  /** Returns the value masked with the width.
+    *
+    * This supports truncating negative values as well as values that are too
+    * wide for the width
+    */
+  def maskBigInt(value: BigInt, width: Int): BigInt = {
+    value & ((BigInt(1) << width) - 1)
+  }
 }
 
 object MemoizedHash {

--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -160,7 +160,8 @@ class ConstantPropagation extends Transform with DependencyAPIMigration with Res
         case IntWidth(b) => b
       }
 
-      val v: Seq[Boolean] = s"%${w}s".format(a.value.toString(2)).map(_ == '1')
+      val maskedValue = Utils.maskBigInt(a.value, w.toInt)
+      val v: Seq[Boolean] = s"%${w}s".format(maskedValue.toString(2)).map(_ == '1')
 
       (BigInt(0) until w).zip(v).foldLeft(identityValue) {
         case (acc, (_, x)) => reduce(acc, x)

--- a/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+++ b/src/test/scala/firrtlTests/ConstantPropagationTests.scala
@@ -1604,4 +1604,27 @@ class ConstantPropagationEquivalenceSpec extends FirrtlFlatSpec {
          |    out <= head_temp""".stripMargin
     firrtlEquivalenceTest(input, transforms)
   }
+
+  "reduction of literals" should "be propagated" in {
+    val input =
+      s"""circuit ConstPropReductionTester :
+         |  module ConstPropReductionTester :
+         |    output out1 : UInt<1>
+         |    output out2 : UInt<1>
+         |    output out3 : UInt<1>
+         |    out1 <= xorr(SInt<2>(-1))
+         |    out2 <= andr(SInt<2>(-1))
+         |    out3 <= orr(SInt<2>(-1))""".stripMargin
+    firrtlEquivalenceTest(input, transforms)
+  }
+
+   "addition of negative literals" should "be propagated" in {
+     val input =
+       s"""circuit AddTester :
+          |  module AddTester :
+          |    output ref : SInt<2>
+          |    ref <= add(SInt<1>("h-1"), SInt<1>("h-1"))
+          |""".stripMargin
+     firrtlEquivalenceTest(input, transforms)
+   }
 }


### PR DESCRIPTION
manual backport of https://github.com/freechipsproject/firrtl/pull/1746

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
none

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
none

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
- Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
