### PR TITLE
Add MiMa binary compatibility checking

### DIFF
--- a/.run_chisel_tests.sh
+++ b/.run_chisel_tests.sh
@@ -3,8 +3,8 @@ set -e
 
 # Use appropriate branches.
 # Each stable branch of FIRRTL should have a fixed value for these branches.
-CHISEL_BRANCH="master"
-TREADLE_BRANCH="master"
+CHISEL_BRANCH="3.4.x"
+TREADLE_BRANCH="1.2.x"
 
 # Skip chisel tests if the commit message says to
 # Replace ... with .. in TRAVIS_COMMIT_RANGE, see https://github.com/travis-ci/travis-ci/issues/4596

--- a/.travis.yml
+++ b/.travis.yml
@@ -136,3 +136,8 @@ jobs:
       script:
         - benchmark/scripts/benchmark_cold_compile.py -N 2 --designs regress/ICache.fir --versions HEAD
         - benchmark/scripts/find_heap_bound.py -- -cp firrtl*jar firrtl.stage.FirrtlMain -i regress/ICache.fir -o out -X verilog
+    - stage: test
+      name: "[Release Branch] Check Binary-compatibility"
+      script:
+        - sbt compile
+        - sbt +mimaReportBinaryIssues

--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,11 @@ lazy val commonSettings = Seq(
   )
 )
 
+import com.typesafe.tools.mima.core._
+lazy val mimaSettings = Seq(
+  mimaPreviousArtifacts := Set("edu.berkeley.cs" %% "firrtl" % "1.4.0")
+)
+
 lazy val protobufSettings = Seq(
   sourceDirectory in ProtobufConfig := baseDirectory.value / "src" / "main" / "proto",
   protobufRunProtoc in ProtobufConfig := (args =>
@@ -184,6 +189,7 @@ lazy val firrtl = (project in file("."))
     buildInfoUsePackageAsPath := true,
     buildInfoKeys := Seq[BuildInfoKey](buildInfoPackage, version, scalaVersion, sbtVersion)
   )
+  .settings(mimaSettings)
 
 lazy val benchmark = (project in file("benchmark"))
   .dependsOn(firrtl)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -24,4 +24,6 @@ addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
 
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.0")
+
 libraryDependencies += "com.github.os72" % "protoc-jar" % "3.11.4"


### PR DESCRIPTION
Combined with https://github.com/freechipsproject/firrtl/pull/1920 to enable backporting to `1.4.x`

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement


 - new test 

#### API Impact

Enforces binary compatibility

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes

None

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
