### PR TITLE
Strip dependencies from BlackBoxSourceHelper

### DIFF
--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -58,9 +58,9 @@ class BlackBoxSourceHelper extends Transform with DependencyAPIMigration {
   import BlackBoxSourceHelper._
   private val DefaultTargetDir = new File(".")
 
-  override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized
+  override def prerequisites = Seq.empty
 
-  override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
+  override def optionalPrerequisites = Seq.empty
 
   override def optionalPrerequisiteOf = Seq.empty
 


### PR DESCRIPTION
Remove all prerequisites and optionalPrerequisites from
BlackBoxSourceHelper. These were false dependencies that were added
without me actually looking at what the transform does.
BlackBoxSourceHelper is an identity transform that only performs IO
side effects based on Chisel-generated annotations. Therefore this
transform can literally run anytime it wants without consequence.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@ibm.com>

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

Changes when `BlackBoxSourceHelper` may run. This should have zero effect unless, possibly, users are generating `BlackBoxSourceHelper`-related annotations and then not invalidating `BlackBoxSourceHelper`. (This is user error.) Users likely won't even hit this as `BlackBoxSourceHelper` is run inside the Verilog emitter.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

None.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
