### PR TITLE
Make mill compatiable to 2.13.

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1,4 +1,3 @@
-// Build script for mill 0.6.0
 import mill._
 import mill.scalalib._
 import mill.scalalib.publish._
@@ -6,29 +5,18 @@ import mill.modules.Util
 import $ivy.`com.lihaoyi::mill-contrib-buildinfo:$MILL_VERSION`
 import mill.contrib.buildinfo.BuildInfo
 
-object firrtl extends mill.Cross[firrtlCrossModule]("2.11.12", "2.12.12")
+object firrtl extends mill.Cross[firrtlCrossModule]("2.11.12", "2.12.12", "2.13.2")
 
-class firrtlCrossModule(crossVersion: String) extends ScalaModule with SbtModule with PublishModule with BuildInfo {
-  // different scala version shares same sources
-  // mill use foo/2.11.12 foo/2.12.12 as millSourcePath by default
-  override def millSourcePath = super.millSourcePath / os.up / os.up
-
-  def scalaVersion = crossVersion
+class firrtlCrossModule(val crossScalaVersion: String) extends CrossSbtModule with PublishModule with BuildInfo {
+  override def millSourcePath = super.millSourcePath / os.up
 
   // 2.12.12 -> Array("2", "12", "12") -> "12" -> 12
-  private def majorVersion = crossVersion.split('.')(1).toInt
+  private def majorVersion = crossScalaVersion.split('.')(1).toInt
 
   def publishVersion = "1.4-SNAPSHOT"
 
-  def antlr4Version = "4.7.1"
-
-  def protocVersion = "3.5.1"
-
-  def mainClass = Some("firrtl.stage.FirrtlMain")
-  
-  private def scalacCrossOptions = majorVersion match {
-    case i if i < 12 => Seq()
-    case _ => Seq("-Xsource:2.11")
+  override def mainClass = T {
+    Some("firrtl.stage.FirrtlMain")
   }
 
   private def javacCrossOptions = majorVersion match {
@@ -36,36 +24,51 @@ class firrtlCrossModule(crossVersion: String) extends ScalaModule with SbtModule
     case _ => Seq("-source", "1.8", "-target", "1.8")
   }
 
-  override def scalacOptions = super.scalacOptions() ++ Seq(
-    "-deprecation",
-    "-unchecked",
-    "-Yrangepos", // required by SemanticDB compiler plugin
-  ) ++ scalacCrossOptions
-  
-  override def javacOptions = super.javacOptions() ++ javacCrossOptions
+  override def scalacOptions = T {
+    super.scalacOptions() ++ Seq(
+      "-deprecation",
+      "-unchecked",
+      "-Yrangepos" // required by SemanticDB compiler plugin
+    )
+  }
 
-  override def ivyDeps = super.ivyDeps() ++ Agg(
-    ivy"${scalaOrganization()}:scala-reflect:${scalaVersion()}",
-    ivy"com.github.scopt::scopt:3.7.1",
-    ivy"net.jcazevedo::moultingyaml:0.4.2",
-    ivy"org.json4s::json4s-native:3.6.9",
-    ivy"org.apache.commons:commons-text:1.7",
-    ivy"org.antlr:antlr4-runtime:4.7.2",
-    ivy"com.google.protobuf:protobuf-java:3.5.1"
-  )
-  
+  override def javacOptions = T {
+    super.javacOptions() ++ javacCrossOptions
+  }
+
+  override def ivyDeps = T {
+    super.ivyDeps() ++ Agg(
+      ivy"${scalaOrganization()}:scala-reflect:${scalaVersion()}",
+      ivy"com.github.scopt::scopt:3.7.1",
+      ivy"net.jcazevedo::moultingyaml:0.4.2",
+      ivy"org.json4s::json4s-native:3.6.9",
+      ivy"org.apache.commons:commons-text:1.8",
+      ivy"org.antlr:antlr4-runtime:$antlr4Version",
+      ivy"com.google.protobuf:protobuf-java:$protocVersion"
+    ) ++ {
+      if (majorVersion > 12)
+        Agg(ivy"org.scala-lang.modules::scala-parallel-collections:0.2.0")
+      else
+        Agg()
+    }
+  }
+
   object test extends Tests {
     private def ivyCrossDeps = majorVersion match {
       case i if i < 12 => Agg(ivy"junit:junit:4.12")
       case _ => Agg()
     }
 
-    def ivyDeps = Agg(
-      ivy"org.scalatest::scalatest:3.2.1",
-      ivy"org.scalatestplus::scalacheck-1-14:3.1.3.0"
-    ) ++ ivyCrossDeps
+    override def ivyDeps = T {
+      Agg(
+        ivy"org.scalatest::scalatest:3.2.0",
+        ivy"org.scalatestplus::scalacheck-1-14:3.1.3.0"
+      ) ++ ivyCrossDeps
+    }
 
-    def testFrameworks = Seq("org.scalatest.tools.Framework")
+    def testFrameworks = T {
+      Seq("org.scalatest.tools.Framework")
+    }
 
     // a sbt-like testOnly command.
     // for example, mill -i "firrtl[2.12.12].test.testOnly" "firrtlTests.AsyncResetSpec"
@@ -88,10 +91,11 @@ class firrtlCrossModule(crossVersion: String) extends ScalaModule with SbtModule
     generatedAntlr4Source() ++ generatedProtoSources() :+ generatedBuildInfo()._2
   }
 
-  /** antlr4 */
+  /* antlr4 */
+  def antlr4Version = "4.7.1"
 
   def antlrSource = T.source {
-    millSourcePath / 'src / 'main / 'antlr4 / "FIRRTL.g4"
+    millSourcePath / "src" / "main" / "antlr4" / "FIRRTL.g4"
   }
 
   def downloadAntlr4Jar = T.persistent {
@@ -110,10 +114,11 @@ class firrtlCrossModule(crossVersion: String) extends ScalaModule with SbtModule
     T.ctx.dest
   }
 
-  /** protoc */
+  /* protoc */
+  def protocVersion = "3.5.1"
 
   def protobufSource = T.source {
-    millSourcePath / 'src / 'main / 'proto / "firrtl.proto"
+    millSourcePath / "src" / "main" / "proto" / "firrtl.proto"
   }
 
   def downloadProtocJar = T.persistent {
@@ -130,16 +135,19 @@ class firrtlCrossModule(crossVersion: String) extends ScalaModule with SbtModule
     T.ctx.dest / "firrtl"
   }
 
-  def pomSettings = PomSettings(
-    description = artifactName(),
-    organization = "edu.berkeley.cs",
-    url = "https://github.com/freechipsproject/firrtl",
-    licenses = Seq(License.`BSD-3-Clause`),
-    versionControl = VersionControl.github("freechipsproject", "firrtl"),
-    developers = Seq(
-      Developer("jackbackrack", "Jonathan Bachrach", "https://eecs.berkeley.edu/~jrb/")
+  def pomSettings = T {
+    PomSettings(
+      description = artifactName(),
+      organization = "edu.berkeley.cs",
+      url = "https://github.com/freechipsproject/firrtl",
+      licenses = Seq(License.`BSD-3-Clause`),
+      versionControl = VersionControl.github("freechipsproject", "firrtl"),
+      developers = Seq(
+        Developer("jackbackrack", "Jonathan Bachrach", "https://eecs.berkeley.edu/~jrb/")
+      )
     )
-  )
+  }
+
   // make mill publish sbt compatible package
-  def artifactName = "firrtl"
+  override def artifactName = "firrtl"
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - bug fix                            

#### API Impact
None
<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact
None
<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

   - Squash: The PR will be squashed and merged (choose this if you have no preference. 

#### Release Notes
This PR makes `build.sc` use `CrossSbtModule` and add Scala 2.13.2 support to mill.
 
### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
