### PR TITLE
Add Checks of 2.11 Deprecation Message to FirrtlMainSpec

### DIFF
--- a/src/main/scala/firrtl/stage/transforms/CheckScalaVersion.scala
+++ b/src/main/scala/firrtl/stage/transforms/CheckScalaVersion.scala
@@ -13,6 +13,12 @@ object CheckScalaVersion {
     val "2" :: major :: _ :: Nil = BuildInfo.scalaVersion.split("\\.").toList
     major.toInt
   }
+
+  final def deprecationMessage(version: String, option: String) =
+    s"""|FIRRTL support for Scala $version is deprecated, please upgrade to Scala 2.12.
+        |  Migration guide: $migrationDocumentLink
+        |  Suppress warning with '$option'""".stripMargin
+
 }
 
 class CheckScalaVersion extends Transform with DependencyAPIMigration {
@@ -24,13 +30,8 @@ class CheckScalaVersion extends Transform with DependencyAPIMigration {
     def suppress = state.annotations.contains(SuppressScalaVersionWarning)
     if (getScalaMajorVersion == 11 && !suppress) {
       val option = s"--${SuppressScalaVersionWarning.longOption}"
-      val msg =
-        s"""FIRRTL support for Scala 2.11 is deprecated, please upgrade to Scala 2.12.
-           |  Migration guide: $migrationDocumentLink
-           |  Suppress warning with '$option'""".stripMargin
-      dramaticWarning(msg)
+      dramaticWarning(deprecationMessage("2.11", option))
     }
     state
   }
 }
-

--- a/src/test/scala/firrtlTests/stage/FirrtlMainSpec.scala
+++ b/src/test/scala/firrtlTests/stage/FirrtlMainSpec.scala
@@ -8,9 +8,10 @@ import org.scalatest.matchers.should.Matchers
 
 import java.io.{File, PrintWriter}
 
-import firrtl.FileUtils
+import firrtl.{BuildInfo, FileUtils}
 
-import firrtl.stage.FirrtlMain
+import firrtl.stage.{FirrtlMain, SuppressScalaVersionWarning}
+import firrtl.stage.transforms.CheckScalaVersion
 import firrtl.util.BackendCompilationUtilities
 import org.scalatest.featurespec.AnyFeatureSpec
 import org.scalatest.matchers.should.Matchers
