### PR TITLE
Fix verilog prep

### DIFF
--- a/src/main/scala/firrtl/transforms/ManipulateNames.scala
+++ b/src/main/scala/firrtl/transforms/ManipulateNames.scala
@@ -185,7 +185,7 @@ abstract class ManipulateNames[A <: ManipulateNames[_]: ClassTag] extends Transf
   override def optionalPrerequisites:  Seq[TransformDependency] = Seq.empty
   override def optionalPrerequisiteOf: Seq[TransformDependency] = Forms.LowEmitters
   override def invalidates(a: Transform) = a match {
-    case _: analyses.GetNamespace => true
+    case passes.InferTypes | _: analyses.GetNamespace => true
     case _ => false
   }
 

--- a/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
+++ b/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
@@ -47,6 +47,4 @@ class VerilogRename extends RemoveKeywordCollisions(v_keywords) {
 
   override def optionalPrerequisiteOf = Seq.empty
 
-  override def invalidates(a: Transform) = false
-
 }

--- a/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
+++ b/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
@@ -249,6 +249,7 @@ class LoweringCompilersSpec extends AnyFlatSpec with Matchers {
       new firrtl.transforms.FlattenRegUpdate,
       firrtl.passes.VerilogModulusCleanup,
       new firrtl.transforms.VerilogRename,
+      firrtl.passes.InferTypes,
       firrtl.passes.VerilogPrep,
       new firrtl.AddDescriptionNodes
     )
@@ -273,6 +274,7 @@ class LoweringCompilersSpec extends AnyFlatSpec with Matchers {
       new firrtl.transforms.DeadCodeElimination,
       firrtl.passes.VerilogModulusCleanup,
       new firrtl.transforms.VerilogRename,
+      firrtl.passes.InferTypes,
       firrtl.passes.VerilogPrep,
       new firrtl.AddDescriptionNodes
     )


### PR DESCRIPTION
### Contributor Checklist

<del>- [ ] Did you add Scaladoc to every public function/method?</del>
<del>- [ ] Did you update the FIRRTL spec to include every new feature/behavior?</del>
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- bug fix

#### API Impact
None

#### Backend Code Generation Impact
Fix #1931 

#### Desired Merge Strategy
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
Bug fix for rename error in VerilogPrep.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
