### PR TITLE
Make StageOption Unserializable

### DIFF
--- a/src/main/scala/firrtl/options/StageAnnotations.scala
+++ b/src/main/scala/firrtl/options/StageAnnotations.scala
@@ -10,7 +10,7 @@ import java.io.File
 
 import scopt.OptionParser
 
-sealed trait StageOption { this: Annotation => }
+sealed trait StageOption extends Unserializable { this: Annotation => }
 
 /** An annotation that should not be serialized automatically [[phases.WriteOutputAnnotations WriteOutputAnnotations]].
   * This usually means that this is an annotation that is used only internally to a [[Stage]].

--- a/src/test/scala/firrtlTests/options/phases/WriteOutputAnnotationsSpec.scala
+++ b/src/test/scala/firrtlTests/options/phases/WriteOutputAnnotationsSpec.scala
@@ -12,6 +12,7 @@ import firrtl.options.{
   OutputAnnotationFileAnnotation,
   Phase,
   PhaseException,
+  StageOption,
   StageOptions,
   TargetDirAnnotation,
   WriteDeletedAnnotation
@@ -60,7 +61,7 @@ class WriteOutputAnnotationsSpec extends AnyFlatSpec with Matchers with firrtl.t
 
   behavior.of(classOf[WriteOutputAnnotations].toString)
 
-  it should "write annotations to a file (excluding DeletedAnnotations)" in new Fixture {
+  it should "write annotations to a file (excluding DeletedAnnotations and StageOptions)" in new Fixture {
     val file = new File(dir + "/should-write-annotations-to-a-file.anno.json")
     val annotations = Seq(
       OutputAnnotationFileAnnotation(file.toString),
@@ -70,12 +71,13 @@ class WriteOutputAnnotationsSpec extends AnyFlatSpec with Matchers with firrtl.t
       DeletedAnnotation("foo", WriteOutputAnnotationsSpec.FooAnnotation)
     )
     val expected = annotations.filter {
-      case a: DeletedAnnotation => false
-      case a => true
+      case _: DeletedAnnotation => false
+      case _: StageOption       => false
+      case _ => true
     }
     val out = phase.transform(annotations)
 
-    info("annotations are unmodified")
+    info("annotations should be as expected")
     out.toSeq should be(annotations)
 
     fileContainsAnnotations(file, expected)
@@ -96,7 +98,11 @@ class WriteOutputAnnotationsSpec extends AnyFlatSpec with Matchers with firrtl.t
     info("annotations are unmodified")
     out.toSeq should be(annotations)
 
-    fileContainsAnnotations(file, annotations)
+    val expected = annotations.filter {
+      case _: StageOption => false
+      case _ => true
+    }
+    fileContainsAnnotations(file, expected)
   }
 
   it should "do nothing if no output annotation file is specified" in new Fixture {
@@ -126,9 +132,10 @@ class WriteOutputAnnotationsSpec extends AnyFlatSpec with Matchers with firrtl.t
       WriteOutputAnnotationsSpec.Custom("hello!")
     )
     val serializedFileName = view[StageOptions](annotations).getBuildFileName("Custom", Some(".Emission"))
-    val expected = annotations.map {
-      case _: WriteOutputAnnotationsSpec.Custom => WriteOutputAnnotationsSpec.Replacement(serializedFileName)
-      case a => a
+    val expected = annotations.flatMap {
+      case _: WriteOutputAnnotationsSpec.Custom => Some(WriteOutputAnnotationsSpec.Replacement(serializedFileName))
+      case _: StageOption                       => None
+      case a => Some(a)
     }
 
     val out = phase.transform(annotations)


### PR DESCRIPTION
These options are generally specific to a stage and thus should not be
propagating across serialization

The `StageOption`s are:
* `TargetDirAnnotation`
* `ProgramArgsAnnotation`
* `InputAnnotationFileAnnotation`
* `OutputAnnotationFileAnnotation`
* `WriteDeletedAnnotation`

`InputAnnotationFileAnnotation` is already [consumed](https://github.com/freechipsproject/firrtl/blob/e420f99d87ece9f56504b3afc2e37d40b6e8c7b1/src/main/scala/firrtl/options/phases/GetIncludes.scala#L34) so the question is if any of these others should propagation across serialization? It does not make sense that providing `-td` to an invocation of Chisel should then be propagated automagically when you call FIRRTL and pass the intermediate annotation file. In general, all of these should be set for each stage by the user as they please.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
   - code/API cleanup  

#### API Impact

This changes behavior in a way that should generally work better for users. For example, the current behavior has to be [worked around in rocket-chip](https://github.com/chipsalliance/rocket-chip/blob/d71c5a674275676b9c870a20cb0a42cd039a4115/src/main/scala/stage/phases/GenerateFirrtlAnnos.scala#L26) to manually emit the output annotation file so that it doesn't include annotations that would conflict like `TargetDirAnnotation`.

#### Backend Code Generation Impact

No change

#### Desired Merge Strategy
  - Rebase

#### Release Notes

StageOptions (like TargetDirAnnotation) are no longer serialized in the output annotation file. This improves composability of Stages.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
