### PR TITLE
Support binary files in CustomFileEmission

### DIFF
--- a/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
+++ b/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
@@ -6,7 +6,7 @@ import firrtl.AnnotationSeq
 import firrtl.annotations.{Annotation, DeletedAnnotation, JsonProtocol}
 import firrtl.options.{CustomFileEmission, Dependency, Phase, PhaseException, StageOptions, Unserializable, Viewer}
 
-import java.io.{BufferedWriter, File, FileWriter, PrintWriter}
+import java.io.{File, FileOutputStream, PrintWriter}
 
 import scala.collection.mutable
 
@@ -37,7 +37,7 @@ class WriteOutputAnnotations extends Phase {
 
         filesWritten.get(canonical) match {
           case None =>
-            val w = new BufferedWriter(new FileWriter(filename))
+            val w = new FileOutputStream(filename)
             a.getBytes.foreach(w.write(_))
             w.close()
             filesWritten(canonical) = a


### PR DESCRIPTION
"[FileWriter](https://docs.oracle.com/javase/8/docs/api/java/io/FileWriter.html) is meant for writing streams of characters. For writing streams of raw bytes, consider using a FileOutputStream."

The recommended way of turning a `String` into `Iterable[Byte]` is still sound because [String.getBytes()](https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#getBytes--) "Encodes this String into a sequence of bytes using the platform's default charset, storing the result into a new byte array." 

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - bug fix       

#### API Impact

Makes CustomFileEmission actually support binary files

#### Backend Code Generation Impact

none

#### Desired Merge Strategy

  - Squash

#### Release Notes

Fix bug in `CustomFileEmission` improperly serializing binary files

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
