### PR TITLE
Make {Stage, FirrtlStage}.run protected

### DIFF
--- a/src/main/scala/firrtl/options/Stage.scala
+++ b/src/main/scala/firrtl/options/Stage.scala
@@ -23,7 +23,7 @@ abstract class Stage extends Phase {
     * @param annotations input annotations
     * @return output annotations
     */
-  def run(annotations: AnnotationSeq): AnnotationSeq
+  protected def run(annotations: AnnotationSeq): AnnotationSeq
 
   /** Execute this stage on some input annotations. Annotations will be read from any input annotation files.
     * @param annotations input annotations

--- a/src/main/scala/firrtl/stage/FirrtlStage.scala
+++ b/src/main/scala/firrtl/stage/FirrtlStage.scala
@@ -35,7 +35,7 @@ class FirrtlStage extends Stage {
 
   val shell: Shell = new Shell("firrtl") with FirrtlCli
 
-  def run(annotations: AnnotationSeq): AnnotationSeq = phase.transform(annotations)
+  override protected def run(annotations: AnnotationSeq): AnnotationSeq = phase.transform(annotations)
 
 }
 


### PR DESCRIPTION
Add the `protected` access modifier to the `Stage.run` method. Carry this through to `FirrtlStage.run` as well.

This enables users to build Stage-based APIs which don't expose the internal `run` method. This should help avoid confusion as there are currently three ways to call a `Stage`:

1. `execute: (Array[String], AnnotationSeq) => AnnotationSeq`
2. `transform: AnnotationSeq => AnnotationSeq`
3. `run: AnnotationSeq => AnnotationSeq`

(1) and (2) are variants of the same thing and provide mandatory `Phase`s that do checks of the annotations, mandatory file reads/writes, and wrap internal `Phase`s. `run` is the internal method that gets packaged in an anonymous `Phase`. Ergo, `run` was never meant to be exposed, but I left it wide open. 😬 

### Contributor Checklist

- [n/a] Did you add Scaladoc to every public function/method?
- [n/a] Did you update the FIRRTL spec to include every new feature/behavior?
- [n/a] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
- new feature/API

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

This removes the `run` method from `Stage` and `FirrtlStage`.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Remove `run` method from `Stage` and `FirrtlStage` (please use `transform` or `execute`)

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
