### PR TITLE
Sane PadWidths

### DIFF
--- a/src/main/scala/firrtl/backends/verilog/PadWidthsVerilog.scala
+++ b/src/main/scala/firrtl/backends/verilog/PadWidthsVerilog.scala
@@ -12,7 +12,7 @@ import firrtl.stage.TransformManager.TransformDependency
 
 
 /** Adds padding for mul, div, rem, dshl which breaks firrtl width invariance, but is nmeeded to match Verilog semantics */
-object PadWidthsVerilog extends firrtl.passes.Pass {
+private[firrtl] object PadWidthsVerilog extends firrtl.passes.Pass {
 
   override def prerequisites: Seq[TransformDependency] = Forms.MidForm ++
     Seq( Dependency(firrtl.passes.LowerTypes),

--- a/src/main/scala/firrtl/backends/verilog/PadWidthsVerilog.scala
+++ b/src/main/scala/firrtl/backends/verilog/PadWidthsVerilog.scala
@@ -1,0 +1,51 @@
+// See LICENSE for license details.
+
+package firrtl.backends.verilog
+
+import firrtl.ir._
+import firrtl.PrimOps._
+import firrtl.Mappers._
+import firrtl.{Dshlw, SystemVerilogEmitter, Transform, VerilogEmitter, bitWidth}
+import firrtl.options.Dependency
+import firrtl.stage.Forms
+import firrtl.stage.TransformManager.TransformDependency
+
+
+/** Adds padding for mul, div, rem, dshl which breaks firrtl width invariance, but is nmeeded to match Verilog semantics */
+object PadWidthsVerilog extends firrtl.passes.Pass {
+
+  override def prerequisites: Seq[TransformDependency] = Forms.MidForm ++
+    Seq( Dependency(firrtl.passes.LowerTypes),
+         Dependency(firrtl.transforms.RemoveReset),
+         Dependency[firrtl.transforms.RemoveWires] )
+
+  override def optionalPrerequisites = Seq(Dependency[firrtl.transforms.ConstantPropagation])
+
+  override def optionalPrerequisiteOf =
+    Seq( Dependency(firrtl.passes.memlib.VerilogMemDelays),
+      Dependency[SystemVerilogEmitter],
+      Dependency[VerilogEmitter] )
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case _: firrtl.transforms.ConstantPropagation | firrtl.passes.Legalize => true
+    case _ => false
+  }
+
+  import firrtl.passes.PadWidths.forceWidth
+  private def getWidth(e: Expression): Int = bitWidth(e.tpe).toInt
+
+  // Recursive, updates expression so children exp's have correct widths
+  private def onExp(e: Expression): Expression = e.map(onExp) match {
+    case ex: DoPrim => ex.op match {
+      case Mul | Div | Rem => ex.map(forceWidth(ex.args.map(getWidth).max))
+      case Dshl =>
+        // special case as args aren't all same width
+        ex copy (op = Dshlw, args = Seq(forceWidth(getWidth(ex))(ex.args.head), ex.args(1)))
+      case _ => ex
+    }
+    case ex => ex
+  }
+
+  private def onStmt(s: Statement): Statement = s.map(onExp).map(onStmt)
+  def run(c: Circuit): Circuit = c.copy(modules = c.modules.map(_.map(onStmt)))
+}

--- a/src/main/scala/firrtl/backends/verilog/PadWidthsVerilog.scala
+++ b/src/main/scala/firrtl/backends/verilog/PadWidthsVerilog.scala
@@ -19,17 +19,12 @@ object PadWidthsVerilog extends firrtl.passes.Pass {
          Dependency(firrtl.transforms.RemoveReset),
          Dependency[firrtl.transforms.RemoveWires] )
 
-  override def optionalPrerequisites = Seq(Dependency[firrtl.transforms.ConstantPropagation])
-
   override def optionalPrerequisiteOf =
     Seq( Dependency(firrtl.passes.memlib.VerilogMemDelays),
       Dependency[SystemVerilogEmitter],
       Dependency[VerilogEmitter] )
 
-  override def invalidates(a: Transform): Boolean = a match {
-    case _: firrtl.transforms.ConstantPropagation | firrtl.passes.Legalize => true
-    case _ => false
-  }
+  override def invalidates(a: Transform): Boolean = false
 
   import firrtl.passes.PadWidths.forceWidth
   private def getWidth(e: Expression): Int = bitWidth(e.tpe).toInt

--- a/src/main/scala/firrtl/backends/verilog/PadWidthsVerilog.scala
+++ b/src/main/scala/firrtl/backends/verilog/PadWidthsVerilog.scala
@@ -7,6 +7,7 @@ import firrtl.PrimOps._
 import firrtl.Mappers._
 import firrtl.{Dshlw, SystemVerilogEmitter, Transform, VerilogEmitter, bitWidth}
 import firrtl.options.Dependency
+import firrtl.passes.SplitExpressions
 import firrtl.stage.Forms
 import firrtl.stage.TransformManager.TransformDependency
 
@@ -24,7 +25,10 @@ private[firrtl] object PadWidthsVerilog extends firrtl.passes.Pass {
       Dependency[SystemVerilogEmitter],
       Dependency[VerilogEmitter] )
 
-  override def invalidates(a: Transform): Boolean = false
+  override def invalidates(a: Transform): Boolean = a match {
+    case SplitExpressions => true // we generate pad and bits operations inline which need to be split up
+    case _ => false
+  }
 
   import firrtl.passes.PadWidths.forceWidth
   private def getWidth(e: Expression): Int = bitWidth(e.tpe).toInt

--- a/src/main/scala/firrtl/passes/PadWidths.scala
+++ b/src/main/scala/firrtl/passes/PadWidths.scala
@@ -31,41 +31,42 @@ object PadWidths extends Pass {
     case _ => false
   }
 
-  private def width(t: Type): Int = bitWidth(t).toInt
-  private def width(e: Expression): Int = width(e.tpe)
-  // Returns an expression with the correct integer width
-  private def fixup(i: Int)(e: Expression) = {
-    def tx = e.tpe match {
-      case t: UIntType => UIntType(IntWidth(i))
-      case t: SIntType => SIntType(IntWidth(i))
-      // default case should never be reached
-    }
-    width(e) match {
-      case j if i > j => DoPrim(Pad, Seq(e), Seq(i), tx)
-      case j if i < j =>
-        val e2 = DoPrim(Bits, Seq(e), Seq(i - 1, 0), UIntType(IntWidth(i)))
-        // Bit Select always returns UInt, cast if selecting from SInt
-        e.tpe match {
-          case UIntType(_) => e2
-          case SIntType(_) => DoPrim(AsSInt, Seq(e2), Seq.empty, SIntType(IntWidth(i)))
-        }
-      case _ => e
+
+  /** Adds padding or a bit extract to ensure that the expression is of the with specified.
+    * @note only works on UInt and SInt type expressions, other expressions will yield a match error */
+  private[firrtl] def forceWidth(width: Int)(e: Expression): Expression = {
+    val old = getWidth(e)
+    if(width == old) { e }
+    else if(width > old) {
+      // padding retains the signedness
+      val newType = e.tpe match {
+        case _: UIntType => UIntType(IntWidth(width))
+        case _: SIntType => SIntType(IntWidth(width))
+        case other => throw new RuntimeException(s"forceWidth does not support expressions of type $other")
+      }
+      DoPrim(Pad, Seq(e), Seq(width), newType)
+    } else {
+      val e2 = DoPrim(Bits, Seq(e), Seq(width - 1, 0), UIntType(IntWidth(width)))
+      // Bit Select always returns UInt, cast if selecting from SInt
+      e.tpe match {
+        case UIntType(_) => e2
+        case SIntType(_) => DoPrim(AsSInt, Seq(e2), Seq.empty, SIntType(IntWidth(width)))
+      }
     }
   }
+
+  private def getWidth(t: Type): Int = bitWidth(t).toInt
+  private def getWidth(e: Expression): Int = getWidth(e.tpe)
 
   // Recursive, updates expression so children exp's have correct widths
   private def onExp(e: Expression): Expression = e map onExp match {
     case Mux(cond, tval, fval, tpe) =>
-      Mux(cond, fixup(width(tpe))(tval), fixup(width(tpe))(fval), tpe)
-    case ex: ValidIf => ex copy (value = fixup(width(ex.tpe))(ex.value))
+      Mux(cond, forceWidth(getWidth(tpe))(tval), forceWidth(getWidth(tpe))(fval), tpe)
+    case ex: ValidIf => ex copy (value = forceWidth(getWidth(ex.tpe))(ex.value))
     case ex: DoPrim => ex.op match {
-      case Lt | Leq | Gt | Geq | Eq | Neq | Not | And | Or | Xor |
-           Add | Sub | Mul | Div | Rem | Shr =>
+      case Lt | Leq | Gt | Geq | Eq | Neq | And | Or | Xor | Add | Sub =>
         // sensitive ops
-        ex map fixup((ex.args map width foldLeft 0)(math.max))
-      case Dshl =>
-        // special case as args aren't all same width
-        ex copy (op = Dshlw, args = Seq(fixup(width(ex.tpe))(ex.args.head), ex.args(1)))
+        ex.map(forceWidth(ex.args.map(getWidth).max))
       case _ => ex
     }
     case ex => ex
@@ -74,9 +75,9 @@ object PadWidths extends Pass {
   // Recursive. Fixes assignments and register initialization widths
   private def onStmt(s: Statement): Statement = s map onExp match {
     case sx: Connect =>
-      sx copy (expr = fixup(width(sx.loc))(sx.expr))
+      sx copy (expr = forceWidth(getWidth(sx.loc))(sx.expr))
     case sx: DefRegister =>
-      sx copy (init = fixup(width(sx.tpe))(sx.init))
+      sx copy (init = forceWidth(getWidth(sx.tpe))(sx.init))
     case sx => sx map onStmt
   }
 

--- a/src/main/scala/firrtl/passes/PadWidths.scala
+++ b/src/main/scala/firrtl/passes/PadWidths.scala
@@ -18,7 +18,10 @@ object PadWidths extends Pass {
   override def prerequisites: Seq[TransformDependency] =
     firrtl.stage.Forms.LowForm :+ Dependency(firrtl.passes.RemoveValidIf)
 
-  override def invalidates(a: Transform): Boolean = false
+  override def invalidates(a: Transform): Boolean = a match {
+    case SplitExpressions => true // we generate pad and bits operations inline which need to be split up
+    case _ => false
+  }
 
   /** Adds padding or a bit extract to ensure that the expression is of the with specified.
     * @note only works on UInt and SInt type expressions, other expressions will yield a match error */

--- a/src/main/scala/firrtl/passes/SplitExpressions.scala
+++ b/src/main/scala/firrtl/passes/SplitExpressions.scala
@@ -7,7 +7,8 @@ import firrtl.{SystemVerilogEmitter, Transform, VerilogEmitter}
 import firrtl.ir._
 import firrtl.options.Dependency
 import firrtl.Mappers._
-import firrtl.Utils.{kind, flow, get_info}
+import firrtl.Utils.{flow, get_info, kind}
+import firrtl.transforms.CombineCats
 
 // Datastructures
 import scala.collection.mutable
@@ -25,7 +26,7 @@ object SplitExpressions extends Pass {
          Dependency[VerilogEmitter] )
 
   override def invalidates(a: Transform) = a match {
-    case ResolveKinds => true
+    case ResolveKinds | _: CombineCats => true
     case _            => false
   }
 

--- a/src/main/scala/firrtl/stage/Forms.scala
+++ b/src/main/scala/firrtl/stage/Forms.scala
@@ -82,7 +82,8 @@ object Forms {
          Dependency[firrtl.transforms.DeadCodeElimination] )
 
   val VerilogMinimumOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
-    Seq( Dependency[firrtl.transforms.BlackBoxSourceHelper],
+    Seq( Dependency(firrtl.backends.verilog.PadWidthsVerilog),
+         Dependency[firrtl.transforms.BlackBoxSourceHelper],
          Dependency[firrtl.transforms.FixAddingNegativeLiterals],
          Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
          Dependency[firrtl.transforms.InlineBitExtractionsTransform],

--- a/src/main/scala/firrtl/stage/Forms.scala
+++ b/src/main/scala/firrtl/stage/Forms.scala
@@ -72,17 +72,17 @@ object Forms {
     Seq( Dependency(passes.RemoveValidIf),
          Dependency(passes.PadWidths),
          Dependency(passes.memlib.VerilogMemDelays),
-         Dependency(passes.SplitExpressions),
-         Dependency[firrtl.transforms.LegalizeAndReductionsTransform] )
+         Dependency(passes.SplitExpressions) )
 
   val LowFormOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
     Seq( Dependency[firrtl.transforms.ConstantPropagation],
-         Dependency[firrtl.transforms.CombineCats],
          Dependency(passes.CommonSubexpressionElimination),
          Dependency[firrtl.transforms.DeadCodeElimination] )
 
   val VerilogMinimumOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
     Seq( Dependency(firrtl.backends.verilog.PadWidthsVerilog),
+         Dependency[firrtl.transforms.LegalizeAndReductionsTransform],
+         Dependency[firrtl.transforms.CombineCats],
          Dependency[firrtl.transforms.BlackBoxSourceHelper],
          Dependency[firrtl.transforms.FixAddingNegativeLiterals],
          Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],

--- a/src/test/scala/firrtlTests/PadWidthsSpec.scala
+++ b/src/test/scala/firrtlTests/PadWidthsSpec.scala
@@ -28,6 +28,32 @@ class PadWidthsSpec extends AnyFlatSpec with FirrtlMatchers {
     executeTest(input, check)
   }
 
+  it should "pad widths of connects" in {
+    val input =
+      """circuit Top :
+        |  module Top :
+        |    output a : UInt<32>
+        |    input b : UInt<20>
+        |    a <= b
+        |    """.stripMargin
+    val check = Seq("a <= pad(b, 32)")
+    executeTest(input, check)
+  }
+
+  it should "pad widths of register init expressions" in {
+    val input =
+      """circuit Top :
+        |  module Top :
+        |    input clock: Clock
+        |    input reset: AsyncReset
+        |
+        |    reg r: UInt<8>, clock with:
+        |      reset => (reset, UInt<1>("h1"))
+        |    """.stripMargin
+    val check = Seq("reset => (reset, pad(UInt<1>(\"h1\"), 8))")
+    executeTest(input, check)
+  }
+
   private def testOp(op: String, width: Int, resultWidth: Int): Unit = {
     assert(width > 0)
     val input =

--- a/src/test/scala/firrtlTests/PadWidthsSpec.scala
+++ b/src/test/scala/firrtlTests/PadWidthsSpec.scala
@@ -50,7 +50,8 @@ class PadWidthsSpec extends AnyFlatSpec with FirrtlMatchers {
         |    reg r: UInt<8>, clock with:
         |      reset => (reset, UInt<1>("h1"))
         |    """.stripMargin
-    val check = Seq("reset => (reset, pad(UInt<1>(\"h1\"), 8))")
+    // PadWidths will call into constant prop directly, thus the literal is widened instead of adding a pad
+    val check = Seq("reset => (reset, UInt<8>(\"h1\"))")
     executeTest(input, check)
   }
 

--- a/src/test/scala/firrtlTests/PadWidthsSpec.scala
+++ b/src/test/scala/firrtlTests/PadWidthsSpec.scala
@@ -1,0 +1,150 @@
+// See LICENSE for license details.
+
+package firrtlTests
+
+import firrtl.CircuitState
+import firrtl.options.Dependency
+import firrtl.stage.{Forms, TransformManager}
+import firrtl.testutils.FirrtlMatchers
+import org.scalatest.flatspec.AnyFlatSpec
+import firrtl.annotations.Annotation
+
+class PadWidthsSpec extends AnyFlatSpec with FirrtlMatchers {
+  private val compiler = new TransformManager(Seq(Dependency(firrtl.passes.PadWidths)))
+
+
+  behavior of "PadWidths pass"
+
+  it should "pad widths inside a mux" in {
+    val input =
+      """circuit Top :
+        |  module Top :
+        |    input a : UInt<32>
+        |    input b : UInt<20>
+        |    input pred : UInt<1>
+        |    output c : UInt<32>
+        |    c <= mux(pred,a,b)""".stripMargin
+    val check = Seq("c <= mux(pred, a, pad(b, 32))")
+    executeTest(input, check)
+  }
+
+  private def testOp(op: String, width: Int, resultWidth: Int): Unit = {
+    assert(width > 0)
+    val input =
+      s"""circuit Top :
+         |  module Top :
+         |    input a : UInt<32>
+         |    input b : UInt<$width>
+         |    output c : UInt<$resultWidth>
+         |    c <= $op(a,b)""".stripMargin
+    val check = if(width < 32) {
+      Seq(s"c <= $op(a, pad(b, 32))")
+    } else if(width == 32) {
+      Seq(s"c <= $op(a, b)")
+    } else {
+      Seq(s"c <= $op(pad(a, $width), b)")
+    }
+    executeTest(input, check)
+  }
+
+  it should "pad widths of the arguments to add and sub" in {
+    // add and sub have the same width inference rule: max(w_1, w_2) + 1
+    testOp("add", 2, 33)
+    testOp("add", 32, 33)
+    testOp("add", 35, 36)
+
+    testOp("sub", 2, 33)
+    testOp("sub", 32, 33)
+    testOp("sub", 35, 36)
+  }
+
+  it should "pad widths of the arguments to and, or and xor" in {
+    // and, or and xor have the same width inference rule: max(w_1, w_2)
+    testOp("and", 2, 32)
+    testOp("and", 32, 32)
+    testOp("and", 35, 35)
+
+    testOp("or", 2, 32)
+    testOp("or", 32, 32)
+    testOp("or", 35, 35)
+
+    testOp("xor", 2, 32)
+    testOp("xor", 32, 32)
+    testOp("xor", 35, 35)
+  }
+
+  it should "pad widths of the arguments to lt, leq, gt, geq, eq and neq" in {
+    // lt, leq, gt, geq, eq and ne have the same width inference rule: 1
+    testOp("lt", 2, 1)
+    testOp("lt", 32, 1)
+    testOp("lt", 35, 1)
+
+    testOp("leq", 2, 1)
+    testOp("leq", 32, 1)
+    testOp("leq", 35, 1)
+
+    testOp("gt", 2, 1)
+    testOp("gt", 32, 1)
+    testOp("gt", 35, 1)
+
+    testOp("geq", 2, 1)
+    testOp("geq", 32, 1)
+    testOp("geq", 35, 1)
+
+    testOp("eq", 2, 1)
+    testOp("eq", 32, 1)
+    testOp("eq", 35, 1)
+
+    testOp("neq", 2, 1)
+    testOp("neq", 32, 1)
+    testOp("neq", 35, 1)
+  }
+
+  private val resolvedCompiler = new TransformManager(Forms.Resolved)
+  private def checkWidthsAfterPadWidths(input: String, op: String): Unit = {
+    val circuit = firrtl.Parser.parse(input)
+    val result = compiler.runTransform(CircuitState(circuit, Seq()))
+
+    // we serialize the result in order to rerun width inference
+    val resultFir = firrtl.Parser.parse(result.circuit.serialize)
+    val newWidths = resolvedCompiler.runTransform(CircuitState(resultFir, Seq()))
+
+    // the newly loaded circuit should look the same in serialized form (if this fails, the test has a bug)
+    assert(newWidths.circuit.serialize == result.circuit.serialize)
+
+    // we compare the widths produced by PadWidths with the widths that would normally be inferred
+    assert(newWidths.circuit.modules.head == result.circuit.modules.head, s"failed with op `$op`")
+  }
+
+  it should "always generate valid firrtl" in {
+    // an older version of PadWidths would generate ill types firrtl for mul, div, rem and dshl
+
+    def input(op: String): String =
+      s"""circuit Top:
+         |  module Top:
+         |    input a: UInt<3>
+         |    input b: UInt<1>
+         |    output c: UInt
+         |    c <= $op(a, b)
+         |""".stripMargin
+
+    def test(op: String): Unit = checkWidthsAfterPadWidths(input(op), op)
+
+    // This was never broken, but we want to make sure that the test works.
+    test("add")
+
+    test("mul")
+    test("div")
+    test("rem")
+    test("dshl")
+  }
+
+  private def executeTest(input: String, expected: Seq[String]): Unit = {
+    val circuit = firrtl.Parser.parse(input.split("\n").toIterator)
+    val result = compiler.runTransform(CircuitState(circuit, Seq()))
+    val lines = result.circuit.serialize.split("\n").map(normalized)
+    expected.map(normalized).foreach { e =>
+      assert(lines.contains(e), f"Failed to find $e in ${lines.mkString("\n")}")
+    }
+  }
+}


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- bug fix 
- code refactoring

#### API Impact
- `PadWidths` now doesn't pad `dshl`, `rem`, `mul` and `div`
- the new `PadWidthsVerilog` pass does the padding which violates Firrtl width invariances

#### Backend Code Generation Impact

- none

#### Desired Merge Strategy

- squash

#### Release Notes
- `PadWidths` now generates only valid firrtl

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
