### PR TITLE
Specify appropriate Chisel and Treadle branches for CI tests

### DIFF
--- a/.run_chisel_tests.sh
+++ b/.run_chisel_tests.sh
@@ -1,13 +1,18 @@
 set -e
 
+# Use appropriate branches.
+# Each stable branch of FIRRTL should have a fixed value for these branches.
+CHISEL_BRANCH="master"
+TREADLE_BRANCH="master"
+
 # Skip chisel tests if the commit message says to
 # Replace ... with .. in TRAVIS_COMMIT_RANGE, see https://github.com/travis-ci/travis-ci/issues/4596
 if git log --format=%B --no-merges ${TRAVIS_COMMIT_RANGE/.../..} | grep '\[skip chisel tests\]'; then
   exit 0
 else
-  git clone https://github.com/freechipsproject/treadle.git --depth 10
+  git clone https://github.com/freechipsproject/treadle.git --single-branch -b ${TREADLE_BRANCH} --depth 10
   (cd treadle && sbt $SBT_ARGS +publishLocal)
-  git clone https://github.com/ucb-bar/chisel3.git
+  git clone https://github.com/ucb-bar/chisel3.git --single-branch -b ${CHISEL_BRANCH}
   mkdir -p chisel3/lib
   cp utils/bin/firrtl.jar chisel3/lib
   cd chisel3


### PR DESCRIPTION
**Type of improvement:** CI
**API impact:** none
**Backend code-generation impact:** none

Currently, the Chisel-based CI tests just clone into Chisel. This does not work for backports. CI is currently broken for backports due to a versioning error: `object CheckScalaVersion is not a member of package firrtl.stage.transforms`

This is a really simple fix, but it doesn't seem to be too onerous to maintain since each stable branch will get a version of this file, but it will be constant for the lifetime of that stable branch _unless we change the version compatibility matrix_. However, that would be a big enough deal to warrant a manual change.

I am opening this against master just to keep it consistent, but the goal is:

- Add this to master
- Backport to `1.3.x`, change vars to `3.3.x` and `1.2.x`
- Backport to `1.2.x`, change vars to `3.2.x` and `1.1.x`
