### PR TITLE
CircuitGraph: remove fields from public API

### DIFF
--- a/src/main/scala/firrtl/analyses/CircuitGraph.scala
+++ b/src/main/scala/firrtl/analyses/CircuitGraph.scala
@@ -36,25 +36,25 @@ object CircuitGraph {
   *
   * @param connectionGraph Source-to-sink connectivity graph
   */
-class CircuitGraph private[analyses] (val connectionGraph: ConnectionGraph) {
+class CircuitGraph private[analyses] (connectionGraph: ConnectionGraph) {
 
   // Reverse (sink-to-source) connectivity graph
-  lazy val reverseConnectionGraph = connectionGraph.reverseConnectionGraph
+  private lazy val reverseConnectionGraph = connectionGraph.reverseConnectionGraph
 
   // AST Circuit
-  val circuit = connectionGraph.circuit
+  private val circuit = connectionGraph.circuit
 
   // AST Information
-  val irLookup = connectionGraph.irLookup
+  private val irLookup = connectionGraph.irLookup
 
   // Module/Instance Hierarchy information
-  lazy val instanceGraph = new InstanceGraph(circuit)
+  private lazy val instanceGraph = new InstanceGraph(circuit)
 
   // Per module, which modules does it instantiate
-  lazy val moduleChildren = instanceGraph.getChildrenInstanceOfModule
+  private lazy val moduleChildren = instanceGraph.getChildrenInstanceOfModule
 
   // Top-level module target
-  val main = ModuleTarget(circuit.main, circuit.main)
+  private val main = ModuleTarget(circuit.main, circuit.main)
 
   /** Given a signal, return the signals that it drives
     * @param source


### PR DESCRIPTION
They are never used outside of the class
not even in tests.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
  - now that these members are private they do not need Scaladoc anymore!
- [x] Did you add at least one test demonstrating the PR?
  - now that these members are private they do not need extra tests anymore!
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- API fix

#### API Impact
- make members of `CircuitGraph` private before they escape as public API into a release and haunt us forever

#### Backend Code Generation Impact
- none

#### Desired Merge Strategy
- squash

#### Release Notes
n/a

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you mark as `Please Merge`?