@@ -159,6 +160,16 @@ class FirrtlMainSpec extends AnyFeatureSpec with GivenWhenThen with Matchers wit
          |""".stripMargin
   }
 
+  /** This returns a string containing the default standard out string based on the Scala version. E.g., if there are
+    * version-specific deprecation warnings, those are available here and can be passed to tests that should have them.
+    */
+  val defaultStdOut: Option[String] = BuildInfo.scalaVersion.split("\\.").toList match {
+    case "2" :: v :: _ :: Nil if v.toInt <= 11 =>
+      Some(CheckScalaVersion.deprecationMessage("2.11", s"--${SuppressScalaVersionWarning.longOption}"))
+    case x =>
+      None
+  }
+
   info("As a FIRRTL command line user")
   info("I want to compile some FIRRTL")
   Feature("FirrtlMain command line interface") {
@@ -192,32 +203,43 @@ class FirrtlMainSpec extends AnyFeatureSpec with GivenWhenThen with Matchers wit
       FirrtlMainTest(args   = Array("-X", "none", "-E", "chirrtl"),
                       files  = Seq("Top.fir")),
       FirrtlMainTest(args   = Array("-X", "high", "-E", "high"),
+                      stdout = defaultStdOut,
                       files  = Seq("Top.hi.fir")),
       FirrtlMainTest(args   = Array("-X", "middle", "-E", "middle", "-foaf", "Top"),
+                      stdout = defaultStdOut,
                       files  = Seq("Top.mid.fir", "Top.anno.json")),
       FirrtlMainTest(args   = Array("-X", "low", "-E", "low", "-foaf", "annotations.anno.json"),
+                      stdout = defaultStdOut,
                       files  = Seq("Top.lo.fir", "annotations.anno.json")),
       FirrtlMainTest(args   = Array("-X", "verilog", "-E", "verilog", "-foaf", "foo.anno"),
+                      stdout = defaultStdOut,
                       files  = Seq("Top.v", "foo.anno.anno.json")),
       FirrtlMainTest(args   = Array("-X", "sverilog", "-E", "sverilog", "-foaf", "foo.json"),
+                      stdout = defaultStdOut,
                       files  = Seq("Top.sv", "foo.json.anno.json")),
 
       /* Test all one file per module emitters */
       FirrtlMainTest(args   = Array("-X", "none", "-e", "chirrtl"),
                       files  = Seq("Top.fir", "Child.fir")),
       FirrtlMainTest(args   = Array("-X", "high", "-e", "high"),
+                      stdout = defaultStdOut,
                       files  = Seq("Top.hi.fir", "Child.hi.fir")),
       FirrtlMainTest(args   = Array("-X", "middle", "-e", "middle"),
+                      stdout = defaultStdOut,
                       files  = Seq("Top.mid.fir", "Child.mid.fir")),
       FirrtlMainTest(args   = Array("-X", "low", "-e", "low"),
+                      stdout = defaultStdOut,
                       files  = Seq("Top.lo.fir", "Child.lo.fir")),
       FirrtlMainTest(args   = Array("-X", "verilog", "-e", "verilog"),
+                      stdout = defaultStdOut,
                       files  = Seq("Top.v", "Child.v")),
       FirrtlMainTest(args   = Array("-X", "sverilog", "-e", "sverilog"),
+                      stdout = defaultStdOut,
                       files  = Seq("Top.sv", "Child.sv")),
 
       /* Test mixing of -E with -e */
       FirrtlMainTest(args     = Array("-X", "middle", "-E", "high", "-e", "middle"),
+                     stdout   = defaultStdOut,
                      files    = Seq("Top.hi.fir", "Top.mid.fir", "Child.mid.fir"),
                      notFiles = Seq("Child.hi.fir")),
 
@@ -225,14 +247,19 @@ class FirrtlMainSpec extends AnyFeatureSpec with GivenWhenThen with Matchers wit
       FirrtlMainTest(args   = Array("-X", "none", "-E", "chirrtl", "-o", "foo"),
                       files  = Seq("foo.fir")),
       FirrtlMainTest(args   = Array("-X", "high", "-E", "high", "-o", "foo"),
+                      stdout = defaultStdOut,
                       files  = Seq("foo.hi.fir")),
       FirrtlMainTest(args   = Array("-X", "middle", "-E", "middle", "-o", "foo.middle"),
+                      stdout = defaultStdOut,
                       files  = Seq("foo.middle.mid.fir")),
       FirrtlMainTest(args   = Array("-X", "low", "-E", "low", "-o", "foo.lo.fir"),
+                      stdout = defaultStdOut,
                       files  = Seq("foo.lo.fir")),
       FirrtlMainTest(args   = Array("-X", "verilog", "-E", "verilog", "-o", "foo.sv"),
+                      stdout = defaultStdOut,
                       files  = Seq("foo.sv.v")),
       FirrtlMainTest(args   = Array("-X", "sverilog", "-E", "sverilog", "-o", "Foo"),
+                      stdout = defaultStdOut,
                       files  = Seq("Foo.sv"))
     )
       .foreach(runStageExpectFiles)
@@ -331,7 +358,7 @@ class FirrtlMainSpec extends AnyFeatureSpec with GivenWhenThen with Matchers wit
       annotationJson should not include ("InlineInstances")
 
       And("no warning should be printed")
-      out should not include ("Warning:")
+      out should not include ("YAML Annotation files are deprecated")
 
       And("no error should be printed")
       out should not include ("Error:")
@@ -436,4 +463,5 @@ class FirrtlMainSpec extends AnyFeatureSpec with GivenWhenThen with Matchers wit
     )
       .foreach(runStageExpectFiles)
   }
+
 }


### PR DESCRIPTION
Feedback/review of #1842. 

#1842 does actually fail on `FirrtlMainSpec` as this is very strictly testing stdout printing behavior. This does some refactoring to expose the deprecation message and to then check that this shows up when running under 2.11.