### PR TITLE
Fix verilog emission of negation of negative literal

### DIFF
--- a/src/main/scala/firrtl/stage/Forms.scala
+++ b/src/main/scala/firrtl/stage/Forms.scala
@@ -84,6 +84,7 @@ object Forms {
   val VerilogMinimumOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
     Seq( Dependency[firrtl.transforms.BlackBoxSourceHelper],
          Dependency[firrtl.transforms.FixAddingNegativeLiterals],
+         Dependency[firrtl.transforms.FixNegatingNegativeLiterals],
          Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
          Dependency[firrtl.transforms.InlineBitExtractionsTransform],
          Dependency[firrtl.transforms.InlineCastsTransform],

--- a/src/main/scala/firrtl/transforms/FixNegatingNegativeLiterals.scala
+++ b/src/main/scala/firrtl/transforms/FixNegatingNegativeLiterals.scala
@@ -1,0 +1,48 @@
+// See LICENSE for license details.
+
+package firrtl.transforms
+
+import firrtl.{CircuitState, DependencyAPIMigration, Transform}
+import firrtl.ir._
+import firrtl.options.Dependency
+import firrtl.PrimOps.Neg
+
+/** Constant propagates negation of negative literals
+  *
+  * Negation of negative literals leads to illegal verilog. For example,
+  * neg(SInt<2>(-1)) would emit '--2'sh1' if it were not constant propagated.
+  */
+class FixNegatingNegativeLiterals extends Transform with DependencyAPIMigration {
+
+  override def prerequisites = Seq(
+    Dependency[firrtl.passes.InferWidths],
+    Dependency(firrtl.passes.InferTypes),
+  )
+
+  override def optionalPrerequisites = Seq.empty
+
+  override def optionalPrerequisiteOf = Seq.empty
+
+  override def invalidates(a: Transform) = false
+
+  private def foldNeg(e: DoPrim) = e.args.head match {
+    case UIntLiteral(v, IntWidth(w)) => SIntLiteral(-v, IntWidth(w + 1))
+    case SIntLiteral(v, IntWidth(w)) => SIntLiteral(-v, IntWidth(w + 1))
+    case _ => e
+  }
+
+  private def fixupExpr(e: Expression): Expression = {
+    e.mapExpr(fixupExpr) match {
+      case neg@ DoPrim(Neg, _, _, _) => foldNeg(neg)
+      case _ => e
+    }
+  }
+  private def fixupStmt(stmt: Statement): Statement = {
+    stmt.mapStmt(fixupStmt).mapExpr(fixupExpr)
+  }
+
+  def execute(state: CircuitState): CircuitState = {
+    val modulesx = state.circuit.modules.map(_.mapStmt(fixupStmt))
+    state.copy(circuit = state.circuit.copy(modules = modulesx))
+  }
+}

--- a/src/main/scala/firrtl/transforms/FixNegatingNegativeLiterals.scala
+++ b/src/main/scala/firrtl/transforms/FixNegatingNegativeLiterals.scala
@@ -16,7 +16,7 @@ class FixNegatingNegativeLiterals extends Transform with DependencyAPIMigration 
 
   override def prerequisites = Seq(
     Dependency[firrtl.passes.InferWidths],
-    Dependency(firrtl.passes.InferTypes),
+    Dependency(firrtl.passes.InferTypes)
   )
 
   override def optionalPrerequisites = Seq.empty

--- a/src/test/scala/firrtlTests/VerilogEmitterTests.scala
+++ b/src/test/scala/firrtlTests/VerilogEmitterTests.scala
@@ -233,6 +233,19 @@ class DoPrimVerilog extends FirrtlFlatSpec {
       lines should contain (e)
     }
   }
+
+  "Neg of a negative literal" should "emit correctly" in {
+    val compiler = new VerilogCompiler
+    val input =
+      """circuit DoubleNegative :
+        |  module DoubleNegative :
+        |    output out : SInt<3>
+        |    out <= neg(SInt<2>(-1))
+        |""".stripMargin
+    val result = compiler.compileAndEmit(CircuitState(parse(input), ChirrtlForm), Seq.empty)
+    result shouldNot containLine("assign out = --2'sh1;")
+    result should containLine("assign out = 3'sh1;")
+  }
 }
 
 class VerilogEmitterSpec extends FirrtlFlatSpec {


### PR DESCRIPTION
The verilog emitter emits a double negative `--` for `neg` of a negative literal ex. `Neg(SInt<2>(-1))`. This is illegal because `--` is the decrement operator. This PR adds `FixNegatingNegativeLiterals` to constant prop these nodes.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
adds `FixNegatingNegativeLiterals` transform

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
for `neg(SInt<2>(-1))`, instead of `--2'sh1` emit `3'sh1`.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
- Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
