### PR TITLE
Restrict boolean inlining to avoid context-sensitive width bugs

### DIFF
--- a/src/test/scala/firrtlTests/InlineBooleanExpressionsSpec.scala
+++ b/src/test/scala/firrtlTests/InlineBooleanExpressionsSpec.scala
@@ -241,4 +241,15 @@ class InlineBooleanExpressionsSpec extends FirrtlFlatSpec {
         |    out <= _f""".stripMargin
     firrtlEquivalenceTest(input, Seq(new InlineBooleanExpressions))
   }
+
+  it should "avoid inlining when it would create context-sensitivity bugs" in {
+    val input =
+      """circuit AddNot:
+        |  module AddNot:
+        |    input a: UInt<1>
+        |    input b: UInt<1>
+        |    output o: UInt<2>
+        |    o <= add(a, not(b))""".stripMargin
+    firrtlEquivalenceTest(input, Seq(new InlineBooleanExpressions))
+  }
 }


### PR DESCRIPTION
**Type of improvement:** bug fix
**API impact:** none
**Backend code-generation impact:** avoids boolean inlining in cases where it implicitly turns boolean ops into wider ops

The boolean inlining will turn the following FIRRTL:
```
circuit AddNot:
  module AddNot:
    input a: UInt<1>
    input b: UInt<1>
    output o: UInt<2>
    o <= add(a, not(b))
```

Into the following Verilog:
```
module AddNot(
  input        a,
  input        b,
  output [1:0] o
);
  assign o = a + ~b;
endmodule
```

This causes the operand of the context-sensitive `~` to be widened. Since `~` is not truth-preserving, this is a LEC violation.

This change restricts inlining in the minimal way to avoid context-sensitivity issues: it inlines ops only when the parent type is also `BoolType` or when the op has all self-determined arguments in IEEE 1364-2005 (namely comparisons and reductions).

It is possible to take into account truth-preservation to determine whether context-sensitivity would create observable LEC differences (i.e., whether pre- and post-op extension produce different results), but that would likely be unnecessarily complicated and prone to bugs.