### PR TITLE
Add custom transforms 'upstream' of emitter annotation in equiv tests

### DIFF
--- a/src/test/scala/firrtl/testutils/FirrtlSpec.scala
+++ b/src/test/scala/firrtl/testutils/FirrtlSpec.scala
@@ -107,13 +107,13 @@ trait FirrtlRunners extends BackendCompilationUtilities {
     }
 
     val customName = s"${prefix}_custom"
-    val customAnnos = getBaseAnnos(customName) ++: toAnnos((new GetNamespace) +: customTransforms) ++: customAnnotations
+    val customAnnos = customAnnotations ++: toAnnos((new GetNamespace) +: customTransforms) ++: getBaseAnnos(customName)
 
     val customResult = (new firrtl.stage.FirrtlStage).execute(Array.empty, customAnnos)
     val nsAnno = customResult.collectFirst { case m: ModuleNamespaceAnnotation => m }.get
 
     val refSuggestedName = s"${prefix}_ref"
-    val refAnnos = getBaseAnnos(refSuggestedName) ++: Seq(RunFirrtlTransformAnnotation(new RenameModules), nsAnno)
+    val refAnnos = Seq(RunFirrtlTransformAnnotation(new RenameModules), nsAnno) ++: getBaseAnnos(refSuggestedName)
 
     val refResult = (new firrtl.stage.FirrtlStage).execute(Array.empty, refAnnos)
     val refName =


### PR DESCRIPTION
**Type of change:** bug fix
**API impact:** none
**Backend code-generation impact:** none

The LEC environment puts the custom transform annotations later in the annotation sequence than the emitter it selects. Since the transform manager tries to honor this, it ends up running the emitter before the custom transforms if it can.
