### PR TITLE
ExpandWhens: VerificationStatements should be part of the simlist

### DIFF
--- a/src/main/scala/firrtl/passes/ExpandWhens.scala
+++ b/src/main/scala/firrtl/passes/ExpandWhens.scala
@@ -133,7 +133,9 @@ object ExpandWhens extends Pass {
       case sx: Stop =>
         simlist += (if (weq(p, one)) sx else Stop(sx.info, sx.ret, sx.clk, AND(p, sx.en)))
         EmptyStmt
-      case sx: Verification => if (weq(p, one)) sx else sx.copy(en = AND(p, sx.en))
+      case sx: Verification =>
+        simlist += (if (weq(p, one)) sx else sx.copy(en = AND(p, sx.en)))
+        EmptyStmt
       // Expand conditionally, see comments below
       case sx: Conditionally =>
         /* 1) Recurse into conseq and alt with empty netlist, updated defaults, updated predicate

--- a/src/test/scala/firrtlTests/formal/VerificationSpec.scala
+++ b/src/test/scala/firrtlTests/formal/VerificationSpec.scala
@@ -2,10 +2,11 @@
 
 package firrtlTests.formal
 
-import firrtl.{SystemVerilogCompiler}
+import firrtl.{CircuitState, SystemVerilogCompiler, ir}
 import firrtl.testutils.FirrtlFlatSpec
 import logger.{LogLevel, Logger}
-import firrtl.ir
+import firrtl.options.Dependency
+import firrtl.stage.TransformManager
 
 class VerificationSpec extends FirrtlFlatSpec {
   behavior of "Formal"
@@ -76,5 +77,21 @@ class VerificationSpec extends FirrtlFlatSpec {
     assert(c.serialize == "assume(clk, pred, en, \"test \\t test\")")
     assert(ir.Serializer.serialize(c) == "assume(clk, pred, en, \"test \\t test\")")
 
+  }
+
+  "VerificationStatements" should "end up at the bottom of the circuit like other simulation statements" in {
+    val compiler = new TransformManager(Seq(Dependency(firrtl.passes.ExpandWhens)))
+    val in =
+      """circuit m :
+        |  module m :
+        |    input clock : Clock
+        |    input a : UInt<8>
+        |    output b : UInt<16>
+        |    b <= a
+        |    assert(clock, eq(a, b), UInt<1>("h1"), "")
+        |""".stripMargin
+    val afterExpandWhens = compiler.transform(CircuitState(firrtl.Parser.parse(in), Seq())).circuit.serialize
+    val lastLine = afterExpandWhens.split("\n").last
+    assert(lastLine.trim.startsWith("assert"))
   }
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- bug fix

#### API Impact

- none

#### Backend Code Generation Impact

- none

#### Desired Merge Strategy
- squash

#### Release Notes
n/a

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you mark as `Please Merge`?
