### PR TITLE
Don't use ResolvedAnnotationPaths in ConstProp nor DCE

### DIFF
--- a/src/test/scala/firrtlTests/DCETests.scala
+++ b/src/test/scala/firrtlTests/DCETests.scala
@@ -491,6 +491,42 @@ class DCETests extends FirrtlFlatSpec {
     (verilog shouldNot include).regex("""fwrite""")
     (verilog shouldNot include).regex("""fatal""")
   }
+
+  "DCE" should "not duplicate unnecessarily" in {
+    val input =
+      """circuit Top :
+        |  module child :
+        |    input x : UInt<1>
+        |    output z : UInt<1>
+        |    z <= not(x)
+        |  module Top :
+        |    input x : UInt<1>
+        |    output z : UInt<1>
+        |    inst c of child
+        |    inst c_1 of child
+        |    c.x <= x
+        |    c_1.x <= x
+        |    z <= and(c.z, c_1.z)""".stripMargin
+    val check =
+      """circuit Top :
+        |  module child :
+        |    input x : UInt<1>
+        |    output z : UInt<1>
+        |    z <= not(x)
+        |  module Top :
+        |    input x : UInt<1>
+        |    output z : UInt<1>
+        |    inst c of child
+        |    inst c_1 of child
+        |    z <= and(c.z, c_1.z)
+        |    c.x <= x
+        |    c_1.x <= x""".stripMargin
+    val top = CircuitTarget("Top").module("Top")
+    val annos =
+      Seq(top.instOf("c", "child").ref("z"), top.instOf("c_1", "child").ref("z"))
+        .map(DontTouchAnnotation(_))
+    exec(input, check, annos)
+  }
 }
 
 class DCECommandLineSpec extends FirrtlFlatSpec {


### PR DESCRIPTION
Both use EliminateTargetPaths to duplicate modules based on annotations.
Currently, EliminateTargetPaths API is a little too limited so it
duplicates more than it should which effectively breaks Dedup whenever
DontTouchAnnotations are present.

Also, make ConstProp and DCE treat all HasDontTouches as local
annotations even if they are instance annotations. This is more
conservative but it is generally better to preserve deduplication than
to maximally optimize every instance.

This is a workaround, but it is important in lieu of making `EliminateTargetPaths` work as one would hope. To make `EliminateTargetPaths` work as would be intuitive and useful, I think it's API needs to allow transforms to expose 3 things:
1. Which annotations to be sensitive to (including traits).
2. Which targets to use from those annotations
3. How to dedup those targets

Note that (1) is the current API although I'm not sure if it would work for traits. (2) is important because an annotation that extends `HasDontTouches` may have some targets that are not dontTouched so `EliminateTargetPaths` can't blindly take all `targets`. (3) is the subtle but critical. It differs from how Deduplication should also Deduplicate Annotations. Using `HasDontTouches` as an example, it is reasonable for annotations that are different (and thus shouldn't deduplicate themselves) to nevertheless dont touch targets in differing instances of the same module such that `EliminateTargetPaths` should "deduplicate" the different instance path targets into a local target--thus it shouldn't duplicate those modules.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - bug fix 

The bug is that DontTouchAnnotations break Deduplication (via re-duplication). This is a workaround rather than a fix to the API deficiencies in EliminateTargetPaths

#### API Impact

This is binary incompatible because `ConstProp` and `DeadCodeElimination` no longer implement `ResolvedAnnotationPaths`. Incompatibilities from stuff like this illustrates that we should avoid inheritance for features like this in the future.

#### Backend Code Generation Impact

Improved deduplication

#### Desired Merge Strategy

  - Squash

#### Release Notes

`ConstantPropagation` and `DeadCodeElimination` no longer implement `ResolvedAnnotationPaths`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
