### PR TITLE
Better error messages for unserializable annotations

### DIFF
--- a/src/main/scala/firrtl/annotations/AnnotationUtils.scala
+++ b/src/main/scala/firrtl/annotations/AnnotationUtils.scala
@@ -18,6 +18,16 @@ case class AnnotationClassNotFoundException(className: String)
     extends FirrtlUserException(
       s"Annotation class $className not found! Please check spelling and classpath"
     )
+class UnserializableAnnotationException private (msg: String) extends FirrtlUserException(msg)
+object UnserializableAnnotationException {
+  private def toMessage(pair: (Annotation, Throwable)): String =
+    s"Failed to serialiaze annotation of type ${pair._1.getClass.getName} because '${pair._2.getMessage}'"
+  private[firrtl] def apply(badAnnos: Seq[(Annotation, Throwable)]) = {
+    require(badAnnos.nonEmpty)
+    val msg = badAnnos.map(toMessage).mkString("\n  ", "\n  ", "\n")
+    new UnserializableAnnotationException(msg)
+  }
+}
 
 object AnnotationUtils {
 


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- better error message

#### API Impact

No impact

#### Backend Code Generation Impact

No Impact

#### Desired Merge Strategy

  - Squash

#### Release Notes

Improve error message when trying to serialize unserializable annotations

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
