### PR TITLE
Legalize mem clocks

### DIFF
--- a/src/main/scala/firrtl/transforms/LegalizeClocksAndAsyncResets.scala
+++ b/src/main/scala/firrtl/transforms/LegalizeClocksAndAsyncResets.scala
@@ -52,6 +52,9 @@ object LegalizeClocksAndAsyncResetsTransform {
           (None, rxClock)
         }
         Block(clockNodeOpt ++: resetNodeOpt ++: Seq(rx))
+      case Connect(info, loc, rhs @ DoPrim(_, _, _, ClockType)) if (Utils.kind(loc) == MemKind) =>
+        val node = DefNode(info, namespace.newTemp, rhs)
+        Block(node, Connect(info, loc, WRef(node)))
       case p: Print if isLiteralExpression(p.clk) =>
         val node = DefNode(p.info, namespace.newTemp, p.clk)
         val px = p.copy(clk = WRef(node))

--- a/src/test/scala/firrtlTests/transforms/LegalizeClocksAndAsyncResets.scala
+++ b/src/test/scala/firrtlTests/transforms/LegalizeClocksAndAsyncResets.scala
@@ -49,6 +49,36 @@ class LegalizeClocksTransformSpec extends FirrtlFlatSpec {
     result.getEmittedCircuit.value shouldNot include("always @(posedge 1")
   }
 
+  it should "not emit @(posedge 1'h0) for mem" in {
+    val input =
+      """circuit test :
+        |  module test :
+        |    output rdata : UInt<8>
+        |    input wdata : UInt<8>
+        |    input addr : UInt<5>
+        |    mem m :
+        |      data-type => UInt<8>
+        |      depth => 32
+        |      read-latency => 0
+        |      write-latency => 1
+        |      reader => r
+        |      writer => w
+        |      read-under-write => undefined
+        |    m.r.clk <= asClock(UInt(0))
+        |    m.r.en <= UInt(1)
+        |    m.r.addr <= addr
+        |    rdata <= m.r.data
+        |    m.w.clk <= asClock(UInt(0))
+        |    m.w.en <= UInt(1)
+        |    m.w.mask <= UInt(1)
+        |    m.w.addr <= addr
+        |    m.w.data <= wdata
+        |""".stripMargin
+    val result = compile(input)
+    result should containLine(s"always @(posedge _GEN_1) begin")
+    result.getEmittedCircuit.value shouldNot include("always @(posedge 1")
+  }
+
   it should "not emit @(posedge clock or posedge 1'h0) for a constantly deasserted areset" in {
     val input = """circuit test :
                   |  module test :


### PR DESCRIPTION
**Type of improvement:** bug fix
**API impact:** none
B**ackend code-generation impact:** FIRRTL will no longer emit `always @(posedge 1'b0)` for synchronous memory ports that have tied-off clocks.

Prior to this PR, `LegalizeClocksAndAsyncResetsTransform` only applied to registers. It makes sense to avoid messing with clocks that just go to submodules or ports, since they are plain wires, but memory port clocks get directly put into sensitivity lists. This PR fixes the potential issue and adds a test that would fail on master.

As with the register clock legalization, this also resolves related issues with emitting things like `always @(posedge ~clk)` that are not handled by Verilator. H/t to @jerryz123 for finding this issue.