### PR TITLE
Loosen inlining restrictions

### DIFF
--- a/src/main/scala/firrtl/transforms/InlineBooleanExpressions.scala
+++ b/src/main/scala/firrtl/transforms/InlineBooleanExpressions.scala
@@ -60,18 +60,19 @@ class InlineBooleanExpressions extends Transform with DependencyAPIMigration {
   }
 
   private val fileLineRegex = """(.*) ([0-9]+):[0-9]+""".r
-  private def sameFileAndLineInfo(info1: Info, info2: Info): Boolean = {
-    (info1, info2) match {
-      case (FileInfo(fileLineRegex(file1, line1)), FileInfo(fileLineRegex(file2, line2))) =>
-        (file1 == file2) && (line1 == line2)
-      case (MultiInfo(infos1), MultiInfo(infos2)) if infos1.size == infos2.size =>
-        infos1.zip(infos2).forall {
-          case (i1, i2) =>
-            sameFileAndLineInfo(i1, i2)
-        }
-      case (NoInfo, NoInfo) => true
-      case _                => false
+  private def getFileAndLineNumbers(info: Info): Set[(String, String)] = {
+    info match {
+      case FileInfo(fileLineRegex(file, line)) => Set(file -> line)
+      case FileInfo(file)                      => Set(file -> "0")
+      case MultiInfo(infos)                    => infos.flatMap(getFileAndLineNumbers).toSet
+      case NoInfo                              => Set.empty[(String, String)]
     }
+  }
+
+  private def sameFileAndLineInfo(info1: Info, info2: Info): Boolean = {
+    val set1 = getFileAndLineNumbers(info1)
+    val set2 = getFileAndLineNumbers(info2)
+    set1.subsetOf(set2)
   }
 
   /** A helper class to initialize and store mutable state that the expression
@@ -85,22 +86,34 @@ class InlineBooleanExpressions extends Transform with DependencyAPIMigration {
     var inlineCount: Int = 1
 
     /** Whether or not an can be inlined
+      * @param ref the WRef that references refExpr
       * @param refExpr the expression to check for inlining
       * @param outerExpr the parent expression of refExpr, if any
       */
-    def canInline(refExpr: Expression, outerExpr: Option[Expression]): Boolean = {
+    def canInline(ref: WRef, refExpr: Expression, outerExpr: Option[Expression]): Boolean = {
       val contextInsensitiveDetOps: Set[PrimOp] = Set(Lt, Leq, Gt, Geq, Eq, Neq, Andr, Orr, Xorr)
       outerExpr match {
         case None => true
-        case Some(o) if (o.tpe == Utils.BoolType) =>
-          refExpr match {
-            case _: Mux => false
-            case e => e.tpe == Utils.BoolType
-          }
         case Some(o) =>
-          refExpr match {
-            case DoPrim(op, _, _, Utils.BoolType) => contextInsensitiveDetOps(op)
-            case _                                => false
+          if ((refExpr.tpe != Utils.BoolType) || refExpr.isInstanceOf[Mux]) {
+            false
+          } else {
+            o match {
+              // if outer expression is also boolean context does not affect width
+              case o if o.tpe == Utils.BoolType => true
+
+              // mux condition argument is self-determined
+              case m: Mux if m.cond eq ref => true
+
+              // dshl/dshr second argument is self-determined
+              case DoPrim(Dshl | Dshr, Seq(_, shamt), _, _) if shamt eq ref => true
+
+              case o =>
+                refExpr match {
+                  case DoPrim(op, _, _, _) => contextInsensitiveDetOps(op)
+                  case _                   => false
+                }
+            }
           }
       }
     }
@@ -117,10 +130,10 @@ class InlineBooleanExpressions extends Transform with DependencyAPIMigration {
         case ref: WRef if !dontTouches.contains(ref.name.Ref) && ref.name.head == '_' =>
           val refKey = ref.name.Ref
           netlist.get(we(ref)) match {
-            case Some((refExpr, refInfo)) if sameFileAndLineInfo(info, refInfo) =>
+            case Some((refExpr, refInfo)) if sameFileAndLineInfo(refInfo, info) =>
               val inlineNum = inlineCounts.getOrElse(refKey, 1)
               val notTooDeep = !outerExpr.isDefined || ((inlineNum + inlineCount) <= maxInlineCount)
-              if (canInline(refExpr, outerExpr) && notTooDeep) {
+              if (canInline(ref, refExpr, outerExpr) && notTooDeep) {
                 inlineCount += inlineNum
                 refExpr
               } else {

--- a/src/main/scala/firrtl/transforms/InlineBooleanExpressions.scala
+++ b/src/main/scala/firrtl/transforms/InlineBooleanExpressions.scala
@@ -106,7 +106,7 @@ class InlineBooleanExpressions extends Transform with DependencyAPIMigration {
               case m: Mux if m.cond eq ref => true
 
               // dshl/dshr second argument is self-determined
-              case DoPrim(Dshl | Dshr, Seq(_, shamt), _, _) if shamt eq ref => true
+              case DoPrim(Dshl | Dshlw | Dshr, Seq(_, shamt), _, _) if shamt eq ref => true
 
               case o =>
                 refExpr match {

--- a/src/test/scala/firrtlTests/InlineBooleanExpressionsSpec.scala
+++ b/src/test/scala/firrtlTests/InlineBooleanExpressionsSpec.scala
@@ -171,7 +171,7 @@ class InlineBooleanExpressionsSpec extends FirrtlFlatSpec {
     (result) should be(parse(check).serialize)
   }
 
-  it should "inline if mux condition and dshl/dhslr shamt args" in {
+  it should "inline mux condition and dshl/dhslr shamt args" in {
     val input =
       """circuit inline_mux_dshl_dshlr_args :
         |  module inline_mux_dshl_dshlr_args :

--- a/src/test/scala/firrtlTests/InlineBooleanExpressionsSpec.scala
+++ b/src/test/scala/firrtlTests/InlineBooleanExpressionsSpec.scala
@@ -403,7 +403,7 @@ class InlineBooleanExpressionsSpec extends FirrtlFlatSpec {
         |
         |    node _T_1 = and(a, b)
         |    out <= and(_T_1, c)""".stripMargin
-    val result = exec(input, PrettyNoExprInlining :: Nil)
+    val result = exec(parse(input), PrettyNoExprInlining :: Nil)
     (result) should be(parse(input).serialize)
   }
 }

--- a/src/test/scala/firrtlTests/InlineBooleanExpressionsSpec.scala
+++ b/src/test/scala/firrtlTests/InlineBooleanExpressionsSpec.scala
@@ -3,6 +3,7 @@
 package firrtlTests
 
 import firrtl._
+import firrtl.ir.{Circuit, Connect, FileInfo, MultiInfo, Statement}
 import firrtl.annotations.{Annotation, ReferenceTarget}
 import firrtl.options.Dependency
 import firrtl.passes._
@@ -16,9 +17,9 @@ class InlineBooleanExpressionsSpec extends FirrtlFlatSpec {
     transform.prerequisites
   ).flattenedTransformOrder :+ transform
 
-  protected def exec(input: String, annos: Seq[Annotation] = Nil) = {
+  protected def exec(input: Circuit, annos: Seq[Annotation] = Nil) = {
     transforms
-      .foldLeft(CircuitState(parse(input), UnknownForm, AnnotationSeq(annos))) { (c: CircuitState, t: Transform) =>
+      .foldLeft(CircuitState(input, UnknownForm, AnnotationSeq(annos))) { (c: CircuitState, t: Transform) =>
         t.runTransform(c)
       }
       .circuit
@@ -48,7 +49,7 @@ class InlineBooleanExpressionsSpec extends FirrtlFlatSpec {
         |    node _c = lt(x1, x2)
         |    node _y = mux(lt(x1, x2), head(x1, 1), head(x2, 1))
         |    out <= mux(lt(x1, x2), head(x1, 1), head(x2, 1))""".stripMargin
-    val result = exec(input)
+    val result = exec(parse(input))
     (result) should be(parse(check).serialize)
     firrtlEquivalenceTest(input, Seq(new InlineBooleanExpressions))
   }
@@ -77,7 +78,7 @@ class InlineBooleanExpressionsSpec extends FirrtlFlatSpec {
         |    node _y = mux(lt(x1, x2), _t, _f)
         |    out <= mux(lt(x1, x2), _t, _f)""".stripMargin
     val result = exec(
-      input,
+      parse(input),
       Seq(
         DontTouchAnnotation(ReferenceTarget("Top", "Top", Seq.empty, "_t", Seq.empty)),
         DontTouchAnnotation(ReferenceTarget("Top", "Top", Seq.empty, "_f", Seq.empty))
@@ -122,9 +123,87 @@ class InlineBooleanExpressionsSpec extends FirrtlFlatSpec {
         |    outA2 <= _y @[A 2:3]
         |
         |    outB <= _y @[B]""".stripMargin
-    val result = exec(input)
+    val result = exec(parse(input))
     (result) should be(parse(check).serialize)
     firrtlEquivalenceTest(input, Seq(new InlineBooleanExpressions))
+  }
+
+  it should "inline if subexpression info is a subset of parent info" in {
+    val input =
+      parse("""circuit test :
+              |  module test :
+              |    input in_1 : UInt<1>
+              |    input in_2 : UInt<1>
+              |    input in_3 : UInt<1>
+              |    output out : UInt<1>
+              |    node _c = in_1 @[A 1:1]
+              |    node _t = in_2 @[A 1:1]
+              |    node _f = in_3 @[A 1:1]
+              |    out <= mux(_c, _t, _f)""".stripMargin).mapModule { m =>
+        // workaround to insert MultiInfo
+        def onStmt(stmt: Statement): Statement = stmt match {
+          case c: Connect =>
+            c.mapInfo { _ =>
+              MultiInfo(
+                Seq(
+                  FileInfo("A 1:1"),
+                  FileInfo("A 2:2"),
+                  FileInfo("A 3:3")
+                )
+              )
+            }
+          case other => other.mapStmt(onStmt)
+        }
+        m.mapStmt(onStmt)
+      }
+    val check =
+      """circuit test :
+        |  module test :
+        |    input in_1 : UInt<1>
+        |    input in_2 : UInt<1>
+        |    input in_3 : UInt<1>
+        |    output out : UInt<1>
+        |    node _c = in_1 @[A 1:1]
+        |    node _t = in_2 @[A 1:1]
+        |    node _f = in_3 @[A 1:1]
+        |    out <= mux(in_1, in_2, in_3) @[A 1:1 A 2:2 A 3:3]""".stripMargin
+    val result = exec(input)
+    (result) should be(parse(check).serialize)
+  }
+
+  it should "inline if mux condition and dshl/dhslr shamt args" in {
+    val input =
+      """circuit inline_mux_dshl_dshlr_args :
+        |  module inline_mux_dshl_dshlr_args :
+        |    input in_1 : UInt<3>
+        |    input in_2 : UInt<3>
+        |    input in_3 : UInt<3>
+        |    output out_1 : UInt<3>
+        |    output out_2 : UInt<3>
+        |    output out_3 : UInt<4>
+        |    node _c = head(in_1, 1)
+        |    node _t = in_2
+        |    node _f = in_3
+        |    out_1 <= mux(_c, _t, _f)
+        |    out_2 <= dshr(in_1, _c)
+        |    out_3 <= dshl(in_1, _c)""".stripMargin
+    val check =
+      """circuit inline_mux_dshl_dshlr_args :
+        |  module inline_mux_dshl_dshlr_args :
+        |    input in_1 : UInt<3>
+        |    input in_2 : UInt<3>
+        |    input in_3 : UInt<3>
+        |    output out_1 : UInt<3>
+        |    output out_2 : UInt<3>
+        |    output out_3 : UInt<4>
+        |    node _c = head(in_1, 1)
+        |    node _t = in_2
+        |    node _f = in_3
+        |    out_1 <= mux(head(in_1, 1), _t, _f)
+        |    out_2 <= dshr(in_1, head(in_1, 1))
+        |    out_3 <= dshl(in_1, head(in_1, 1))""".stripMargin
+    val result = exec(parse(input))
+    (result) should be(parse(check).serialize)
   }
 
   it should "inline boolean DoPrims" in {
@@ -163,7 +242,7 @@ class InlineBooleanExpressionsSpec extends FirrtlFlatSpec {
         |    node _f = lt(andr(head(_c, 1)), x2)
         |
         |    outB <= lt(andr(head(_c, 1)), x2)""".stripMargin
-    val result = exec(input)
+    val result = exec(parse(input))
     (result) should be(parse(check).serialize)
     firrtlEquivalenceTest(input, Seq(new InlineBooleanExpressions))
   }
@@ -208,7 +287,7 @@ class InlineBooleanExpressionsSpec extends FirrtlFlatSpec {
         |    node _h = geq(x1, gt(x1, leq(x1, lt(x1, x2))))
         |
         |    outB <= geq(x1, gt(x1, leq(x1, lt(x1, x2))))""".stripMargin
-    val result = exec(input)
+    val result = exec(parse(input))
     (result) should be(parse(check).serialize)
     firrtlEquivalenceTest(input, Seq(new InlineBooleanExpressions))
   }
@@ -254,7 +333,7 @@ class InlineBooleanExpressionsSpec extends FirrtlFlatSpec {
          |    node _6 = or(or(or(_3, c_4), c_5), c_6)
          |
          |    out <= or(or(or(_3, c_4), c_5), c_6)""".stripMargin
-    val result = exec(input, Seq(InlineBooleanExpressionsMax(3)))
+    val result = exec(parse(input), Seq(InlineBooleanExpressionsMax(3)))
     (result) should be(parse(check).serialize)
     firrtlEquivalenceTest(input, Seq(new InlineBooleanExpressions))
   }


### PR DESCRIPTION
```
circuit test :
  module test :
    input clock : Clock
    input reset : UInt<1>
    input a : UInt<1>
    input b : UInt<1>
    input foo : UInt<8>
    input bar : UInt<8>
    output out : UInt<8>
    reg myReg : UInt<8>, clock with :
      reset => (UInt<1>("h0"), myReg) @[Example.scala 8:22]
    node _T = and(a, b) @[Example.scala 11:11]
    node _myReg_T = add(foo, UInt<8>("h3")) @[Example.scala 12:18]
    node _myReg_T_1 = tail(_myReg_T, 1) @[Example.scala 12:18]
    node _GEN_0 = mux(_T, _myReg_T_1, myReg) @[Example.scala 11:17 Example.scala 12:11 Example.scala 8:22]
    out <= myReg @[Example.scala 9:7]
    myReg <= mux(reset, UInt<8>("h0"), _GEN_0) @[Example.scala 8:22 Example.scala 8:22]
```

Two issues were preventing the inlining of `_T`.
1. FileInfo comparison did not work for `FileInfo` and `MultiInfo`
2. the mux condition argument is not inlined if the type of the mux is not a boolean and the subexpression is not part of `contextInsensitiveDetOps`

This PR loosens the inlining restrictions so that Mux condition arguments and dshl/dshr shift amount arguments are always inlined because those arguments are self-determined. This also updates the FileInfo comparison to check that the inlined expression file and line number pairs are a subset of the file and line number pairs of the parent expression rather than require an exact match.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [n/a] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
- new feature/API 

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
none

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
expression `_a` in the following examples may now be inlined
```
node _a = xorr(a) @[A 1:1]
out <= and(_a, f) @[A 1:1 A 2:2 A 3:3]
```
```
node _a = xorr(a) 
out <= mux(_a, UInt<3>(1), UInt<3>(0))
```
```
node _a = xorr(a) 
out <= dshl(UInt<3>(0), _a)
```
```
node _a = xorr(a) 
out <= dshr(UInt<3>(0), _a)
```

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
- Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
