### PR TITLE
Add --pretty:no-expr-inlining to prevent expression inlining

### DIFF
--- a/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
+++ b/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
@@ -253,15 +253,30 @@ case class FirrtlCircuitAnnotation(circuit: Circuit) extends NoTargetAnnotation 
 
 /** Suppresses warning about Scala 2.11 deprecation
   *
-  *  - set with `--Wno-scala-version-warning`
+  *  - set with `--warn:no-scala-version-deprecation`
   */
-case object SuppressScalaVersionWarning extends NoTargetAnnotation with FirrtlOption with HasShellOptions {
-  def longOption: String = "Wno-scala-version-warning"
+case object WarnNoScalaVersionDeprecation extends NoTargetAnnotation with FirrtlOption with HasShellOptions {
+  def longOption: String = "warn:no-scala-version-deprecation"
   val options = Seq(
     new ShellOption[Unit](
       longOption = longOption,
       toAnnotationSeq = { _ => Seq(this) },
       helpText = "Suppress Scala 2.11 deprecation warning (ignored in Scala 2.12+)"
+    )
+  )
+}
+
+/** Turn off all expression inlining
+  *
+  * @note this primarily applies to emitted Verilog
+  */
+case object PrettyNoExprInlining extends NoTargetAnnotation with FirrtlOption with HasShellOptions {
+  def longOption: String = "pretty:no-expr-inlining"
+  val options = Seq(
+    new ShellOption[Unit](
+      longOption = longOption,
+      toAnnotationSeq = { _ => Seq(this) },
+      helpText = "Disable expression inlining"
     )
   )
 }

--- a/src/main/scala/firrtl/stage/FirrtlCli.scala
+++ b/src/main/scala/firrtl/stage/FirrtlCli.scala
@@ -20,7 +20,8 @@ trait FirrtlCli { this: Shell =>
     firrtl.EmitCircuitAnnotation,
     firrtl.EmitAllModulesAnnotation,
     NoCircuitDedupAnnotation,
-    SuppressScalaVersionWarning
+    WarnNoScalaVersionDeprecation,
+    PrettyNoExprInlining
   )
     .map(_.addOptions(parser))
 

--- a/src/main/scala/firrtl/stage/package.scala
+++ b/src/main/scala/firrtl/stage/package.scala
@@ -32,7 +32,8 @@ package object stage {
           case InfoModeAnnotation(i)        => c.copy(infoModeName = i)
           case FirrtlCircuitAnnotation(cir) => c.copy(firrtlCircuit = Some(cir))
           case a: CompilerAnnotation => logger.warn(s"Use of CompilerAnnotation is deprecated. Ignoring $a"); c
-          case SuppressScalaVersionWarning => c
+          case WarnNoScalaVersionDeprecation => c
+          case PrettyNoExprInlining          => c
         }
       }
   }

--- a/src/main/scala/firrtl/stage/transforms/CheckScalaVersion.scala
+++ b/src/main/scala/firrtl/stage/transforms/CheckScalaVersion.scala
@@ -3,7 +3,7 @@
 package firrtl.stage.transforms
 
 import firrtl.{BuildInfo, CircuitState, DependencyAPIMigration, Transform}
