### PR TITLE
Fix mill re-download external jar every time.

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -94,7 +94,7 @@ class firrtlCrossModule(crossVersion: String) extends ScalaModule with SbtModule
     millSourcePath / 'src / 'main / 'antlr4 / "FIRRTL.g4"
   }
 
-  def downloadAntlr4Jar = T {
+  def downloadAntlr4Jar = T.persistent {
     Util.download(s"https://www.antlr.org/download/antlr-$antlr4Version-complete.jar")
   }
 
@@ -116,7 +116,7 @@ class firrtlCrossModule(crossVersion: String) extends ScalaModule with SbtModule
     millSourcePath / 'src / 'main / 'proto / "firrtl.proto"
   }
 
-  def downloadProtocJar = T {
+  def downloadProtocJar = T.persistent {
     Util.download(s"https://repo.maven.apache.org/maven2/com/github/os72/protoc-jar/$protocVersion/protoc-jar-$protocVersion.jar")
   }
 


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
- performance improvement
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
none
#### Backend Code Generation Impact
none
<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
no re-download jar each time, speed up firrtl compile time under mill build system.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
