### PR TITLE
Forms: move Verilog-specific transforms into the emitter

### DIFF
--- a/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
+++ b/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
@@ -12,9 +12,7 @@ object CommonSubexpressionElimination extends Pass {
   override def prerequisites = firrtl.stage.Forms.LowForm ++
     Seq( Dependency(firrtl.passes.RemoveValidIf),
          Dependency[firrtl.transforms.ConstantPropagation],
-         Dependency(firrtl.passes.memlib.VerilogMemDelays),
-         Dependency(firrtl.passes.SplitExpressions),
-         Dependency[firrtl.transforms.CombineCats] )
+         Dependency(firrtl.passes.SplitExpressions))
 
   override def optionalPrerequisiteOf =
     Seq( Dependency[SystemVerilogEmitter],

--- a/src/main/scala/firrtl/passes/PadWidths.scala
+++ b/src/main/scala/firrtl/passes/PadWidths.scala
@@ -13,11 +13,7 @@ import scala.collection.mutable
 // Makes all implicit width extensions and truncations explicit
 object PadWidths extends Pass {
 
-  override def prerequisites =
-    ((new mutable.LinkedHashSet())
-       ++ firrtl.stage.Forms.LowForm
-       - Dependency(firrtl.passes.Legalize)
-       + Dependency(firrtl.passes.RemoveValidIf)).toSeq
+  override def prerequisites = firrtl.stage.Forms.LowForm
 
   override def optionalPrerequisites = Seq(Dependency[firrtl.transforms.ConstantPropagation])
 

--- a/src/main/scala/firrtl/passes/SplitExpressions.scala
+++ b/src/main/scala/firrtl/passes/SplitExpressions.scala
@@ -17,8 +17,7 @@ import scala.collection.mutable
 object SplitExpressions extends Pass {
 
   override def prerequisites = firrtl.stage.Forms.LowForm ++
-    Seq( Dependency(firrtl.passes.RemoveValidIf),
-         Dependency(firrtl.passes.memlib.VerilogMemDelays) )
+    Seq( Dependency(firrtl.passes.RemoveValidIf))
 
   override def optionalPrerequisiteOf =
     Seq( Dependency[SystemVerilogEmitter],

--- a/src/main/scala/firrtl/stage/Forms.scala
+++ b/src/main/scala/firrtl/stage/Forms.scala
@@ -68,21 +68,19 @@ object Forms {
          Dependency[checks.CheckResets],
          Dependency[firrtl.transforms.RemoveWires] )
 
-  val LowFormMinimumOptimized: Seq[TransformDependency] = LowForm ++
-    Seq( Dependency(passes.RemoveValidIf),
-         Dependency(passes.PadWidths),
-         Dependency(passes.memlib.VerilogMemDelays),
-         Dependency(passes.SplitExpressions),
-         Dependency[firrtl.transforms.LegalizeAndReductionsTransform] )
+  val LowFormMinimumOptimized: Seq[TransformDependency] = LowForm ++ Seq(Dependency(passes.memlib.VerilogMemDelays))
 
   val LowFormOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
     Seq( Dependency[firrtl.transforms.ConstantPropagation],
-         Dependency[firrtl.transforms.CombineCats],
          Dependency(passes.CommonSubexpressionElimination),
          Dependency[firrtl.transforms.DeadCodeElimination] )
 
   val VerilogMinimumOptimized: Seq[TransformDependency] = LowFormMinimumOptimized ++
-    Seq( Dependency[firrtl.transforms.BlackBoxSourceHelper],
+    Seq( Dependency(passes.RemoveValidIf),
+         Dependency(passes.PadWidths),
+         Dependency(passes.SplitExpressions),
+         Dependency[firrtl.transforms.LegalizeAndReductionsTransform],
+         Dependency[firrtl.transforms.BlackBoxSourceHelper],
          Dependency[firrtl.transforms.FixAddingNegativeLiterals],
          Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
          Dependency[firrtl.transforms.InlineBitExtractionsTransform],
@@ -94,7 +92,8 @@ object Forms {
          Dependency(passes.VerilogPrep),
          Dependency[firrtl.AddDescriptionNodes] )
 
-  val VerilogOptimized: Seq[TransformDependency] = LowFormOptimized ++ VerilogMinimumOptimized
+  val VerilogOptimized: Seq[TransformDependency] =
+    LowFormOptimized ++ Seq(Dependency[firrtl.transforms.CombineCats]) ++ VerilogMinimumOptimized
 
   val AssertsRemoved: Seq[TransformDependency] =
     Seq( Dependency(firrtl.transforms.formal.ConvertAsserts),

--- a/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
+++ b/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
@@ -37,9 +37,7 @@ class DeadCodeElimination extends Transform
   override def prerequisites = firrtl.stage.Forms.LowForm ++
     Seq( Dependency(firrtl.passes.RemoveValidIf),
          Dependency[firrtl.transforms.ConstantPropagation],
-         Dependency(firrtl.passes.memlib.VerilogMemDelays),
          Dependency(firrtl.passes.SplitExpressions),
-         Dependency[firrtl.transforms.CombineCats],
          Dependency(passes.CommonSubexpressionElimination) )
 
   override def optionalPrerequisites = Seq.empty


### PR DESCRIPTION
I have come to the conclusion that instead of trying to split `PadWidths` into two passes, we should try to make our optimizations work without it.

This PR tries to move all (or at least most) passes that are specific to Verilog emission into the `Verilog` `Forms` and thus into the emitter.



### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
