### PR TITLE
Improve Travis Chisel Tests

### DIFF
--- a/.run_chisel_tests.sh
+++ b/.run_chisel_tests.sh
@@ -11,11 +11,10 @@ TREADLE_BRANCH="master"
 if git log --format=%B --no-merges ${TRAVIS_COMMIT_RANGE/.../..} | grep '\[skip chisel tests\]'; then
   exit 0
 else
+  sbt $SBT_ARGS publishLocal
   git clone https://github.com/freechipsproject/treadle.git --single-branch -b ${TREADLE_BRANCH} --depth 10
-  (cd treadle && sbt $SBT_ARGS +publishLocal)
+  (cd treadle && sbt $SBT_ARGS publishLocal)
   git clone https://github.com/ucb-bar/chisel3.git --single-branch -b ${CHISEL_BRANCH}
-  mkdir -p chisel3/lib
-  cp utils/bin/firrtl.jar chisel3/lib
   cd chisel3
-  sbt "set concurrentRestrictions in Global += Tags.limit(Tags.Test, 2)" clean test
+  sbt $SBT_ARGS test
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,6 @@ jobs:
         use: firrtl_build
       script:
         - verilator --version
-        - sbt $SBT_ARGS +publishLocal
         - bash .run_chisel_tests.sh
     - stage: test
       name: "Formal equivalence: RocketCore"


### PR DESCRIPTION
I can't tell you why this works, but it seems to. Disabling the limit on parallelism in the Chisel tests _seems_ to avoid whatever flakey issue we were hitting in `sbt test`.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [NA] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - ci fix?

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
