### PR TITLE
Fix "fix" for negative literals > 32 bits

### DIFF
--- a/src/main/scala/firrtl/transforms/FixAddingNegativeLiteralsTransform.scala
+++ b/src/main/scala/firrtl/transforms/FixAddingNegativeLiteralsTransform.scala
@@ -17,7 +17,7 @@ object FixAddingNegativeLiterals {
     * @param width width of the negative number
     * @return maximum negative number
     */
-  def minNegValue(width: BigInt): BigInt = -(1 << (width.toInt - 1))
+  def minNegValue(width: BigInt): BigInt = -(BigInt(1) << (width.toInt - 1))
 
   /** Updates the type of the DoPrim from its arguments (e.g. if is UnknownType)
     * @param d input DoPrim

--- a/src/test/scala/firrtlTests/VerilogEmitterTests.scala
+++ b/src/test/scala/firrtlTests/VerilogEmitterTests.scala
@@ -735,6 +735,26 @@ class VerilogEmitterSpec extends FirrtlFlatSpec {
     result should containLine("assign z = _GEN_0[1:0];")
   }
 
+  it should "correctly emit addition with a negative literal with width > 32" in {
+    val result = compileBody(
+      """input x : SInt<34>
+        |output z : SInt<34>
+        |z <= asSInt(tail(add(x, SInt<34>(-2)), 1))
+        |""".stripMargin
+    )
+    result should containLine("assign z = $signed(x) - 34'sh2;")
+  }
+
+  it should "correctly emit conjunction with a negative literal with width > 32" in {
+    val result = compileBody(
+      """input x : SInt<34>
+        |output z : SInt<34>
+        |z <= asSInt(and(x, SInt<34>(-2)))
+        |""".stripMargin
+    )
+    result should containLine("assign z = $signed(x) & -34'sh2;")
+  }
+
   it should "emit FileInfo as Verilog comment" in {
     def result(info: String): CircuitState = compileBody(
       s"""input x : UInt<2>


### PR DESCRIPTION
Overflow of 32-bit Int would cause any negative literal value equal to
-(2^(width % 32 - 1)) where width >= 32 to be incorrectly inverted.

From the added tests:
```
z <= asSInt(and(x, SInt<34>(-2)))
```
Would compile to
```verilog
assign z = $signed(x) & 34'sh2;
```
This PR fixes it to the correct:
```verilog
assign z = $signed(x) & -34'sh2;
```

This bug was introduced in https://github.com/freechipsproject/firrtl/pull/1374 but would only manifest as an assertion failure. https://github.com/freechipsproject/firrtl/pull/1782 exposed the behavior to all ops (not just addition) in 1.4. Both of those PRs are present on `1.2.x`, so this bugfix needs to be backported.

Note, that https://github.com/freechipsproject/firrtl/pull/1782 causing the inversion to occur for all ops (not just addition) is a little weird, but technically correct. Inverting the max negative literal for a given width overflows back to the negative literal, but I wouldn't be surprised if this is a lint warning. In any case, this PR does **not** fix that (potential) issue, it only fixes the bug.

Please merge commit this to master and then to `1.4.x`, I intend to use this commit in the rocket-chip bump if possible.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - bug fix   

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

   - Rebase

#### Release Notes

Fix rare bug where performing an op with a negative literal value equal to -(2^(width % 32 - 1)) where width >= 32 would be emitted incorrectly

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
