### PR TITLE
FlattenSpec: flattening a module with no instaces should be a no-op

### DIFF
--- a/src/main/scala/firrtl/passes/Inline.scala
+++ b/src/main/scala/firrtl/passes/Inline.scala
@@ -358,7 +358,7 @@ class InlineInstances extends Transform with DependencyAPIMigration with Registe
         Some(m.map(onStmt(ModuleName(m.name, CircuitName(c.main)))))
     })
 
-    val renames = renamesSeq.foldLeftOption(_ andThen _)
+    val renames = renamesSeq.reduceLeftOption(_ andThen _)
 
     CircuitState(flatCircuit, LowForm, annos, renames)
   }

--- a/src/main/scala/firrtl/passes/Inline.scala
+++ b/src/main/scala/firrtl/passes/Inline.scala
@@ -358,10 +358,7 @@ class InlineInstances extends Transform with DependencyAPIMigration with Registe
         Some(m.map(onStmt(ModuleName(m.name, CircuitName(c.main)))))
     })
 
-    val renames = renamesSeq match {
-      case Nil        => None
-      case car :: cdr => Some(cdr.foldLeft(car)(_ andThen _))
-    }
+    val renames = renamesSeq.foldLeftOption(_ andThen _)
 
     CircuitState(flatCircuit, LowForm, annos, renames)
   }

--- a/src/main/scala/firrtl/passes/Inline.scala
+++ b/src/main/scala/firrtl/passes/Inline.scala
@@ -264,10 +264,15 @@ class InlineInstances extends Transform with DependencyAPIMigration with Registe
         }
       }
 
-      val maxIdx = indexMap.values.max
-      val resultSeq = Seq.fill(maxIdx + 1)(RenameMap())
-      val resultMap = indexMap.mapValues(idx => resultSeq(maxIdx - idx))
-      (resultMap, resultSeq)
+      indexMap match {
+        case a if a.isEmpty =>
+          (Map.empty[(OfModule, Instance), RenameMap], Seq.empty[RenameMap])
+        case a =>
+          val maxIdx = indexMap.values.max
+          val resultSeq = Seq.fill(maxIdx + 1)(RenameMap())
+          val resultMap = indexMap.mapValues(idx => resultSeq(maxIdx - idx))
+          (resultMap, resultSeq)
+      }
     }
 
     def fixupRefs(
@@ -353,8 +358,11 @@ class InlineInstances extends Transform with DependencyAPIMigration with Registe
         Some(m.map(onStmt(ModuleName(m.name, CircuitName(c.main)))))
     })
 
-    val renames = renamesSeq.tail.foldLeft(renamesSeq.head)(_ andThen _)
+    val renames = renamesSeq match {
+      case Nil        => None
+      case car :: cdr => Some(cdr.foldLeft(car)(_ andThen _))
+    }
 
-    CircuitState(flatCircuit, LowForm, annos, Some(renames))
+    CircuitState(flatCircuit, LowForm, annos, renames)
   }
 }

--- a/src/test/scala/firrtlTests/FlattenTests.scala
+++ b/src/test/scala/firrtlTests/FlattenTests.scala
@@ -272,4 +272,16 @@ class FlattenTests extends LowTransformSpec {
       """.stripMargin
     execute(input, check, Seq(flatten("Top")))
   }
+
+  "The Flatten transform" should "work on modules with no instances" in {
+    val input = """
+                  |circuit Top :
+                  |  module Top :
+                  |    input a : UInt<32>
+                  |    output b : UInt<32>
+                  |    b <= a
+      """.stripMargin
+    val check = input
+    execute(input, check, Seq(flatten("Top")))
+  }
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?


#### Type of Improvement
 - bug fix

#### API Impact

- fix existing

#### Backend Code Generation Impact
- none

#### Desired Merge Strategy

- rebase


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
