### PR TITLE
VerilogMemDelays: fix lowering of direct mem-to-mem connections

### DIFF
--- a/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
+++ b/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
@@ -110,7 +110,7 @@ class MemDelayAndReadwriteTransformer(m: DefModule) {
 
       val readStmts = (mem.readers ++ mem.readwriters).map {
         case r =>
-          def oldDriver(f: String) = netlist(we(memPortField(mem, r, f)))
+          def oldDriver(f: String) = swapMemRefs(netlist(we(memPortField(mem, r, f))))
           def newField(f:  String) = memPortField(newMem, rMap.getOrElse(r, r), f)
           val clk = oldDriver("clk")
 
@@ -139,7 +139,7 @@ class MemDelayAndReadwriteTransformer(m: DefModule) {
 
       val writeStmts = (mem.writers ++ mem.readwriters).map {
         case w =>
-          def oldDriver(f: String) = netlist(we(memPortField(mem, w, f)))
+          def oldDriver(f: String) = swapMemRefs(netlist(we(memPortField(mem, w, f))))
           def newField(f:  String) = memPortField(newMem, wMap.getOrElse(w, w), f)
           val clk = oldDriver("clk")
 


### PR DESCRIPTION
**Type of improvement:** bug fix
**API impact:** none
**Backend code-generation impact:** avoids generating illegal Verilog for some inputs
**Desired merge strategy:** merge commit

**Release notes:**
An update to the VerilogMemDelays pass avoids generating illegal Verilog when directly connecting the output of one memory to the input of another.

Summary: most expressions in the modules are processed to correctly reflect renaming ports via an expression mapper, but the connections of inputs to mems are handled separately. This separate handling now calls the expression-mapping function to appropriately update the RHS of these connections if they are themselves memory references; i.e., if the input(s) of a memory are directly driven by the output(s) of another memory.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
