### PR TITLE
Speed up writing CustomFileEmission with buffering

### DIFF
--- a/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
+++ b/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
@@ -6,7 +6,7 @@ import firrtl.AnnotationSeq
 import firrtl.annotations.{Annotation, DeletedAnnotation, JsonProtocol}
 import firrtl.options.{CustomFileEmission, Dependency, Phase, PhaseException, StageOptions, Unserializable, Viewer}
 
-import java.io.{File, FileOutputStream, PrintWriter}
+import java.io.{BufferedOutputStream, File, FileOutputStream, PrintWriter}
 
 import scala.collection.mutable
 
@@ -37,8 +37,11 @@ class WriteOutputAnnotations extends Phase {
 
         filesWritten.get(canonical) match {
           case None =>
-            val w = new FileOutputStream(filename)
-            a.getBytes.foreach(w.write(_))
+            val w = new BufferedOutputStream(new FileOutputStream(filename))
+            a.getBytes match {
+              case arr: mutable.WrappedArray[Byte] => w.write(arr.array.asInstanceOf[Array[Byte]])
+              case other => other.foreach(w.write(_))
+            }
             w.close()
             filesWritten(canonical) = a
           case Some(first) =>


### PR DESCRIPTION
Turns out buffering is useful.

For a medium-sized design, this reduces the time to write CHIRRTL from 60 seconds to 200-500 ms.

Adding special handling for common case of `Array[Byte]`* further reduced the time to write the file to ~60-70 ms.

*which comes from having already created a `String` in the `ChirrtlEmitter`, something we should consider doing differently

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [NA] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - performance improvement  

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes

Speed up writing of annotations that use `CustomFileEmission`

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