-import firrtl.stage.SuppressScalaVersionWarning
+import firrtl.stage.WarnNoScalaVersionDeprecation
 import firrtl.options.StageUtils.dramaticWarning
 
 object CheckScalaVersion {
@@ -27,9 +27,9 @@ class CheckScalaVersion extends Transform with DependencyAPIMigration {
   override def invalidates(a: Transform) = false
 
   def execute(state: CircuitState): CircuitState = {
-    def suppress = state.annotations.contains(SuppressScalaVersionWarning)
+    def suppress = state.annotations.contains(WarnNoScalaVersionDeprecation)
     if (getScalaMajorVersion == 11 && !suppress) {
-      val option = s"--${SuppressScalaVersionWarning.longOption}"
+      val option = s"--${WarnNoScalaVersionDeprecation.longOption}"
       dramaticWarning(deprecationMessage("2.11", option))
     }
     state

--- a/src/test/scala/firrtlTests/InlineBooleanExpressionsSpec.scala
+++ b/src/test/scala/firrtlTests/InlineBooleanExpressionsSpec.scala
@@ -8,7 +8,7 @@ import firrtl.options.Dependency
 import firrtl.passes._
 import firrtl.transforms._
 import firrtl.testutils._
-import firrtl.stage.TransformManager
+import firrtl.stage.{PrettyNoExprInlining, TransformManager}
 
 class InlineBooleanExpressionsSpec extends FirrtlFlatSpec {
   val transform = new InlineBooleanExpressions
@@ -311,5 +311,20 @@ class InlineBooleanExpressionsSpec extends FirrtlFlatSpec {
         |    output o: UInt<2>
         |    o <= add(a, not(b))""".stripMargin
     firrtlEquivalenceTest(input, Seq(new InlineBooleanExpressions))
+  }
+
+  it should s"respect --${PrettyNoExprInlining.longOption}" in {
+    val input =
+      """circuit Top :
+        |  module Top :
+        |    input a : UInt<1>
+        |    input b : UInt<1>
+        |    input c : UInt<1>
+        |    output out : UInt<1>
+        |
+        |    node _T_1 = and(a, b)
+        |    out <= and(_T_1, c)""".stripMargin
+    val result = exec(input, PrettyNoExprInlining :: Nil)
+    (result) should be(parse(input).serialize)
   }
 }

--- a/src/test/scala/firrtlTests/stage/FirrtlMainSpec.scala
+++ b/src/test/scala/firrtlTests/stage/FirrtlMainSpec.scala
@@ -10,7 +10,7 @@ import java.io.{File, PrintWriter}
 
 import firrtl.{BuildInfo, FileUtils}
 
-import firrtl.stage.{FirrtlMain, SuppressScalaVersionWarning}
+import firrtl.stage.{FirrtlMain, WarnNoScalaVersionDeprecation}
 import firrtl.stage.transforms.CheckScalaVersion
 import firrtl.util.BackendCompilationUtilities
 import org.scalatest.featurespec.AnyFeatureSpec
@@ -169,7 +169,7 @@ class FirrtlMainSpec
     */
   val defaultStdOut: Option[String] = BuildInfo.scalaVersion.split("\\.").toList match {
     case "2" :: v :: _ :: Nil if v.toInt <= 11 =>
-      Some(CheckScalaVersion.deprecationMessage("2.11", s"--${SuppressScalaVersionWarning.longOption}"))
+      Some(CheckScalaVersion.deprecationMessage("2.11", s"--${WarnNoScalaVersionDeprecation.longOption}"))
     case x =>
       None
   }


### PR DESCRIPTION
**Note:** this is a backwards incompatible change, but only to a CLI option and associated annotation that is new in `1.4.0-RC1`

Also rename `--Wno-scala-version-warning` to
`--warn:no-scala-version-deprecation` and adopt naming convention where
resulting annotation matches the CLI option

This is motivated partially out of caution (because `InlineBooleanExpressions` is such an intrusive change) and also by the observation that we should just in generation have an option to disable it and related things. The new option also disables CombineCats. I didn't have it apply to `InlineCasts` because those are handled specially by the VerilogEmitter, that transform is not a prettification as much as an "avoid lint warnings", but I could be convinced to make it apply there.

I'm also proposing a new CLI scoping scheme with the new prefixes `--warn:` for warning relation options and `--pretty:` for prettification options. I'm open to changing or dropping these depending on how people feel. The implication here is that we should have other prefixes like:
* `--opt:` for optimization-related things `--no-dce` and `--no-dedup`
* `--check:` for `--no-check-comb-loops`
* `--feature:` or `--func:` for `--no-asa`

There's also the implication that sometimes these disable, sometimes they could enable, we could consider some infrastructure to make it accept `--warn:scala-version-deprecation` which currently would be illegal, but I think that's beyond the scope of this current proposal/PR.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - new feature/API          

#### API Impact

Breaks an API from 1.4.0-RC1 and adds new API to prevent inlining expressions

#### Backend Code Generation Impact

Gives the user control over if expressions should be inlined

#### Desired Merge Strategy

 - Squash

#### Release Notes

Add `--pretty:no-expr-inlining` to prevent expression inlining and rename `--Wno-scala-version-warning` to `--warn:no-scala-version-deprecation`

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
