### PR TITLE
Deprecate CompilerAnnotation

### DIFF
--- a/src/main/scala/firrtl/ExecutionOptionsManager.scala
+++ b/src/main/scala/firrtl/ExecutionOptionsManager.scala
@@ -343,7 +343,7 @@ case class FirrtlExecutionOptions(
     List() ++ (if (inputFileNameOverride.nonEmpty) Seq(FirrtlFileAnnotation(inputFileNameOverride)) else Seq()) ++
       (if (outputFileNameOverride.nonEmpty) { Some(OutputFileAnnotation(outputFileNameOverride)) }
        else { None }) ++
-      Some(CompilerAnnotation(compilerName)) ++
+      Some(RunFirrtlTransformAnnotation.stringToEmitter(compilerName)) ++
       Some(InfoModeAnnotation(infoModeName)) ++
       firrtlSource.map(FirrtlSourceAnnotation(_)) ++
       customTransforms.map(t => RunFirrtlTransformAnnotation(t)) ++

--- a/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
+++ b/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
@@ -152,22 +152,23 @@ object FirrtlSourceAnnotation extends HasShellOptions {
   *  - If unset, a [[CompilerAnnotation]] with the default [[VerilogCompiler]]
   * @param compiler compiler name
   */
+@deprecated("Use a RunFirrtlTransformAnnotation targeting a specific Emitter.", "FIRRTL 1.4.0")
 case class CompilerAnnotation(compiler: Compiler = new VerilogCompiler()) extends NoTargetAnnotation with FirrtlOption
 
 object CompilerAnnotation extends HasShellOptions {
 
-  private[firrtl] def apply(compilerName: String): CompilerAnnotation = {
+  private[firrtl] def apply(compilerName: String): RunFirrtlTransformAnnotation = {
     val c = compilerName match {
-      case "none"     => new NoneCompiler()
-      case "high"     => new HighFirrtlCompiler()
-      case "low"      => new LowFirrtlCompiler()
-      case "middle"   => new MiddleFirrtlCompiler()
-      case "verilog"  => new VerilogCompiler()
-      case "mverilog" => new MinimumVerilogCompiler()
-      case "sverilog" => new SystemVerilogCompiler()
+      case "none"     => new ChirrtlEmitter
+      case "high"     => new HighFirrtlEmitter
+      case "low"      => new LowFirrtlEmitter
+      case "middle"   => new MiddleFirrtlEmitter
+      case "verilog"  => new VerilogEmitter
+      case "mverilog" => new MinimumVerilogEmitter
+      case "sverilog" => new SystemVerilogEmitter
       case _          => throw new OptionsException(s"Unknown compiler name '$compilerName'! (Did you misspell it?)")
     }
-    CompilerAnnotation(c)
+    RunFirrtlTransformAnnotation(c)
   }
 
   val options = Seq(

--- a/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
+++ b/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
@@ -155,26 +155,13 @@ object FirrtlSourceAnnotation extends HasShellOptions {
 @deprecated("Use a RunFirrtlTransformAnnotation targeting a specific Emitter.", "FIRRTL 1.4.0")
 case class CompilerAnnotation(compiler: Compiler = new VerilogCompiler()) extends NoTargetAnnotation with FirrtlOption
 
+@deprecated("Use a RunFirrtlTransformAnnotation targeting a specific Emitter.", "FIRRTL 1.4.0")
 object CompilerAnnotation extends HasShellOptions {
-
-  private[firrtl] def apply(compilerName: String): RunFirrtlTransformAnnotation = {
-    val c = compilerName match {
-      case "none"     => new ChirrtlEmitter
-      case "high"     => new HighFirrtlEmitter
-      case "low"      => new LowFirrtlEmitter
-      case "middle"   => new MiddleFirrtlEmitter
-      case "verilog"  => new VerilogEmitter
-      case "mverilog" => new MinimumVerilogEmitter
-      case "sverilog" => new SystemVerilogEmitter
-      case _          => throw new OptionsException(s"Unknown compiler name '$compilerName'! (Did you misspell it?)")
-    }
-    RunFirrtlTransformAnnotation(c)
-  }
 
   val options = Seq(
     new ShellOption[String](
       longOption = "compiler",
-      toAnnotationSeq = a => Seq(CompilerAnnotation(a)),
+      toAnnotationSeq = a => Seq(RunFirrtlTransformAnnotation.stringToEmitter(a)),
       helpText = "The FIRRTL compiler to use (default: verilog)",
       shortOption = Some("X"),
       helpValueName = Some("<none|high|middle|low|verilog|mverilog|sverilog>")
@@ -194,6 +181,20 @@ object RunFirrtlTransformAnnotation extends HasShellOptions {
 
   def apply(transform: TransformDependency): RunFirrtlTransformAnnotation =
     RunFirrtlTransformAnnotation(transform.getObject)
+
+  private[firrtl] def stringToEmitter(a: String): RunFirrtlTransformAnnotation = {
+    val emitter = a match {
+      case "none"     => new ChirrtlEmitter
+      case "high"     => new HighFirrtlEmitter
+      case "low"      => new LowFirrtlEmitter
+      case "middle"   => new MiddleFirrtlEmitter
+      case "verilog"  => new VerilogEmitter
+      case "mverilog" => new MinimumVerilogEmitter
+      case "sverilog" => new SystemVerilogEmitter
+      case _          => throw new OptionsException(s"Unknown compiler name '$a'! (Did you misspell it?)")
+    }
+    RunFirrtlTransformAnnotation(emitter)
+  }
 
   val options = Seq(
     new ShellOption[Seq[String]](
@@ -226,6 +227,13 @@ object RunFirrtlTransformAnnotation extends HasShellOptions {
       },
       helpText = "Convert all FIRRTL names to a specific case",
       helpValueName = Some("<lower|upper>")
+    ),
+    new ShellOption[String](
+      longOption = "compiler",
+      toAnnotationSeq = a => Seq(stringToEmitter(a)),
+      helpText = "The FIRRTL compiler to use (default: verilog)",
+      shortOption = Some("X"),
+      helpValueName = Some("<none|high|middle|low|verilog|mverilog|sverilog>")
     )
   )
 

--- a/src/main/scala/firrtl/stage/FirrtlCli.scala
+++ b/src/main/scala/firrtl/stage/FirrtlCli.scala
@@ -16,7 +16,6 @@ trait FirrtlCli { this: Shell =>
     OutputFileAnnotation,
     InfoModeAnnotation,
     FirrtlSourceAnnotation,
-    CompilerAnnotation,
     RunFirrtlTransformAnnotation,
     firrtl.EmitCircuitAnnotation,
     firrtl.EmitAllModulesAnnotation,

--- a/src/main/scala/firrtl/stage/FirrtlStage.scala
+++ b/src/main/scala/firrtl/stage/FirrtlStage.scala
@@ -7,7 +7,13 @@ import firrtl.options.{Dependency, Phase, PhaseManager, Shell, Stage, StageMain}
 import firrtl.options.phases.DeletedWrapper
 import firrtl.stage.phases.CatchExceptions
 
-class FirrtlPhase extends PhaseManager(targets = Seq(Dependency[firrtl.stage.phases.Compiler])) {
+class FirrtlPhase
+    extends PhaseManager(
+      targets = Seq(
+        Dependency[firrtl.stage.phases.Compiler],
+        Dependency[firrtl.stage.phases.ConvertCompilerAnnotations]
+      )
+    ) {
 
   override def invalidates(a: Phase) = false
 

--- a/src/main/scala/firrtl/stage/phases/AddDefaults.scala
+++ b/src/main/scala/firrtl/stage/phases/AddDefaults.scala
@@ -6,7 +6,7 @@ import firrtl.{AnnotationSeq, VerilogEmitter}
 import firrtl.options.{Dependency, Phase, TargetDirAnnotation}
 import firrtl.stage.TransformManager.TransformDependency
 import firrtl.transforms.BlackBoxTargetDirAnno
-import firrtl.stage.{CompilerAnnotation, FirrtlOptions, InfoModeAnnotation, RunFirrtlTransformAnnotation}
+import firrtl.stage.{FirrtlOptions, InfoModeAnnotation, RunFirrtlTransformAnnotation}
 
 /** [[firrtl.options.Phase Phase]] that adds default [[FirrtlOption]] [[firrtl.annotations.Annotation Annotation]]s.
   * This is a part of the preprocessing done by [[FirrtlStage]].
@@ -23,10 +23,9 @@ class AddDefaults extends Phase {
 
   /** Append any missing default annotations to an annotation sequence */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {
-    var bb, c, em, im = true
+    var bb, em, im = true
     annotations.foreach {
       case _: BlackBoxTargetDirAnno => bb = false
-      case _: CompilerAnnotation    => c = false
       case _: InfoModeAnnotation    => im = false
       case RunFirrtlTransformAnnotation(_: firrtl.Emitter) => em = false
       case _ =>
@@ -39,7 +38,7 @@ class AddDefaults extends Phase {
 
     (if (bb) Seq(BlackBoxTargetDirAnno(targetDir)) else Seq()) ++
       // if there is no compiler or emitter specified, add the default emitter
-      (if (c && em) Seq(RunFirrtlTransformAnnotation(DefaultEmitterTarget)) else Seq()) ++
+      (if (em) Seq(RunFirrtlTransformAnnotation(DefaultEmitterTarget)) else Seq()) ++
       (if (im) Seq(InfoModeAnnotation()) else Seq()) ++
       annotations
   }

--- a/src/main/scala/firrtl/stage/phases/Checks.scala
+++ b/src/main/scala/firrtl/stage/phases/Checks.scala
@@ -31,14 +31,13 @@ class Checks extends Phase {
     * @throws firrtl.options.OptionsException if any checks fail
     */
   def transform(annos: AnnotationSeq): AnnotationSeq = {
-    val inF, inS, eam, ec, outF, comp, emitter, im, inC = collection.mutable.ListBuffer[Annotation]()
+    val inF, inS, eam, ec, outF, emitter, im, inC = collection.mutable.ListBuffer[Annotation]()
     annos.foreach(_ match {
       case a: FirrtlFileAnnotation     => a +=: inF
       case a: FirrtlSourceAnnotation   => a +=: inS
       case a: EmitAllModulesAnnotation => a +=: eam
       case a: EmitCircuitAnnotation    => a +=: ec
       case a: OutputFileAnnotation     => a +=: outF
-      case a: CompilerAnnotation       => a +=: comp
       case a: InfoModeAnnotation       => a +=: im
       case a: FirrtlCircuitAnnotation  => a +=: inC
       case a @ RunFirrtlTransformAnnotation(_: firrtl.Emitter) => a +=: emitter
@@ -81,13 +80,13 @@ class Checks extends Phase {
       )
     }
 
-    /* One mandatory compiler (or emitter) must be specified */
-    if (comp.size != 1 && emitter.isEmpty) {
-      val x = comp.map { case CompilerAnnotation(x) => x }
-      val (msg, suggest) = if (comp.size == 0) { ("none found", "forget one of") }
-      else { (s"""found '${x.mkString(", ")}'""", "use multiple of") }
-      throw new OptionsException(s"""|Exactly one compiler must be specified, but $msg. Did you $suggest the following?
-                                     |    - an option or annotation: -X, --compiler, CompilerAnnotation""".stripMargin)
+    /* At least one emitter must be specified */
+    if (emitter.isEmpty) {
+      throw new OptionsException(
+        s"""|At least one compiler must be specified, but none found. Specify a compiler via:
+            |    - a RunFirrtlTransformAnnotation targeting a specific emitter, e.g., VerilogEmitter
+            |    - a command line option: -X, --compiler""".stripMargin
+      )
     }
 
     /* One mandatory info mode must be specified */

--- a/src/main/scala/firrtl/stage/phases/ConvertCompilerAnnotations.scala
+++ b/src/main/scala/firrtl/stage/phases/ConvertCompilerAnnotations.scala
@@ -1,0 +1,40 @@
+// See LICENSE for license details.
+
+package firrtl.stage.phases
+
+import firrtl.AnnotationSeq
+import firrtl.options.{Dependency, OptionsException, Phase}
+import firrtl.stage.{CompilerAnnotation, RunFirrtlTransformAnnotation}
+
+@deprecated(
+  "This only exists to convert deprecated CompilerAnnotations to RunFirrtlTransformAnnotations.",
+  "FIRRTL 1.5.0"
+)
+class ConvertCompilerAnnotations extends Phase {
+
+  override def prerequisites = Seq.empty
+  override def optionalPrerequisites = Seq.empty
+  override def optionalPrerequisiteOf = Seq(Dependency[AddDefaults], Dependency[Checks])
+  override def invalidates(a: Phase) = false
+
+  override def transform(annotations: AnnotationSeq): AnnotationSeq = {
+    annotations.collect {
+      case a: CompilerAnnotation => a
+    } match {
+      case a if a.size > 1 =>
+        val (msg, suggest) = (s"""found '${a.mkString(", ")}'""", "use multiple of")
+        throw new OptionsException(
+          s"Zero or more deprecated CompilerAnnotation may be specified, but $msg.".stripMargin
+        )
+      case _ =>
+    }
+    annotations.map {
+      case CompilerAnnotation(a) =>
+        val suggestion = s"RunFirrtlTransformAnnotation(new ${a.emitter.getClass.getName})"
+        logger.warn(s"CompilerAnnotation is deprecated since FIRRTL 1.4.0. Please use '$suggestion' instead.")
+        RunFirrtlTransformAnnotation(a.emitter)
+      case a => a
+    }
+  }
+
+}

--- a/src/main/scala/firrtl/stage/phases/ConvertCompilerAnnotations.scala
+++ b/src/main/scala/firrtl/stage/phases/ConvertCompilerAnnotations.scala
@@ -6,11 +6,7 @@ import firrtl.AnnotationSeq
 import firrtl.options.{Dependency, OptionsException, Phase}
 import firrtl.stage.{CompilerAnnotation, RunFirrtlTransformAnnotation}
 
-@deprecated(
-  "This only exists to convert deprecated CompilerAnnotations to RunFirrtlTransformAnnotations.",
-  "FIRRTL 1.5.0"
-)
-class ConvertCompilerAnnotations extends Phase {
+private[firrtl] class ConvertCompilerAnnotations extends Phase {
 
   override def prerequisites = Seq.empty
   override def optionalPrerequisites = Seq.empty
@@ -22,9 +18,8 @@ class ConvertCompilerAnnotations extends Phase {
       case a: CompilerAnnotation => a
     } match {
       case a if a.size > 1 =>
-        val (msg, suggest) = (s"""found '${a.mkString(", ")}'""", "use multiple of")
         throw new OptionsException(
-          s"Zero or more deprecated CompilerAnnotation may be specified, but $msg.".stripMargin
+          s"Zero or one CompilerAnnotation may be specified, but found '${a.mkString(", ")}'.".stripMargin
         )
       case _ =>
     }

--- a/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
+++ b/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
@@ -4,7 +4,7 @@ package firrtl.stage.phases
 
 import firrtl.stage._
 
-import firrtl.{AnnotationSeq, EmitAllModulesAnnotation, EmitCircuitAnnotation, FirrtlExecutionResult, Parser}
+import firrtl.{AnnotationSeq, EmitAllModulesAnnotation, EmitCircuitAnnotation, Emitter, FirrtlExecutionResult, Parser}
 import firrtl.annotations.NoTargetAnnotation
 import firrtl.FileUtils
 import firrtl.proto.FromProto
@@ -227,6 +227,9 @@ object DriverCompatibility {
           val b = RunFirrtlTransformAnnotation(a.compiler.emitter)
           if (splitModules) { Seq(a, b, EmitAllModulesAnnotation(c.emitter.getClass)) }
           else { Seq(a, b, EmitCircuitAnnotation(c.emitter.getClass)) }
+        case a @ RunFirrtlTransformAnnotation(e: Emitter) =>
+          if (splitModules) { Seq(a, EmitAllModulesAnnotation(e.getClass)) }
+          else { Seq(a, EmitCircuitAnnotation(e.getClass)) }
         case a => Seq(a)
       }
     }

--- a/src/test/scala/firrtl/stage/phases/tests/ConvertCompilerAnnotationsSpec.scala
+++ b/src/test/scala/firrtl/stage/phases/tests/ConvertCompilerAnnotationsSpec.scala
@@ -1,6 +1,6 @@
 // See LICENSE for license details.
 
-package firrtlTests.stage.phases
+package firrtl.stage.phases.tests
 
 import firrtl.{HighFirrtlCompiler, HighFirrtlEmitter, LowFirrtlCompiler}
 import firrtl.options.{Dependency, OptionsException}

--- a/src/test/scala/firrtl/stage/phases/tests/ConvertCompilerAnnotationsSpec.scala
+++ b/src/test/scala/firrtl/stage/phases/tests/ConvertCompilerAnnotationsSpec.scala
@@ -35,6 +35,6 @@ class ConvertCompilerAnnotationsSpec extends AnyFlatSpec with Matchers {
     )
     intercept[OptionsException] {
       phase.transform(annotations)
-    }.getMessage should include("Zero or more deprecated CompilerAnnotation may be specified")
+    }.getMessage should include("Zero or one CompilerAnnotation may be specified")
   }
 }

--- a/src/test/scala/firrtl/testutils/FirrtlSpec.scala
+++ b/src/test/scala/firrtl/testutils/FirrtlSpec.scala
@@ -101,7 +101,7 @@ trait FirrtlRunners extends BackendCompilationUtilities {
         InfoModeAnnotation("ignore") +:
         RenameTopAnnotation(topName) +:
         stage.FirrtlCircuitAnnotation(circuit) +:
-        stage.CompilerAnnotation("mverilog") +:
+        stage.RunFirrtlTransformAnnotation.stringToEmitter("mverilog") +:
         stage.OutputFileAnnotation(topName) +:
         toAnnos(baseTransforms)
     }

--- a/src/test/scala/firrtlTests/stage/FirrtlMainSpec.scala
+++ b/src/test/scala/firrtlTests/stage/FirrtlMainSpec.scala
@@ -286,6 +286,12 @@ class FirrtlMainSpec
         args = Array("-X", "sverilog", "-E", "sverilog", "-o", "Foo"),
         stdout = defaultStdOut,
         files = Seq("Foo.sv")
+      ),
+      /* Test that an output is generated if no emitter is specified */
+      FirrtlMainTest(
+        args = Array("-X", "verilog", "-o", "Foo"),
+        stdout = defaultStdOut,
+        files = Seq("Foo.v")
       )
     )
       .foreach(runStageExpectFiles)

--- a/src/test/scala/firrtlTests/stage/phases/AddDefaultsSpec.scala
+++ b/src/test/scala/firrtlTests/stage/phases/AddDefaultsSpec.scala
@@ -2,11 +2,11 @@
 
 package firrtlTests.stage.phases
 
-import firrtl.NoneCompiler
+import firrtl.ChirrtlEmitter
 import firrtl.annotations.Annotation
 import firrtl.stage.phases.AddDefaults
 import firrtl.transforms.BlackBoxTargetDirAnno
-import firrtl.stage.{CompilerAnnotation, InfoModeAnnotation, RunFirrtlTransformAnnotation}
+import firrtl.stage.{InfoModeAnnotation, RunFirrtlTransformAnnotation}
 import firrtl.options.{Dependency, Phase, TargetDirAnnotation}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -32,7 +32,11 @@ class AddDefaultsSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "not overwrite existing annotations" in new Fixture {
-    val input = Seq(BlackBoxTargetDirAnno("foo"), CompilerAnnotation(new NoneCompiler()), InfoModeAnnotation("ignore"))
+    val input = Seq(
+      BlackBoxTargetDirAnno("foo"),
+      RunFirrtlTransformAnnotation(new ChirrtlEmitter),
+      InfoModeAnnotation("ignore")
+    )
 
     phase.transform(input).toSeq should be(input)
   }

--- a/src/test/scala/firrtlTests/stage/phases/ChecksSpec.scala
+++ b/src/test/scala/firrtlTests/stage/phases/ChecksSpec.scala
@@ -4,7 +4,7 @@ package firrtlTests.stage.phases
 
 import firrtl.stage._
 
-import firrtl.{AnnotationSeq, ChirrtlEmitter, EmitAllModulesAnnotation, NoneCompiler}
+import firrtl.{AnnotationSeq, ChirrtlEmitter, EmitAllModulesAnnotation}
 import firrtl.options.{OptionsException, OutputAnnotationFileAnnotation, Phase}
 import firrtl.stage.phases.Checks
 import org.scalatest.flatspec.AnyFlatSpec
@@ -18,7 +18,7 @@ class ChecksSpec extends AnyFlatSpec with Matchers {
   val outputFile = OutputFileAnnotation("bar")
   val emitAllModules = EmitAllModulesAnnotation(classOf[ChirrtlEmitter])
   val outputAnnotationFile = OutputAnnotationFileAnnotation("baz")
-  val goodCompiler = CompilerAnnotation(new NoneCompiler())
+  val goodCompiler = RunFirrtlTransformAnnotation(new ChirrtlEmitter)
   val infoMode = InfoModeAnnotation("ignore")
 
   val min = Seq(inputFile, goodCompiler, infoMode)
@@ -54,15 +54,15 @@ class ChecksSpec extends AnyFlatSpec with Matchers {
     checkExceptionMessage(phase, in, "No more than one output file can be specified")
   }
 
-  it should "enforce exactly one compiler" in new Fixture {
+  it should "enforce one or more compilers (at this point these are emitters)" in new Fixture {
     info("0 compilers should throw an exception")
     val inZero = Seq(inputFile, infoMode)
-    checkExceptionMessage(phase, inZero, "Exactly one compiler must be specified, but none found")
+    checkExceptionMessage(phase, inZero, "At least one compiler must be specified")
 
-    info("2 compilers should throw an exception")
-    val c = goodCompiler.compiler
+    info("2 compilers should not throw an exception")
+    val c = goodCompiler
     val inTwo = min :+ goodCompiler
-    checkExceptionMessage(phase, inTwo, s"Exactly one compiler must be specified, but found '$c, $c'")
+    phase.transform(inTwo)
   }
 
   it should "validate info mode names" in new Fixture {

--- a/src/test/scala/firrtlTests/stage/phases/ConvertCompilerAnnotationsSpec.scala
+++ b/src/test/scala/firrtlTests/stage/phases/ConvertCompilerAnnotationsSpec.scala
@@ -1,0 +1,40 @@
+// See LICENSE for license details.
+
+package firrtlTests.stage.phases
+
+import firrtl.{HighFirrtlCompiler, HighFirrtlEmitter, LowFirrtlCompiler}
+import firrtl.options.{Dependency, OptionsException}
+import firrtl.stage.{CompilerAnnotation, RunFirrtlTransformAnnotation}
+import firrtl.stage.phases.ConvertCompilerAnnotations
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ConvertCompilerAnnotationsSpec extends AnyFlatSpec with Matchers {
+
+  class Fixture {
+    val phase = new ConvertCompilerAnnotations
+  }
+
+  behavior.of(classOf[ConvertCompilerAnnotations].getName)
+
+  it should "convert a deprecated CompilerAnnotation to a RunFirrtlTransformAnnotation" in new Fixture {
+    val annotations = Seq(CompilerAnnotation(new HighFirrtlCompiler))
+    phase
+      .transform(annotations)
+      .map {
+        case RunFirrtlTransformAnnotation(a) => Dependency.fromTransform(a)
+      }
+      .toSeq should be(Seq(Dependency[HighFirrtlEmitter]))
+  }
+
+  it should "throw an exception if multiple CompilerAnnotations are specified" in new Fixture {
+    val annotations = Seq(
+      CompilerAnnotation(new HighFirrtlCompiler),
+      CompilerAnnotation(new LowFirrtlCompiler)
+    )
+    intercept[OptionsException] {
+      phase.transform(annotations)
+    }.getMessage should include("Zero or more deprecated CompilerAnnotation may be specified")
+  }
+}


### PR DESCRIPTION
This is a follow-on to https://github.com/freechipsproject/firrtl/pull/1835 to fully deprecate `CompilerAnnotation`. 

This does a couple of things:

1. The `CompilerAnnotation$` companion object is changed to emit `RunFirrtlTransformAnnotation`s instead of `CompilerAnnotation`s. In effect, when you do `-X verilog`, you now get a `RunFirrtlTransformAnnotation(new VerilogEmitter)` as opposed to a `CompilerAnnotation(new VerilogCompiler)`.

2. This adds a `ConvertCompilerAnnotation` phase which is doing an explicit conversion of a `CompilerAnnotation` to a `RunFirrtlTransformAnnotation`. This differs from #1835 which relaxed support so that a `RunFirrtlTransformAnnotation(_ <: Emitter)` could substitute for a `CompilerAnnotation`. This PR goes one step further and forces internal phases to only understand transforms. 

3. Better checks and warnings are now provided inside `ConvertCompilerAnnotation`. The check of a single compiler is migrated from `Checks` here. Additionally, if a `CompilerAnnotation` is converted, a verbose warning is printed telling you exactly how to replace your transform, e.g., you now get:

```
CompilerAnnotation is deprecated since FIRRTL 1.4.0. Please use 'RunFirrtlTransformAnnotation(new firrtl.HighFirrtlEmitter)' instead.
```

Note that you should only now get a warning if you actually use a `CompilerAnnotation`. Any use of `-X` will not produce an error.

### Contributor Checklist

- [nope] Did you add Scaladoc to every public function/method?
- [n/a] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
- code refactoring
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

None. Removes a warning that the user couldn't do anything to fix.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

None.

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you mark as `Please Merge`?
